### PR TITLE
fix(uwp): compile with /utf-8 — non-ASCII UI literals rendered as mojibake

### DIFF
--- a/uwp/xllama.vcxproj
+++ b/uwp/xllama.vcxproj
@@ -122,6 +122,10 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <!-- /EHa: enable SEH → C++ exception translation so _set_se_translator fires. -->
       <ExceptionHandling>Async</ExceptionHandling>
+      <!-- Sources are UTF-8 without BOM; without /utf-8 MSVC assumes the system
+           codepage (Windows-1252) and non-ASCII literals (▶ ■ · — ●) reach the
+           UI as mojibake ("â–¶ Run"). -->
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <!-- WindowsApp.lib is the UWP umbrella library.


### PR DESCRIPTION
MainPage.cpp is UTF-8 without BOM and embeds ▶ ■ · — ● ✕ in wide string
literals. Without /utf-8, MSVC decodes the source as the system codepage
(Windows-1252), so the UTF-8 bytes land in the compiled wchar_t literals
verbatim: the footer showed "â–¶ Run", "â– Cancel" and "Â·" in the
tok/s counter on console. /utf-8 sets both source and execution charsets
to UTF-8 for every ClCompile item (all first-party, UTF-8/ASCII).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EBJMHC6ymWhBKY8M9jdiRT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-ASCII text in builds by ensuring UTF-8 source literals are compiled correctly.
  * Helps prevent garbled characters in user-facing text on Windows builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->