### PR TITLE
perf: ORT GenAI 0.14.1 + KV-cache reuse + CPU/GPU routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.8.0] - 2026-07-08
+
+### Added — KV-cache reuse across chat turns (continuous decoding)
+
+The interactive app re-prefilled the **entire** ChatML history on every turn
+(`BuildChatMLPrompt` + a fresh `OgaGenerator` per `generate()`), so turn-N TTFT
+paid to re-process ~all prior tokens (~1.8k at budget → seconds). `OrtSession`
+now keeps its generator alive across turns and appends only the new turn's
+tokens (`OgaGenerator_AppendTokenSequences` on the persistent generator), so the
+per-turn prefill covers just the delta.
+
+- `GenerateParams` gains `reuse_kv` / `reset_kv`; `InferenceResult` gains
+  `ended_with_stop` and now populates prefill telemetry (`n_p_eval`/`t_p_eval_ms`)
+  on the interactive path too (previously bench-only). Decode timing excludes
+  prefill, matching the bench convention.
+- `OrtSession` holds `m_chat_gen`/`m_chat_params`/`m_chat_stream` + the bound
+  sampling signature; the stateless path is preserved unchanged and still used
+  when `reuse_kv` is false.
+- `MainPageController::BuildDeltaPrompt` builds the incremental turn; the KV is
+  reused only when valid and no context turn was evicted (RewindTo truncates the
+  tail, not the head → eviction forces a full re-prefill). Reuse is invalidated
+  on new/loaded chat, settings change, abort, and any generator failure.
+- **Correctness guard**: a continuation that fails before emitting a token
+  auto-falls back to a full re-prefill (no UI double-streaming) — worst case is
+  the previous behaviour, never a wrong result.
+- Settings toggle `kv_reuse` (ToggleSwitch + `settings.json`, default on) so the
+  win can be A/B'd on console.
+- On-console validation pending: measure turn-2 TTFT with reuse on vs off
+  (Stage 2b bench) and confirm multi-turn coherence before trusting it as default.
+
 ## [0.3.7.0] - 2026-07-08
 
 ### Changed — ONNX Runtime GenAI 0.13.2 → 0.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.9.0] - 2026-07-08
+
+### Added — per-conversation CPU/GPU routing (Stage 3, default off)
+
+The v0.3.6 matrix showed the EP choice is per-workload: DML fp16 wins prompt
+prefill at scale (1.8× at ~1k tokens), CPU int4 wins decode. The app can now
+route between them.
+
+- Settings `routing` (0 = CPU only / default = unchanged behaviour, 1 = GPU
+  only, 2 = auto: route first prompts over ~500 est. tokens to GPU) + `gpu_model`
+  (DML fp16 model dir, default `smollm2-360m-dml-fp16`); a routing ComboBox in
+  the Settings dialog.
+- The decision is made once at a conversation's first turn and **sticky** for its
+  lifetime (the KV cache is per-EP): `m_active_model` holds the routed dir,
+  cleared on new/loaded chat so each conversation re-decides. Reuses the existing
+  single-slot `EnsureSession` (one model resident at a time) — switching
+  conversations may reload, which is memory-safe on the 3801 MB budget.
+- Default routing = CPU, so behaviour is identical until a user opts in. GPU
+  routing requires the DML fp16 model present on device (LocalState/USB).
+- On-console validation pending: confirm auto-routing picks GPU for long prompts
+  and that TTFT improves for prompt-heavy conversations.
+
 ## [0.3.8.0] - 2026-07-08
 
 ### Added — KV-cache reuse across chat turns (continuous decoding)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ per-turn prefill covers just the delta.
 - On-console validation pending: measure turn-2 TTFT with reuse on vs off
   (Stage 2b bench) and confirm multi-turn coherence before trusting it as default.
 
+### Added — multi-turn TTFT bench (Stage 2b)
+
+- Headless bench gains a KV-reuse measurement: when `bench_turns.txt` is present
+  (turn-2 user prompt; `prompt.txt` supplies turn 1), `main_loop` runs both turns
+  on one persistent `Session` and measures turn-2 prefill **with reuse** (append
+  only the delta) vs the **cold** baseline (full re-prefill of the 2-turn
+  context), writing `bench-kv-result.csv` (+ `.done`) with a `speedup` column and
+  logging the numbers. This measures the Stage 2 win on console instead of
+  assuming it.
+
 ## [0.3.7.0] - 2026-07-08
 
 ### Changed — ONNX Runtime GenAI 0.13.2 → 0.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   per-workload verdict; "GPU vs CPU same model" milestone closed by the
   v0.3.6 matrix.
 - `docs/uwp-constraints.md` §5: stale "future work" paragraph replaced with
-  the measured per-workload approach; documented the untested App-vs-Game
-  designation lever (all current numbers are App-mode).
+  the measured per-workload approach; documented the App-vs-Game designation
+  lever — **settled 2026-07-08**: the package was found already designated
+  Game, so all measured figures are Game-mode numbers (the interim "all
+  numbers are App-mode" assumption was wrong and has been rectified in
+  §5/§7/§11); the GPU decode gap is a DML/kernel issue, not platform
+  scheduling.
+- Environment change (2026-07-08): Dev Mode storage allocation raised to
+  90 GB — the Q:\ ~2.2–2.5 GB disk budget (§9) is superseded as the binding
+  constraint for model sizing; ROADMAP Phase 3.5 updated accordingly.
 - `docs/device-portal.md`: new "Lifecycle gotchas" section — LocalState purge
   semantics (only forward upgrades preserve it), LocalState absent before
   first launch, WDP file APIs returning HTTP 200 with `"Success": false`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Corrected — int4 DML decode diagnosis (desk-check 2026-07-08)
+
+The [0.3.6] entry below (and the docs at the time) attributed the int4 GPU decode
+collapse (8.8 tok/s) to a "missing fused int4 DML kernel" that, if added, would
+imply ~180 tok/s. A source-level desk-check **refines that**: `MatMulNBits` is
+present in the graph (225 nodes) and **runs on the DML GPU** — the profiled run
+shows one `DmlFusedNode` on `DmlExecutionProvider` (96%), no CPU fallback. The
+real limit is that DirectML's `MatMulNBits` is **non-fused**
+(`DML_DEQUANTIZE`→fp16 + full `DML_GEMM`, materialising fp16 weights), so int4
+moves more bandwidth than fp16 and cannot beat it on DML; the builder also gives
+DML `accuracy_level=0` vs CPU's fused-int8 `=4`. Full analysis + config tests in
+`docs/uwp-constraints.md §12`; `ROADMAP.md` Phase 3.5 updated. Net: GPU int4
+decode is blocked by a DirectML kernel-design limit (out of our control), not a
+kernel we could contribute — CPU int4 stays the decode default.
+
 ## [0.3.9.0] - 2026-07-08
 
 ### Added — per-conversation CPU/GPU routing (Stage 3, default off)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.7.0] - 2026-07-08
+
+### Changed — ONNX Runtime GenAI 0.13.2 → 0.14.1
+
+- Bumped `Microsoft.ML.OnnxRuntimeGenAI.DirectML` NuGet from 0.13.2 to **0.14.1**
+  (`uwp/packages.config`, `uwp/xllama.vcxproj` — 8 package-path references).
+  0.14.x reduces CPU-side per-token overhead in `GenerateNextToken`/`SampleTopP`
+  (directly relevant to the decode bottleneck measured in the v0.3.6 matrix) and
+  is the prerequisite for continuous decoding / KV-cache reuse (`RewindTo`,
+  generator reuse — Stage 2). No breaking C-API changes vs 0.13; existing model
+  directories (built with model builder 0.14.1) load unchanged.
+- On-console validation pending: rerun the CPU + DML bench matrix and compare
+  decode tok/s to the v0.3.6 baselines to quantify the per-token overhead win.
+
 ### Docs
 
 - `ROADMAP.md`: new Phase 3.5 — Hardware Ceiling with the ordered unlock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Docs
+
+- `ROADMAP.md`: new Phase 3.5 — Hardware Ceiling with the ordered unlock
+  levers (Game-mode designation, 1B+ models via no-bundle, int4-AWQ proxy,
+  upstream `MatMulNBits` desk check, llama.cpp CPU A/B, per-workload routing,
+  optional upstream kernel contribution); Phase 2 heading refined to the
+  per-workload verdict; "GPU vs CPU same model" milestone closed by the
+  v0.3.6 matrix.
+- `docs/uwp-constraints.md` §5: stale "future work" paragraph replaced with
+  the measured per-workload approach; documented the untested App-vs-Game
+  designation lever (all current numbers are App-mode).
+- `docs/device-portal.md`: new "Lifecycle gotchas" section — LocalState purge
+  semantics (only forward upgrades preserve it), LocalState absent before
+  first launch, WDP file APIs returning HTTP 200 with `"Success": false`,
+  stale PFN staging window, portal unreachable while a game is running.
+
 ## [0.3.6] - 2026-07-07
 
 ### Measured — Hardware utilization matrix (prefill vs decode, CPU vs GPU)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,7 @@ Milestones:
 - [x] SmolLM2-360M bundled inside MSIX as `DeploymentContent`; CI `build-uwp` green
 - [x] ChatML prompt template applied for SmolLM2 Instruct
 
-## Phase 2 — GPU Acceleration ✅ COMPLETE — GPU proven, CPU wins 8× (DML not competitive)
+## Phase 2 — GPU Acceleration ✅ COMPLETE — GPU proven; verdict is per-workload (CPU decode, GPU prefill)
 
 **Goal**: DirectML EP inference using Xbox RDNA 2 hardware.
 
@@ -71,7 +71,7 @@ Milestones:
 - [x] Evaluate Qwen2.5-0.5B INT4 ONNX as GPU EP candidate — ❌ CPU-int4 is ~822 MB (not ~200 MB); only the DML int4-awq variant (~507 MB) borderline fits the pool (see `docs/model-selection.md`)
 - [x] Procure a DML-compatible model variant and run the end-to-end DML bench — ✅ SmolLM2-360M INT4 DML build (285 MB): decode completes, **8.83 tok/s GPU vs 70.9 CPU** (`phase2-dml.csv`)
 - [x] Stage B (only if DML tok/s beats CPU) — ❌ dropped: DML is 8× slower than CPU at this scale; interactive app stays on CPU EP
-- [~] Measure GPU vs CPU tok/s for the same model — ❌ blocked: no GPU execution possible
+- [x] Measure GPU vs CPU tok/s for the same model — ✅ v0.3.6 utilization matrix (same SmolLM2-360M, 3 variants × 2 prompts): CPU int4 decode 68.0 vs GPU fp16 46.8 vs GPU int4 8.8 tok/s; prefill inverts at ~1k tok (GPU fp16 354 vs CPU 198)
 
 ## Phase 3 — Benchmarks + Model Exploration 🔄 IN PROGRESS
 
@@ -85,6 +85,44 @@ Milestones:
 - [x] Evaluate Qwen2.5-0.5B INT4 ONNX — ❌ ~822 MB real (vocab embedding dominates); exceeds disk borderline and GPU pool
 - [x] Evaluate Llama-3.2-1B INT4 ONNX CPU — ❌ ~1.77 GB real; USB-only, same class as SmolLM2-1.7B
 - [x] `load_ms` in bench CSV: column existed but ORT path never measured it (always 0) — `run_inference` now times `OgaCreateModel`; baseline pending next bench run on console
+
+## Phase 3.5 — Hardware Ceiling 🔮 NEXT
+
+**Goal**: close the gap between measured utilization (CPU ~13 GB/s, GPU ~34 GB/s
+effective vs ~224 GB/s bus) and what the Series S can realistically deliver.
+Levers ordered by cost/leverage; the first two are near-free and change the
+denominators for everything else, so they go first.
+
+Milestones:
+
+- [ ] **Game-mode designation experiment**: flip the package from App to Game in
+      Dev Home and rerun the v0.3.6 utilization matrix. App-mode GPU is
+      time-sliced and CPU/RAM are shared — the 113 ms/token DML dispatch
+      overhead may be partly platform scheduling. Free test, run first.
+- [ ] **Unlock 1B+ models on disk**: validate Exp 2 (`xllama-appx-nobundle` +
+      HF download) and/or the USB fallback on console (see Phase 4). Disk, not
+      GPU memory (3801 MB budget), is what blocks larger models — and at 1B+
+      scale the GPU bandwidth advantage (34 vs 13 GB/s) should dominate.
+- [ ] **int4-AWQ block-128 DML variant** (builder `-p int4 -e dml` with AWQ
+      options) as a cheap proxy for fused-kernel behaviour before any kernel work.
+- [ ] **Desk check upstream int4 status**: verify whether the int4 decode
+      collapse is truly a missing DML kernel or a builder/graph issue — ORT's
+      DML EP has a `MatMulNBits` operator; check what graph `-e dml` emits,
+      `accuracy_level`, and whether ORT GenAI 0.14 / newer DirectML changes the
+      picture. May turn "weeks of HLSL" into a config fix.
+- [ ] **llama.cpp CPU A/B**: build the `XLLAMA_USE_ORT=0` path for UWP and
+      bench a GGUF Q4_K model. llama.cpp kernels typically extract ~2× the
+      bandwidth of ORT's AVX2 `MatMulNBits` (~13 GB/s measured) → target
+      ~25–30 GB/s, ~130 tok/s decode at 360M. Risk: AppContainer compat
+      (no mmap) untested since the Phase 1 pivot.
+- [ ] **Per-workload routing in the app**: prompt-length threshold → DML fp16
+      session for long contexts (TTFT 3.0 s vs 5.3 s measured at ~1k tok), CPU
+      int4 for chat decode. Both models fit memory; pure engineering.
+- [ ] (only if the above leaves ambiguity) **Upstream fused int4 DML kernel
+      contribution** — the fork→CI→inject→validate pipeline is proven
+      (PR #2280); bandwidth-implied payoff ~180 tok/s GPU decode (2.5× CPU).
+- [ ] (optional) in-app memory-bandwidth micro-bench (`membw.flag`) to fix the
+      CPU ceiling denominator precisely.
 
 ## Phase 4 — In-App Download + Publication 🔮 FUTURE
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -146,11 +146,27 @@ Milestones:
   (scratchpad); one console bench each to confirm they stay ≈ 8.8 tok/s (the
   kernel structure predicts no material gain). If either beats fp16-DML it
   would refute §12 — worth the ~5 min. Not a path forward, just closure.
-- [ ] **llama.cpp CPU A/B**: build the `XLLAMA_USE_ORT=0` path for UWP and
-      bench a GGUF Q4_K model. llama.cpp kernels typically extract ~2× the
-      bandwidth of ORT's AVX2 `MatMulNBits` (~13 GB/s measured) → target
-      ~25–30 GB/s, ~130 tok/s decode at 360M. Risk: AppContainer compat
-      (no mmap) untested since the Phase 1 pivot.
+- [ ] **llama.cpp CPU A/B** (now the _only_ remaining decode lever — int4-DML is
+      dead, see §12): build the `XLLAMA_USE_ORT=0` path for UWP and bench a GGUF
+      Q4_K model. llama.cpp Q4_K kernels typically extract ~2× the bandwidth of
+      ORT's AVX2 `MatMulNBits` (~13 GB/s measured) → target ~25–30 GB/s, ~130
+      tok/s decode at 360M. - **Sandbox blockers scoped 2026-07-08** (verified against submodule
+      `9a532ae4b`) — 3+ desktop-only APIs, all guardable with
+      `WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)`: (1)
+      `RegOpenKeyEx`/`RegQueryValueExA` CPU-name lookup
+      (`ggml/src/ggml-cpu/ggml-cpu.cpp:321`); (2) `SetThreadAffinityMask`
+      (`ggml-cpu.c:2492`); (3) `SetThreadInformation(ThreadPowerThrottling)`
+      (`ggml-cpu.c:2521`, already behind `_WIN32_WINNT>=0x0602`). Plus
+      `dl_load_library` (`ggml-backend-reg.cpp:214/510`) — avoided by building
+      static CPU-only (`GGML_BACKEND_DL=OFF`), not a source patch. The
+      `patches/README.md` still describes 3 patch files + `apply-uwp-patches.sh`
+      that **no longer exist on disk** — stale, must be recreated. - **The real gate is the MSBuild/vcxproj wiring**, not the patches: the root
+      CMake `FATAL_ERROR`s on UWP, so ggml (C, AVX2) + llama (C++) must be
+      compiled into the UWP target via MSBuild with `XLLAMA_USE_ORT=0`. This
+      needs a dedicated build-loop push (recreate guards → wire vcxproj → CI
+      iterate) — deferred rather than shipping unvalidated patch files. Risk:
+      AppContainer runtime compat (threads OK per §10; no mmap already handled
+      `use_mmap=false`) untested since the Phase 1 pivot.
 - [x] **Per-workload routing in the app** — ✅ implemented (Stage 3, see software
       perf track above); pending on-console A/B with the DML fp16 model present.
 - [ ] (deprioritised by §12) **Fused low-bit GPU GEMM for DirectML** — the real

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,6 +93,20 @@ effective vs ~224 GB/s bus) and what the Series S can realistically deliver.
 Levers ordered by cost/leverage; the first two are near-free and change the
 denominators for everything else, so they go first.
 
+**Software perf track** (branch `feat/perf-0.14-kv-routing`, compile-validated
+in CI, **pending on-console validation** — deploy the 0.3.9.0 MSIX):
+
+- [x] **ORT GenAI 0.13.2 → 0.14.1** (Stage 1, v0.3.7): reduced per-token CPU
+      overhead + prereq for continuous decoding.
+- [x] **KV-cache reuse across chat turns** (Stage 2, v0.3.8): persistent
+      generator, append-only delta per turn → turn-N TTFT drops from re-prefilling
+      the whole history to just the new turn. Correctness-guarded fallback;
+      `kv_reuse` toggle (default on). Multi-turn TTFT bench added (Stage 2b).
+- [x] **Per-conversation CPU/GPU routing** (Stage 3, v0.3.9, default off): route
+      long-prompt conversations to DML fp16, chat to CPU int4; sticky per
+      conversation. (Supersedes the "per-workload routing" hardware milestone
+      below — machinery done, needs the fp16 model on device + console A/B.)
+
 Milestones:
 
 - [x] **Game-mode designation** — ✅ settled 2026-07-08: checked in Dev Home,
@@ -126,9 +140,8 @@ Milestones:
       bandwidth of ORT's AVX2 `MatMulNBits` (~13 GB/s measured) → target
       ~25–30 GB/s, ~130 tok/s decode at 360M. Risk: AppContainer compat
       (no mmap) untested since the Phase 1 pivot.
-- [ ] **Per-workload routing in the app**: prompt-length threshold → DML fp16
-      session for long contexts (TTFT 3.0 s vs 5.3 s measured at ~1k tok), CPU
-      int4 for chat decode. Both models fit memory; pure engineering.
+- [x] **Per-workload routing in the app** — ✅ implemented (Stage 3, see software
+      perf track above); pending on-console A/B with the DML fp16 model present.
 - [ ] (only if the above leaves ambiguity) **Upstream fused int4 DML kernel
       contribution** — the fork→CI→inject→validate pipeline is proven
       (PR #2280); bandwidth-implied payoff ~180 tok/s GPU decode (2.5× CPU).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,10 +49,15 @@ picture is workload-dependent:
 - **Prefill: GPU wins at scale** — 354 vs 198 tok/s at ~1k prompt tokens
   (1.8×, TTFT 3.0 s vs 5.3 s). DML fp16 is the better choice for prompt-heavy
   workloads (long context / RAG) already today.
-- **The int4 GPU decode collapse (8.8 tok/s) is a missing fused int4 DML
-  kernel, not a hardware limit**: fp16 decode is 5.3× faster; effective
-  bandwidth GPU ~34 GB/s vs CPU ~13 GB/s. A `MatMulNBits`-class DML kernel
-  would imply ~180 tok/s (2.5× CPU) — upstream kernel-coverage issue.
+- **The int4 GPU decode collapse (8.8 tok/s) is DirectML's non-fused low-bit
+  kernel, not a missing/CPU one** (desk-check 2026-07-08, `docs/uwp-constraints.md
+§12`): `MatMulNBits` IS registered and runs on the DML GPU (profile: one
+  `DmlFusedNode`, 96%), but DML implements it as `DML_DEQUANTIZE`→fp16 + full
+  `DML_GEMM` — materialising fp16 weights, so int4 moves _more_ bandwidth than
+  fp16 (hence 8.8 < fp16's 46.8). The builder also gives DML `accuracy_level=0`
+  vs CPU's `=4` (fused int8 MLAS → CPU's 68). No config we control fixes it; a
+  fused low-bit GPU GEMM is a DirectML-team feature. **CPU int4 stays the decode
+  winner; GPU's win is prefill.**
 
 GPU pool estimate corrected: measured budget **3801 MB** (was "~768 MB");
 disk is the real constraint. Upstream fix for the `887A0036` init failure
@@ -128,13 +133,19 @@ Milestones:
       DML int4 vs DML fp16 ~3.4 GB, the pure-bandwidth test at scale —
       borderline vs the 3801 MB budget, attempt anyway) — at 1B+ scale the GPU
       bandwidth advantage (34 vs 13 GB/s) should dominate.
-- [ ] **int4-AWQ block-128 DML variant** (builder `-p int4 -e dml` with AWQ
-      options) as a cheap proxy for fused-kernel behaviour before any kernel work.
-- [ ] **Desk check upstream int4 status**: verify whether the int4 decode
-      collapse is truly a missing DML kernel or a builder/graph issue — ORT's
-      DML EP has a `MatMulNBits` operator; check what graph `-e dml` emits,
-      `accuracy_level`, and whether ORT GenAI 0.14 / newer DirectML changes the
-      picture. May turn "weeks of HLSL" into a config fix.
+- [x] **Desk check upstream int4 status** — ✅ done 2026-07-08
+      (`docs/uwp-constraints.md §12`). Verdict: `MatMulNBits` is present and runs
+      on the DML GPU (not missing, not CPU fallback); DirectML implements it
+      **non-fused** (`DML_DEQUANTIZE`→fp16 + `DML_GEMM`), and the builder gives
+      DML `accuracy_level=0` vs CPU's `=4`. int4-on-DML decode cannot beat
+      fp16-on-DML by any config we control — it's a DirectML kernel-design limit,
+      not "weeks of HLSL" we could contribute. **This closes GPU int4 decode as a
+      local lever.**
+- [~] **int4 DML config confirmation** (fast negative): SmolLM2-360M
+  `int4_block_size=128` and `int4_accuracy_level=4` variants are **built**
+  (scratchpad); one console bench each to confirm they stay ≈ 8.8 tok/s (the
+  kernel structure predicts no material gain). If either beats fp16-DML it
+  would refute §12 — worth the ~5 min. Not a path forward, just closure.
 - [ ] **llama.cpp CPU A/B**: build the `XLLAMA_USE_ORT=0` path for UWP and
       bench a GGUF Q4_K model. llama.cpp kernels typically extract ~2× the
       bandwidth of ORT's AVX2 `MatMulNBits` (~13 GB/s measured) → target
@@ -142,9 +153,11 @@ Milestones:
       (no mmap) untested since the Phase 1 pivot.
 - [x] **Per-workload routing in the app** — ✅ implemented (Stage 3, see software
       perf track above); pending on-console A/B with the DML fp16 model present.
-- [ ] (only if the above leaves ambiguity) **Upstream fused int4 DML kernel
-      contribution** — the fork→CI→inject→validate pipeline is proven
-      (PR #2280); bandwidth-implied payoff ~180 tok/s GPU decode (2.5× CPU).
+- [ ] (deprioritised by §12) **Fused low-bit GPU GEMM for DirectML** — the real
+      unlock for GPU int4 decode, but it lives in **DirectML itself**
+      (`DmlOperatorMatMulNBits` currently dequantises to fp16), not in an ORT-side
+      patch we can carry via the PR #2280 pipeline. Track as an upstream
+      DirectML feature request, not a local contribution.
 - [ ] (optional) in-app memory-bandwidth micro-bench (`membw.flag`) to fix the
       CPU ceiling denominator precisely.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,14 +95,25 @@ denominators for everything else, so they go first.
 
 Milestones:
 
-- [ ] **Game-mode designation experiment**: flip the package from App to Game in
-      Dev Home and rerun the v0.3.6 utilization matrix. App-mode GPU is
-      time-sliced and CPU/RAM are shared — the 113 ms/token DML dispatch
-      overhead may be partly platform scheduling. Free test, run first.
-- [ ] **Unlock 1B+ models on disk**: validate Exp 2 (`xllama-appx-nobundle` +
-      HF download) and/or the USB fallback on console (see Phase 4). Disk, not
-      GPU memory (3801 MB budget), is what blocks larger models — and at 1B+
-      scale the GPU bandwidth advantage (34 vs 13 GB/s) should dominate.
+- [x] **Game-mode designation** — ✅ settled 2026-07-08: checked in Dev Home,
+      the package is **already designated Game**. All measured figures
+      (3801 MB budget, v0.3.6 matrix, per-token dispatch overhead) are
+      Game-mode numbers; the platform lever is already exhausted and the GPU
+      decode gap is a DML/kernel issue, not App-mode scheduling. Optional
+      residue: a reverse A/B (flip to App, one run, flip back) to quantify the
+      App/Game delta for the record. Re-check the designation after every
+      package reinstall (it can reset).
+- [x] **Disk unblocked** — ✅ 2026-07-08: Dev Mode storage allocation raised to
+      **90 GB** (Dev Home → Manage Dev Storage). The Q:\ ~2.2–2.5 GB budget in
+      `docs/uwp-constraints.md §9` is superseded; 1B+ (and fp16 1.7B ~3.4 GB)
+      variants can now be uploaded to LocalState. Caveat to verify on first
+      big upload: community reports a ~2 GB per-file limit in Dev Mode
+      (relevant for merged `model.onnx` > 2 GB). Exp 2 nobundle (Phase 4)
+      remains useful for its own sake but is no longer a disk prerequisite.
+- [ ] **1B+ scale bench**: SmolLM2-1.7B in three variants (CPU int4 control vs
+      DML int4 vs DML fp16 ~3.4 GB, the pure-bandwidth test at scale —
+      borderline vs the 3801 MB budget, attempt anyway) — at 1B+ scale the GPU
+      bandwidth advantage (34 vs 13 GB/s) should dominate.
 - [ ] **int4-AWQ block-128 DML variant** (builder `-p int4 -e dml` with AWQ
       options) as a cheap proxy for fused-kernel behaviour before any kernel work.
 - [ ] **Desk check upstream int4 status**: verify whether the int4 decode

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -129,10 +129,17 @@ Milestones:
       big upload: community reports a ~2 GB per-file limit in Dev Mode
       (relevant for merged `model.onnx` > 2 GB). Exp 2 nobundle (Phase 4)
       remains useful for its own sake but is no longer a disk prerequisite.
-- [ ] **1B+ scale bench**: SmolLM2-1.7B in three variants (CPU int4 control vs
-      DML int4 vs DML fp16 ~3.4 GB, the pure-bandwidth test at scale —
-      borderline vs the 3801 MB budget, attempt anyway) — at 1B+ scale the GPU
-      bandwidth advantage (34 vs 13 GB/s) should dominate.
+- [~] **1B+ scale bench**: SmolLM2-1.7B. **CPU int4 built OK** (1.4 GB, merged,
+  ready to upload). **fp16-DML blocked** (found 2026-07-08): a 1.7B fp16
+  `model.onnx` is ~3.4 GB and **exceeds the 2 GB protobuf serialization
+  limit**, so it cannot be merged self-contained; keeping external data
+  re-triggers the `weakly_canonical` AppContainer crash (§8). So the
+  pure-bandwidth fp16-at-scale test is **not deployable as-is** — it needs a
+  sub-2 GB model, an upstream `weakly_canonical` fix, or ORT's external-data
+  path made AppContainer-safe. int4-DML 1.7B is mergeable (<2 GB) but is the
+  dead kernel (§12). Net: at 1.7B we can bench CPU int4 vs int4-DML, but not
+  the fp16 bandwidth crossover — the interesting question stays blocked by
+  the serialization/AppContainer constraint, not the GPU.
 - [x] **Desk check upstream int4 status** — ✅ done 2026-07-08
       (`docs/uwp-constraints.md §12`). Verdict: `MatMulNBits` is present and runs
       on the DML GPU (not missing, not CPU fallback); DirectML implements it

--- a/bench/README.md
+++ b/bench/README.md
@@ -30,6 +30,27 @@ source ~/.config/xllama/xbox-env
 
 Results are appended to `bench/results/phase1-cpu.csv`.
 
+### Xbox — multi-turn TTFT (KV-cache reuse, Stage 2b)
+
+Measures the KV-reuse win: turn-2 prefill **with reuse** (append only the new
+turn) vs the **cold** baseline (full re-prefill of the 2-turn context), on one
+persistent session. Triggered when `bench_turns.txt` is present in LocalState
+(its content = the turn-2 user prompt; `prompt.txt` = turn 1). Upload both plus
+`model.txt` and `bench.flag`, then fetch `bench-kv-result.csv`:
+
+```bash
+source ~/.config/xllama/xbox-env
+PFN=$(./scripts/deploy.sh pfn)
+LS="knownfolderid=LocalAppData&packagefullname=$PFN&path=\\LocalState"
+# upload prompt.txt (turn 1), bench_turns.txt (turn 2), model.txt, bench.flag ...
+# (use the same upload helper as bench-xbox-ort.sh), then:
+curl -sk -u "$XBOX_USER:$XBOX_PASS" \
+  "https://$XBOX_IP:11443/api/filesystem/apps/file?$LS&filename=bench-kv-result.csv"
+```
+
+Schema: `model,prefill1_ms,n_p1,prefill2_reuse_ms,n_p2_reuse,prefill2_cold_ms,n_p2_cold,speedup,decode_tok_s,n_ctx,host,date`.
+`speedup = prefill2_cold_ms / prefill2_reuse_ms` is the headline number.
+
 ### Linux (manual)
 
 ```bash
@@ -54,8 +75,8 @@ Capture output and append a CSV row to `results/phase1-cpu.csv`.
 
 ## Results files
 
-| File                     | Phase | Backend                        | Status                                                                                                                                                                                             |
-| ------------------------ | ----- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `results/phase1-cpu.csv` | 1     | CPU EP (Xbox Series S, Zen 2)  | populated — 4 runs (2026-05-23); best `n_threads=4` at 71.4 tok/s, regression at `n_threads=8` (28.2 tok/s)                                                                                        |
+| File                     | Phase | Backend                        | Status                                                                                                                                                                                                                                                                       |
+| ------------------------ | ----- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `results/phase1-cpu.csv` | 1     | CPU EP (Xbox Series S, Zen 2)  | populated — 4 runs (2026-05-23); best `n_threads=4` at 71.4 tok/s, regression at `n_threads=8` (28.2 tok/s)                                                                                                                                                                  |
 | `results/phase2-dml.csv` | 2     | DML EP (Xbox Series S, RDNA 2) | ✅ populated (2026-07-07) — utilization matrix (v0.3.6): prefill GPU 354 vs CPU 198 tok/s @1k tok; decode CPU 68 vs GPU fp16 46.8 vs GPU int4 8.8; see `docs/uwp-constraints.md §5`. Note: `backend` column mislabels DML runs as `ort-genai-cpu` (hardcoded in `bench.cpp`) |
-| `results/profiles/<ts>/` | 2     | —                              | gitignored — downloaded ORT profiling JSON + log tail per run (`profile-dml-run.sh`)                                                                                                               |
+| `results/profiles/<ts>/` | 2     | —                              | gitignored — downloaded ORT profiling JSON + log tail per run (`profile-dml-run.sh`)                                                                                                                                                                                         |

--- a/docs/device-portal.md
+++ b/docs/device-portal.md
@@ -11,9 +11,11 @@
 In Dev Mode, open **Dev Home** on the console and enable **Device Portal**.
 
 The portal is then accessible at:
+
 ```
 https://<console-ip>:11443
 ```
+
 Accept the self-signed TLS certificate on first visit (use `-k` with curl).
 
 ### Finding the console IP
@@ -62,6 +64,7 @@ PFN=$(./scripts/deploy.sh pfn)
 ```
 
 Or upload individual files:
+
 ```bash
 curl -sS --basic -u "$XBOX_USER:$XBOX_PASS" -k \
     -X POST \
@@ -110,6 +113,31 @@ Note: `path` specifies the **directory** (`\\LocalState` or `\\LocalState\\model
 ## File Explorer (GUI)
 
 Navigate to `https://<ip>:11443/#fileExplorer` for a browser-based file manager.
+
+## Lifecycle gotchas (verified on console, 2026-07-07)
+
+Five non-obvious behaviours of Device Portal + UWP package lifecycle that have
+each invalidated at least one bench run or upload in this project:
+
+1. **Only a forward upgrade (higher version) preserves `LocalState`.**
+   Uninstall + install — including any downgrade — purges all data for the
+   package family: uploaded models and logs are gone. Plan version numbers
+   accordingly before deploying a test build.
+2. **`LocalState` does not exist until the app has launched once** after a
+   clean install. Run `deploy.sh start-app` (and wait a few seconds) before
+   any upload to a fresh package, otherwise mkdir/upload fail.
+3. **The WDP file APIs return HTTP 200 with `"Success": false`** in the body
+   (`"File move failed"`, path not found). Always check the response body
+   _and_ verify with a post-upload listing. `deploy.sh upload-dir` discards
+   responses (`/dev/null`): it can report "Uploaded N file(s)" with zero files
+   actually arrived. Multi-level mkdir fails silently when the parent is
+   missing — create directories one level at a time.
+4. **The PFN read right after "Installation succeeded" can be stale**: for a
+   few seconds the listing may still show the previous version, or both
+   versions at once (staging window). Re-read the PFN before using it in
+   file/taskmanager endpoints.
+5. **A console running a game is unreachable via Device Portal** (total
+   timeouts). Not a fault — the portal only responds from Dev Home.
 
 ## References
 

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -95,7 +95,14 @@ Disk budget failures (deploy-time or LocalState copy):
 
 Note: DirectML itself _is_ available in Dev Mode (NuGet `Microsoft.AI.DirectML 1.15.4`). The memory pool constraint applies to model weight size, not to the API itself.
 
-**Current approach**: CPU EP (`"provider_options": []` in `genai_config.json`) — chosen for deterministic behaviour. GPU EP research with proper D3D profiling is a future work item. See §7 for GPU pool detail and §9 for disk budget.
+**Current approach**: CPU EP (`"provider_options": []` in `genai_config.json`) remains the default for the interactive app (decode-heavy chat). DML fp16 is measured-viable for prompt-heavy workloads and profiling tooling exists (§11). The remaining GPU/CPU unlock levers — Game-mode designation, larger models via no-bundle deploy, fused int4 kernel path, llama.cpp kernel A/B, per-workload routing — are tracked in `ROADMAP.md` Phase 3.5. See §7 for GPU pool detail and §9 for disk budget.
+
+**Untested platform lever — App vs Game designation**: Dev Home can flip a
+sideloaded package from **App** to **Game**, granting Game OS resources
+(exclusive GPU instead of time-sliced access, more cores/RAM). All numbers in
+this document were measured in **App-mode**; part of the per-token DML
+dispatch overhead may be App-mode GPU scheduling rather than DML itself. Not
+yet measured — tracked in `ROADMAP.md` Phase 3.5.
 
 ## 6. Limited Thread Count
 

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -70,18 +70,29 @@ Readings:
    crossover sits between ~285 and ~1050 prompt tokens; at 1k tokens the GPU
    is **1.8× faster** (TTFT ~3.0 s vs ~5.3 s). For prompt-heavy workloads
    (RAG, long context) DML fp16 is already the better choice.
-2. **The int4 decode collapse was the dequant, not (only) dispatch**: fp16
-   decode is 5.3× faster than int4 on DML. At fp16 the GPU streams ~34 GB/s
-   effective (725 MB weights × 46.8 tok/s) vs ~13 GB/s for the CPU — the GPU
-   exploits memory ~2.6× better; DML simply lacks a fused int4
-   (`MatMulNBits`-style) kernel. With one, ~180 tok/s would be the
-   bandwidth-implied ceiling (2.5× CPU).
+2. **The int4 decode collapse is a non-fused DML kernel, not a missing/CPU one**
+   (corrected 2026-07-08 — see §12). The `MatMulNBits` op **is** present in the
+   graph (225 nodes, `bits=4 block_size=32`, verified) and **does run on the GPU**:
+   the profiled run shows the whole model as one `DmlFusedNode_0_0` on
+   `DmlExecutionProvider` (96% of kernel time), with no `MatMulNBits` on CPU — so
+   it is neither absent nor a CPU fallback. But DirectML's `MatMulNBits` kernel
+   (`DmlOperatorMatMulNBits.cpp`) is a **non-fused** `DML_DEQUANTIZE`
+   (int4→fp16 on GPU) + full `DML_GEMM`: it materialises the fp16 weight tensor,
+   so int4 decode moves **more** bandwidth than plain fp16 (read 4-bit, write
+   fp16, read fp16). That is why int4-DML (8.8) is _slower_ than fp16-DML (46.8).
+   The builder also targets DML with `int4_accuracy_level=0` (fp16 compute) while
+   CPU gets `=4` (fused int8 MLAS `SQNBitGemm`) — the reason CPU int4 reaches 68.
+   There is **no fused low-bit GPU GEMM** on DirectML through 1.15.x, so the
+   ~180 tok/s "bandwidth ceiling" is **not** reachable on DML by any config we
+   control; fp16 is the best DML decode config, and it still loses to CPU int4.
 3. CPU decode degrades ~25% from short to ~1 k context; GPU fp16 similarly.
 
-**Verdict**: CPU int4 remains the default for decode-heavy chat; GPU fp16 is
-viable and superior for prompt-heavy scenarios, and the decode gap is a DML
-kernel-coverage issue, not a hardware limit. Effective bandwidth utilization:
-CPU ~13 GB/s, GPU ~34 GB/s, against a ~224 GB/s theoretical bus.
+**Verdict**: CPU int4 remains the decode winner (68 vs fp16-DML 46.8 vs int4-DML
+8.8); GPU fp16 is superior only for prompt-heavy prefill. The int4-DML gap is a
+DirectML kernel-_design_ limit (non-fused low-bit GEMM), not a hardware limit and
+not fixable by our quantization config — see §12 for the full analysis and the
+config tests that confirm it. Effective bandwidth: CPU ~13 GB/s, GPU fp16
+~34 GB/s, against a ~224 GB/s theoretical bus.
 
 **Effect on disk**: models too large to fit the Dev Mode partition also fail before reaching `OgaCreateModel`. This is a distinct failure mode — see §9.
 
@@ -95,7 +106,10 @@ Disk budget failures (deploy-time or LocalState copy):
 
 Note: DirectML itself _is_ available in Dev Mode (NuGet `Microsoft.AI.DirectML 1.15.4`). The memory pool constraint applies to model weight size, not to the API itself.
 
-**Current approach**: CPU EP (`"provider_options": []` in `genai_config.json`) remains the default for the interactive app (decode-heavy chat). DML fp16 is measured-viable for prompt-heavy workloads and profiling tooling exists (§11). The remaining GPU/CPU unlock levers — Game-mode designation, larger models via no-bundle deploy, fused int4 kernel path, llama.cpp kernel A/B, per-workload routing — are tracked in `ROADMAP.md` Phase 3.5. See §7 for GPU pool detail and §9 for disk budget.
+**Current approach**: CPU EP (`"provider_options": []` in `genai_config.json`) remains the default for the interactive app (decode-heavy chat). DML fp16 is measured-viable for prompt-heavy workloads and profiling tooling exists (§11). The remaining GPU/CPU unlock levers — larger models via no-bundle deploy,
+llama.cpp CPU kernel A/B, per-workload routing — are tracked in `ROADMAP.md`
+Phase 3.5. (int4-on-DML decode is **not** a lever: it is blocked by DirectML's
+non-fused low-bit kernel, see §12.) See §7 for GPU pool detail and §9 for disk budget.
 
 **Platform lever — App vs Game designation (settled 2026-07-08)**: Dev Home
 can flip a sideloaded package between **App** and **Game** (tile → View
@@ -248,3 +262,52 @@ PIX for Xbox is GDK tooling gated behind the managed partner program; it is **no
 - Op inventory of the model graph (python + `onnx`, count `node.op_type` incl. `com.microsoft.*` domains) cross-referenced against the profiler's per-op CPU list to identify which ops force fallback.
 - Full-vs-minimal ORT build probe: `strings onnxruntime.dll | grep "Node placements"` on the NuGet-restored DLL (affects only the log probe, not profiling).
 - D3D12 debug layer: not viable in Dev Mode UWP (`DML_CREATE_DEVICE_FLAG_DEBUG` needs `DirectML.Debug.dll` and ORT creates the DML device internally); DXGI HRESULTs already surface through the SEH translator.
+
+## 12. Why int4 Decode Is Slow on DirectML (not a missing kernel)
+
+Desk-check dated 2026-07-08. Corrects the earlier wording that the int4 decode
+collapse (8.8 tok/s) was a "missing fused int4 DML kernel" — the op is present
+and GPU-executed; the limit is that DirectML's kernel is **non-fused**.
+
+**Ground truth (verified locally)**:
+
+- The ORT GenAI model builder `-p int4 -e dml` emits **225
+  `com.microsoft::MatMulNBits`** nodes (`bits=4, block_size=32`) — a fused-op
+  graph, not `DequantizeLinear`+`MatMul`. (`onnx` op inventory of the built
+  `model.onnx`.)
+- The profiled on-console run
+  (`bench/results/profiles/20260707T144203Z/ort_profile_*.json`) shows the entire
+  model as a single **`DmlFusedNode_0_0` on `DmlExecutionProvider`** (1549 ms,
+  96% of kernel time); the only CPU kernels are `Gather` + `Cast` (0.1 ms). No
+  `MatMulNBits` runs on CPU → **not a silent CPU fallback**.
+
+**Root cause (verified against ORT source)**:
+
+- DirectML **does** register `MatMulNBits`
+  (`onnxruntime/core/providers/dml/.../Operators/OperatorRegistration.cpp`), but
+  `DmlOperatorMatMulNBits.cpp` implements it as **`DML_DEQUANTIZE` (int4→fp16 on
+  the GPU) + a full `DML_GEMM`** — it materialises the fp16 weight tensor. There
+  is **no fused low-bit GPU GEMM**. In memory-bound decode (M=1) this reads the
+  4-bit weights, writes a full fp16 weight matrix to VRAM, and reads it back —
+  strictly **more** bandwidth than plain fp16, which is exactly why int4-DML
+  (8.8) is _slower_ than fp16-DML (46.8).
+- The GenAI builder defaults `int4_accuracy_level = 4` for the CPU EP but **`0`
+  for non-CPU EPs**. CPU's level 4 activates MLAS's fused int8 low-bit GEMM
+  (`SQNBitGemm`) — the reason CPU int4 hits 68 tok/s. DML gets level 0 (fp16
+  compute) and its kernel has no int8 fast path to switch into.
+- ORT 1.19/1.20 int4 improvements ("QDQ INT4", int4 embeddings) were added to the
+  **CPU and CUDA EPs only**; no DirectML fused low-bit kernel has shipped through
+  DirectML 1.15.x. Published DirectML-GenAI INT4 models (Phi-3, Llama-3.1) note
+  compute runs at fp16/fp32 accuracy — consistent with level 0.
+
+**Consequence for xllama**: int4-on-DML has **no path to beat fp16-on-DML** for
+decode by any quantization config we control, and fp16-on-DML (46.8) still loses
+to CPU int4 (68). So **CPU int4 stays the decode default**, and the GPU's real
+win is prefill (§5, reading 1) and larger-model bandwidth. A genuinely fused
+low-bit GPU GEMM would be a DirectML-team feature, not an ORT-side PR; treat GPU
+int4 decode as blocked upstream, not a local TODO.
+
+**Config tests that confirm the dead-end** (built, pending one console bench —
+expected ≈ 8.8 tok/s, a fast negative): `int4_block_size=128` and
+`int4_accuracy_level=4` variants of SmolLM2-360M. If either materially beat 8.8
+it would refute the above; the kernel structure predicts they will not.

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -29,7 +29,7 @@ Platform limitations relevant to running LLM inference on Xbox Dev Mode, and how
 ## 5. DirectML: Works on GPU (Headless) but Loses to CPU on Small Models
 
 **Background — pool estimate corrected (2026-07-07)**: the GPU budget measured
-in-app (`QueryVideoMemoryInfo(LOCAL).Budget`) is **3801 MB** in App-mode on
+in-app (`QueryVideoMemoryInfo(LOCAL).Budget`) is **3801 MB** (package designated Game — verified 2026-07-08, see §5) on
 Series S — the earlier "~768 MB pool" was a coarse inference from the
 Phi-3.5-mini OOM bracketing and is superseded. The operative constraint for
 model sizing is the **Dev Mode disk budget** (`Q:\` ~2.2–2.5 GB free), not GPU
@@ -97,12 +97,17 @@ Note: DirectML itself _is_ available in Dev Mode (NuGet `Microsoft.AI.DirectML 1
 
 **Current approach**: CPU EP (`"provider_options": []` in `genai_config.json`) remains the default for the interactive app (decode-heavy chat). DML fp16 is measured-viable for prompt-heavy workloads and profiling tooling exists (§11). The remaining GPU/CPU unlock levers — Game-mode designation, larger models via no-bundle deploy, fused int4 kernel path, llama.cpp kernel A/B, per-workload routing — are tracked in `ROADMAP.md` Phase 3.5. See §7 for GPU pool detail and §9 for disk budget.
 
-**Untested platform lever — App vs Game designation**: Dev Home can flip a
-sideloaded package from **App** to **Game**, granting Game OS resources
-(exclusive GPU instead of time-sliced access, more cores/RAM). All numbers in
-this document were measured in **App-mode**; part of the per-token DML
-dispatch overhead may be App-mode GPU scheduling rather than DML itself. Not
-yet measured — tracked in `ROADMAP.md` Phase 3.5.
+**Platform lever — App vs Game designation (settled 2026-07-08)**: Dev Home
+can flip a sideloaded package between **App** and **Game** (tile → View
+details → App type); Game grants Game OS resources (full GPU access, more
+RAM). Checked on console: **xllama is already designated Game** — the
+designation persists per package family across forward upgrades. Therefore
+the measured figures in this document (3801 MB GPU budget, the utilization
+matrix, the per-token DML dispatch overhead) are **Game-mode numbers**, and
+the earlier assumption labelling them "App-mode" was wrong. Consequence: the
+GPU decode gap cannot be blamed on App-mode scheduling — it is a DML/kernel
+issue, consistent with the fused-int4 analysis above. Operational note:
+re-check the designation after any package reinstall (it can reset to App).
 
 ## 6. Limited Thread Count
 
@@ -113,7 +118,7 @@ yet measured — tracked in `ROADMAP.md` Phase 3.5.
 ## 7. GPU Memory Pool — Detail
 
 **Measured budget (2026-07-07, in-app `QueryVideoMemoryInfo(LOCAL).Budget`):
-3801 MB** in App-mode on Series S. The "~768 MB" figure previously documented
+3801 MB** on Series S (package designated Game, verified 2026-07-08 — see §5). The "~768 MB" figure previously documented
 here was inferred from OOM bracketing and is superseded by this direct
 measurement.
 
@@ -163,7 +168,7 @@ competitive (CPU is 8× faster at 360M scale).
 **Diagnosis**: SEH `0xC0000005` in `OgaCreateModel`. WDP minidump (`type=2`) and the `xllama.log` entry `OgaCreateModel failed: ...` confirm the cause.
 
 **Source note**: the GPU budget (3801 MB) is measured per-process via
-`QueryVideoMemoryInfo(LOCAL).Budget` in App-mode. The historical "~768 MB"
+`QueryVideoMemoryInfo(LOCAL).Budget` with the package designated Game. The historical "~768 MB"
 estimate came from OOM bracketing (Phi-3.5-mini vs SmolLM2-360M) and proved to
 be a strong underestimate. We do not document the underlying Xbox OS memory
 partition layout — treat any claim about the internal platform architecture as
@@ -182,6 +187,14 @@ Tool: `scripts/merge_onnx_external_data.py`. CI runs this automatically as part 
 **Diagnosis**: Win32 probes on the model path — `GetFileAttributesW` and `CreateFile2` with `GENERIC_READ` succeed on `model_dir\model.onnx`, but the crash occurs inside the ORT segment-walking loop. Confirmed by matching the call site to `onnxruntime/core/framework/tensorprotoutils.cc` L337/338/346.
 
 ## 9. Disk Budget (Dev Mode Partition)
+
+> **Superseded (2026-07-08)**: the Dev Mode storage allocation was raised to
+> **90 GB** via Dev Home → Manage Dev Storage. The figures below describe the
+> default allocation and remain valid as the baseline for a fresh Dev Mode
+> activation; with the enlarged allocation, disk is no longer the binding
+> constraint for model sizing (GPU budget and RAM are). One caveat to verify:
+> community reports a ~2 GB per-file limit in Dev Mode, relevant for merged
+> `model.onnx` files above that size.
 
 **Observed**: the Xbox Series S Dev Mode partition (`Q:\`) provides approximately **2.2–2.5 GB of free space** after a clean Dev Mode activation, before any sideloaded package.
 
@@ -226,7 +239,7 @@ PIX for Xbox is GDK tooling gated behind the managed partner program; it is **no
 1. **ORT profiling JSON (primary, definitive)**. `genai_config.json` → `session_options` accepts `enable_profiling` (a string: the profile file _path prefix_, producing `<prefix>_<timestamp>.json`) and `log_severity_level` (0 = VERBOSE). Every `<node>_kernel_time` event in the trace carries `args.provider` — literally `"DmlExecutionProvider"` or `"CPUExecutionProvider"`. Heavy kernels (MatMul/Attention) tagged CPU = silent fallback. This works regardless of ORT build flavor and log routing. Tooling: `scripts/profile-dml-run.sh` (config swap + run + fetch) and `scripts/analyze_ort_profile.py` (per-provider summary + greppable `VERDICT:` line).
    - _Profile location ladder_: the relative prefix resolves against the process CWD, which in AppContainer may be the read-only install root (ORT's profiler ofstream then fails silently). Step 1: the fetch script checks LocalState root **and** `models\<name>\`. Step 2: `--absolute-prefix` renders `genai_config-dml-profile.tpl.json` with an absolute LocalState path. Step 3 (definitive): `set_cwd_to_local_folder()` pins CWD to LocalState at bench startup (v0.3.2+ MSIX).
 2. **Device Portal telemetry (corroborating)**. `GET /api/resourcemanager/systemperf` exists on the Xbox device family and reports `GPUData.AvailableAdapters[]` with `EnginesUtilization[]` (0–1 per engine) and `DedicatedMemoryUsed`. System-wide, ~1 Hz — run a control pass with the CPU config to calibrate background noise. Tooling: `scripts/xbox-gpu-sample.sh`, integrated as `--gpu-sample` in the bench/profile scripts.
-3. **In-app GPU memory (corroborating)**. `IDXGIAdapter3::QueryVideoMemoryInfo(LOCAL)` is callable from the AppContainer and is _per-process_: `CurrentUsage` climbing toward the model size after `OgaCreateModel` means the weights are resident on the GPU; `Budget` is the OS-granted ceiling (measured **3801 MB** App-mode Series S — trust this value over any hard-coded constant). Implemented as `gpu_mem_info()` in `src/bridge/platform.cpp`, logged pre-load/post-load/post-decode and exported as `gpu_mem_mb,gpu_budget_mb` bench CSV columns.
+3. **In-app GPU memory (corroborating)**. `IDXGIAdapter3::QueryVideoMemoryInfo(LOCAL)` is callable from the AppContainer and is _per-process_: `CurrentUsage` climbing toward the model size after `OgaCreateModel` means the weights are resident on the GPU; `Budget` is the OS-granted ceiling (measured **3801 MB** on Series S with the package designated Game — trust this value over any hard-coded constant). Implemented as `gpu_mem_info()` in `src/bridge/platform.cpp`, logged pre-load/post-load/post-decode and exported as `gpu_mem_mb,gpu_budget_mb` bench CSV columns.
 
 **Node-placement log caveat**: at `log_severity_level: 0` ORT emits "Node placements" lines from `session_state.cc`, but (a) only in full (non-minimal) ORT builds, and (b) ORT-core session logs may not route through the `OgaSetLogCallback` sink into `xllama.log`. Absence of the lines is not evidence — the profiling JSON is the primary probe.
 

--- a/include/xllama/inference_params.h
+++ b/include/xllama/inference_params.h
@@ -37,6 +37,9 @@ struct InferenceResult {
     double t_eval_ms = 0.0;
     int n_p_eval = 0;
     int n_eval = 0;
+    bool ended_with_stop = false; // true = stopped on a stop sequence; false = n_predict/EOS cap.
+                                  // Lets a KV-reuse caller know whether the closing <|im_end|>
+                                  // is already in the KV cache when building the next turn's delta.
     size_t peak_ws_mb = 0;
     size_t gpu_mem_mb = 0;    // per-process GPU CurrentUsage after model load (0 = N/A)
     size_t gpu_budget_mb = 0; // OS-granted GPU budget for this process (0 = N/A)

--- a/include/xllama/session.h
+++ b/include/xllama/session.h
@@ -34,6 +34,26 @@ struct GenerateParams {
     // Generation stops and the matching sequence is stripped.
     std::vector<std::string> stop_sequences;
 
+    // Continuous decoding / KV-cache reuse (ORT path only; the llama.cpp path
+    // ignores these and always runs stateless).
+    //   reuse_kv = false           → legacy stateless turn: a fresh generator is
+    //                                created and destroyed; `prompt` is the full
+    //                                context. Proven default.
+    //   reuse_kv = true,  reset_kv = false → continuation turn: `prompt` is only
+    //                                the NEW turn's tokens; they are appended to
+    //                                the generator kept alive from the previous
+    //                                turn, so the per-turn prefill covers just the
+    //                                delta (the multi-turn TTFT win).
+    //   reuse_kv = true,  reset_kv = true  → start/refresh the persistent
+    //                                generator (new conversation, context
+    //                                eviction, or sampling change); `prompt` is
+    //                                the full context. Subsequent turns pass
+    //                                reset_kv = false to reuse it.
+    // On any failure of a continuation turn the session drops its chat state and
+    // reports !success so the caller can retry with reset_kv + the full prompt.
+    bool reuse_kv = false;
+    bool reset_kv = false;
+
     std::function<void(const std::string&)> on_token;
     std::function<void(const std::string&)> on_status;
     std::atomic<bool>* abort_flag = nullptr;

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -235,8 +235,8 @@ class OrtSession final : public Session {
     }
 
     void log_gen(const InferenceResult& res, bool chat) {
-        double dt = (res.n_eval > 0 && res.t_eval_ms > 0) ? res.n_eval / (res.t_eval_ms / 1000.0)
-                                                          : 0.0;
+        double dt =
+            (res.n_eval > 0 && res.t_eval_ms > 0) ? res.n_eval / (res.t_eval_ms / 1000.0) : 0.0;
         char log_buf[256];
         snprintf(log_buf, sizeof(log_buf), "[xllama] session generate%s: decode=%.1f tok/s n=%d\n",
                  chat ? " (chat)" : "", dt, res.n_eval);

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -27,142 +27,245 @@
 
 namespace xllama {
 
-class OrtSession final : public Session {
-  public:
-    OgaModelPtr m_model;
-    OgaTokenizerPtr m_tok;
-
-    explicit OrtSession(OgaModelPtr model, OgaTokenizerPtr tok)
-        : m_model(std::move(model)), m_tok(std::move(tok)) {}
-
-    InferenceResult generate(const GenerateParams& gp) override {
-        InferenceResult res;
-
-        _set_se_translator([](unsigned int code, EXCEPTION_POINTERS*) {
-            char b[48];
-            snprintf(b, sizeof(b), "SEH 0x%08X", code);
-            throw std::runtime_error(b);
-        });
-
-        try {
-            if (gp.on_status)
-                gp.on_status("tokenizing");
-
-            OgaTokenizerStream* raw_stream = nullptr;
-            oga_check(OgaCreateTokenizerStream(m_tok.get(), &raw_stream),
-                      "OgaCreateTokenizerStream");
-            OgaTokenizerStreamPtr stream(raw_stream);
-
-            OgaSequences* raw_seqs = nullptr;
-            oga_check(OgaCreateSequences(&raw_seqs), "OgaCreateSequences");
-            OgaSequencesPtr seqs(raw_seqs);
-            oga_check(OgaTokenizerEncode(m_tok.get(), gp.prompt.c_str(), seqs.get()),
-                      "OgaTokenizerEncode");
-
-            OgaGeneratorParams* raw_params = nullptr;
-            oga_check(OgaCreateGeneratorParams(m_model.get(), &raw_params),
-                      "OgaCreateGeneratorParams");
-            OgaGeneratorParamsPtr gparams(raw_params);
-
-            // max_length includes prompt tokens
-            oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "max_length",
-                                                        static_cast<double>(gp.n_predict + 512)),
-                      "SetSearchNumber max_length");
-            oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "temperature",
-                                                        static_cast<double>(gp.temperature)),
-                      "SetSearchNumber temperature");
-            oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "top_p",
-                                                        static_cast<double>(gp.top_p)),
-                      "SetSearchNumber top_p");
-            oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "top_k",
-                                                        static_cast<double>(gp.top_k)),
-                      "SetSearchNumber top_k");
-            oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "repetition_penalty",
-                                                        static_cast<double>(gp.repetition_penalty)),
-                      "SetSearchNumber repetition_penalty");
-
-            OgaGenerator* raw_gen = nullptr;
-            oga_check(OgaCreateGenerator(m_model.get(), gparams.get(), &raw_gen),
-                      "OgaCreateGenerator");
-            OgaGeneratorPtr gen(raw_gen);
-
-            oga_check(OgaGenerator_AppendTokenSequences(gen.get(), seqs.get()),
-                      "AppendTokenSequences");
-
-            if (gp.on_status)
-                gp.on_status("generating");
-
-            auto t0 = std::chrono::steady_clock::now();
-            int n_generated = 0;
-            bool stopped_by_seq = false;
-
-            while (!OgaGenerator_IsDone(gen.get())) {
-                if (gp.abort_flag && gp.abort_flag->load())
-                    break;
-
-                oga_check(OgaGenerator_GenerateNextToken(gen.get()), "GenerateNextToken");
-
-                const int32_t* next_toks = nullptr;
-                size_t n_next = 0;
-                oga_check(OgaGenerator_GetNextTokens(gen.get(), &next_toks, &n_next),
-                          "GetNextTokens");
-
-                for (size_t i = 0; i < n_next; ++i) {
-                    const char* piece = nullptr;
-                    oga_check(OgaTokenizerStreamDecode(stream.get(), next_toks[i], &piece),
-                              "TokenizerStreamDecode");
-                    if (piece && *piece) {
-                        res.output_text += piece;
-                        if (gp.on_token)
-                            gp.on_token(std::string(piece));
-                    }
-                }
-                ++n_generated;
-
-                // Check stop sequences on accumulated output
-                for (const auto& stop : gp.stop_sequences) {
-                    auto pos = res.output_text.find(stop);
-                    if (pos != std::string::npos) {
-                        res.output_text.erase(pos);
-                        stopped_by_seq = true;
-                        break;
-                    }
-                }
-                if (stopped_by_seq)
-                    break;
-            }
-
-            double elapsed_s =
-                std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
-
-            res.n_eval = n_generated;
-            res.t_eval_ms = elapsed_s * 1000.0;
-            res.peak_ws_mb = peak_working_set_mb();
-            res.success = true;
-
-            char log_buf[256];
-            snprintf(log_buf, sizeof(log_buf),
-                     "[xllama] session generate: decode=%.1f tok/s n=%d\n",
-                     elapsed_s > 0 ? n_generated / elapsed_s : 0.0, n_generated);
-            log_output(log_buf);
-
-        } catch (const std::exception& e) {
-            res.error_msg = e.what();
-            log_output(("[xllama] session generate error: " + res.error_msg + "\n").c_str());
-            if (gp.on_status)
-                gp.on_status("error: " + res.error_msg);
-        }
-
-        return res;
-    }
-};
-
-std::unique_ptr<Session> Session::create(const SessionParams& sp, std::string* err) {
+namespace {
+inline void install_se_translator() {
     _set_se_translator([](unsigned int code, EXCEPTION_POINTERS*) {
         char b[48];
         snprintf(b, sizeof(b), "SEH 0x%08X", code);
         throw std::runtime_error(b);
     });
+}
+} // namespace
+
+class OrtSession final : public Session {
+  public:
+    OgaModelPtr m_model;
+    OgaTokenizerPtr m_tok;
+    int m_n_ctx;
+
+    // Persistent chat state for KV-cache reuse (continuous decoding). Kept alive
+    // between generate() calls when GenerateParams::reuse_kv is set. m_chat_params
+    // must outlive m_chat_gen.
+    OgaGeneratorParamsPtr m_chat_params;
+    OgaGeneratorPtr m_chat_gen;
+    OgaTokenizerStreamPtr m_chat_stream;
+    bool m_chat_valid = false;
+    // Sampling signature bound into m_chat_gen — the generator can only be reused
+    // while these are unchanged (ORT binds sampling at generator creation).
+    float m_b_temp = 0.0f, m_b_top_p = 0.0f, m_b_rep = 0.0f;
+    int m_b_top_k = 0;
+
+    explicit OrtSession(OgaModelPtr model, OgaTokenizerPtr tok, int n_ctx)
+        : m_model(std::move(model)), m_tok(std::move(tok)), m_n_ctx(n_ctx) {}
+
+    void reset_chat_state() {
+        m_chat_gen.reset(); // generator before its params
+        m_chat_params.reset();
+        m_chat_stream.reset();
+        m_chat_valid = false;
+    }
+
+    bool sampling_matches(const GenerateParams& gp) const {
+        return m_chat_valid && m_b_temp == gp.temperature && m_b_top_p == gp.top_p &&
+               m_b_top_k == gp.top_k && m_b_rep == gp.repetition_penalty;
+    }
+
+    OgaGeneratorParamsPtr make_params(const GenerateParams& gp, int max_length) {
+        OgaGeneratorParams* raw_params = nullptr;
+        oga_check(OgaCreateGeneratorParams(m_model.get(), &raw_params), "OgaCreateGeneratorParams");
+        OgaGeneratorParamsPtr gparams(raw_params);
+        oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "max_length",
+                                                    static_cast<double>(max_length)),
+                  "SetSearchNumber max_length");
+        oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "temperature",
+                                                    static_cast<double>(gp.temperature)),
+                  "SetSearchNumber temperature");
+        oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "top_p",
+                                                    static_cast<double>(gp.top_p)),
+                  "SetSearchNumber top_p");
+        oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "top_k",
+                                                    static_cast<double>(gp.top_k)),
+                  "SetSearchNumber top_k");
+        oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "repetition_penalty",
+                                                    static_cast<double>(gp.repetition_penalty)),
+                  "SetSearchNumber repetition_penalty");
+        return gparams;
+    }
+
+    // Decode loop shared by the stateless and chat paths. The caller has already
+    // appended the prompt tokens and captured t_prefill_start immediately before
+    // AppendTokenSequences; prefill-end is marked after the first
+    // GenerateNextToken (in ORT GenAI the prompt prefill runs during the first
+    // compute step), so decode timing excludes prefill. n_predict_cap > 0 caps
+    // per-turn generation (chat mode); 0 relies on max_length (stateless mode).
+    void run_decode(OgaGenerator* gen, OgaTokenizerStream* stream, const GenerateParams& gp,
+                    InferenceResult& res, std::chrono::steady_clock::time_point t_prefill_start,
+                    int n_prompt_tok, int n_predict_cap) {
+        auto t_prefill_end = t_prefill_start;
+        int n_generated = 0;
+        bool stopped_by_seq = false;
+        bool first = true;
+
+        while (!OgaGenerator_IsDone(gen)) {
+            if (gp.abort_flag && gp.abort_flag->load())
+                break;
+            if (n_predict_cap > 0 && n_generated >= n_predict_cap)
+                break;
+
+            oga_check(OgaGenerator_GenerateNextToken(gen), "GenerateNextToken");
+            if (first) {
+                t_prefill_end = std::chrono::steady_clock::now();
+                first = false;
+            }
+
+            const int32_t* next_toks = nullptr;
+            size_t n_next = 0;
+            oga_check(OgaGenerator_GetNextTokens(gen, &next_toks, &n_next), "GetNextTokens");
+            for (size_t i = 0; i < n_next; ++i) {
+                const char* piece = nullptr;
+                oga_check(OgaTokenizerStreamDecode(stream, next_toks[i], &piece),
+                          "TokenizerStreamDecode");
+                if (piece && *piece) {
+                    res.output_text += piece;
+                    if (gp.on_token)
+                        gp.on_token(std::string(piece));
+                }
+            }
+            ++n_generated;
+
+            for (const auto& stop : gp.stop_sequences) {
+                auto pos = res.output_text.find(stop);
+                if (pos != std::string::npos) {
+                    res.output_text.erase(pos);
+                    stopped_by_seq = true;
+                    break;
+                }
+            }
+            if (stopped_by_seq)
+                break;
+        }
+
+        auto t_end = std::chrono::steady_clock::now();
+        res.n_p_eval = n_prompt_tok;
+        res.t_p_eval_ms =
+            std::chrono::duration<double, std::milli>(t_prefill_end - t_prefill_start).count();
+        // Decode excludes the first token (produced by the prefill step), matching
+        // the bench convention so interactive and CSV tok/s are comparable.
+        res.n_eval = n_generated > 0 ? n_generated - 1 : 0;
+        res.t_eval_ms = std::chrono::duration<double, std::milli>(t_end - t_prefill_end).count();
+        res.ended_with_stop = stopped_by_seq;
+        res.peak_ws_mb = peak_working_set_mb();
+        res.success = true;
+    }
+
+    // Legacy stateless turn: fresh generator, full prompt, destroyed at return.
+    void generate_stateless(const GenerateParams& gp, InferenceResult& res) {
+        if (gp.on_status)
+            gp.on_status("tokenizing");
+
+        OgaTokenizerStream* raw_stream = nullptr;
+        oga_check(OgaCreateTokenizerStream(m_tok.get(), &raw_stream), "OgaCreateTokenizerStream");
+        OgaTokenizerStreamPtr stream(raw_stream);
+
+        OgaSequences* raw_seqs = nullptr;
+        oga_check(OgaCreateSequences(&raw_seqs), "OgaCreateSequences");
+        OgaSequencesPtr seqs(raw_seqs);
+        oga_check(OgaTokenizerEncode(m_tok.get(), gp.prompt.c_str(), seqs.get()),
+                  "OgaTokenizerEncode");
+        int n_prompt_tok = static_cast<int>(OgaSequencesGetSequenceCount(seqs.get(), 0));
+
+        OgaGeneratorParamsPtr gparams = make_params(gp, gp.n_predict + 512);
+        OgaGenerator* raw_gen = nullptr;
+        oga_check(OgaCreateGenerator(m_model.get(), gparams.get(), &raw_gen), "OgaCreateGenerator");
+        OgaGeneratorPtr gen(raw_gen);
+
+        if (gp.on_status)
+            gp.on_status("generating");
+        auto t0 = std::chrono::steady_clock::now();
+        oga_check(OgaGenerator_AppendTokenSequences(gen.get(), seqs.get()), "AppendTokenSequences");
+        run_decode(gen.get(), stream.get(), gp, res, t0, n_prompt_tok, 0);
+        log_gen(res, false);
+    }
+
+    // Continuation turn: append `gp.prompt` (the new turn's tokens) to the
+    // persistent generator; on reset_kv or a sampling change, rebuild it first
+    // (then `gp.prompt` is the full context).
+    void generate_chat(const GenerateParams& gp, InferenceResult& res) {
+        const bool reuse = !gp.reset_kv && sampling_matches(gp);
+        if (!reuse) {
+            reset_chat_state();
+            m_chat_params = make_params(gp, m_n_ctx);
+            OgaGenerator* raw_gen = nullptr;
+            oga_check(OgaCreateGenerator(m_model.get(), m_chat_params.get(), &raw_gen),
+                      "OgaCreateGenerator(chat)");
+            m_chat_gen.reset(raw_gen);
+            OgaTokenizerStream* raw_stream = nullptr;
+            oga_check(OgaCreateTokenizerStream(m_tok.get(), &raw_stream),
+                      "OgaCreateTokenizerStream(chat)");
+            m_chat_stream.reset(raw_stream);
+            m_b_temp = gp.temperature;
+            m_b_top_p = gp.top_p;
+            m_b_top_k = gp.top_k;
+            m_b_rep = gp.repetition_penalty;
+            m_chat_valid = true;
+        }
+
+        if (gp.on_status)
+            gp.on_status("tokenizing");
+        OgaSequences* raw_seqs = nullptr;
+        oga_check(OgaCreateSequences(&raw_seqs), "OgaCreateSequences");
+        OgaSequencesPtr seqs(raw_seqs);
+        oga_check(OgaTokenizerEncode(m_tok.get(), gp.prompt.c_str(), seqs.get()),
+                  "OgaTokenizerEncode");
+        int n_prompt_tok = static_cast<int>(OgaSequencesGetSequenceCount(seqs.get(), 0));
+
+        if (gp.on_status)
+            gp.on_status("generating");
+        auto t0 = std::chrono::steady_clock::now();
+        oga_check(OgaGenerator_AppendTokenSequences(m_chat_gen.get(), seqs.get()),
+                  "AppendTokenSequences(chat)");
+        run_decode(m_chat_gen.get(), m_chat_stream.get(), gp, res, t0, n_prompt_tok, gp.n_predict);
+
+        size_t kv = OgaGenerator_GetSequenceCount(m_chat_gen.get(), 0);
+        char lb[192];
+        snprintf(lb, sizeof(lb),
+                 "[xllama] chat turn: reuse=%d prefill=%d tok decode=%d tok kv_len=%zu\n",
+                 reuse ? 1 : 0, res.n_p_eval, res.n_eval, kv);
+        log_output(lb);
+    }
+
+    void log_gen(const InferenceResult& res, bool chat) {
+        double dt = (res.n_eval > 0 && res.t_eval_ms > 0) ? res.n_eval / (res.t_eval_ms / 1000.0)
+                                                          : 0.0;
+        char log_buf[256];
+        snprintf(log_buf, sizeof(log_buf), "[xllama] session generate%s: decode=%.1f tok/s n=%d\n",
+                 chat ? " (chat)" : "", dt, res.n_eval);
+        log_output(log_buf);
+    }
+
+    InferenceResult generate(const GenerateParams& gp) override {
+        InferenceResult res;
+        install_se_translator();
+        try {
+            if (gp.reuse_kv)
+                generate_chat(gp, res);
+            else
+                generate_stateless(gp, res);
+        } catch (const std::exception& e) {
+            res.success = false;
+            res.error_msg = e.what();
+            if (gp.reuse_kv)
+                reset_chat_state(); // poisoned generator — force a fresh one next turn
+            log_output(("[xllama] session generate error: " + res.error_msg + "\n").c_str());
+            if (gp.on_status)
+                gp.on_status("error: " + res.error_msg);
+        }
+        return res;
+    }
+};
+
+std::unique_ptr<Session> Session::create(const SessionParams& sp, std::string* err) {
+    install_se_translator();
 
     const std::string model_dir = resolve_model_path(sp.model_path);
     try {
@@ -186,7 +289,8 @@ std::unique_ptr<Session> Session::create(const SessionParams& sp, std::string* e
                      gpu.budget_mb);
             log_output(gpu_buf);
         }
-        return std::make_unique<OrtSession>(std::move(model), std::move(tok));
+        int n_ctx = sp.n_ctx > 0 ? sp.n_ctx : 2048;
+        return std::make_unique<OrtSession>(std::move(model), std::move(tok), n_ctx);
 
     } catch (const std::exception& e) {
         if (err)

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -10,7 +10,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="0.3.6.0"
+    Version="0.3.7.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -10,7 +10,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="0.3.8.0"
+    Version="0.3.9.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -10,7 +10,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="0.3.7.0"
+    Version="0.3.8.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -479,6 +479,17 @@ std::string MainPageController::BuildChatMLPrompt(const std::string& user_text,
     return prompt;
 }
 
+std::string MainPageController::BuildDeltaPrompt(const std::string& user_text) const {
+    // The persistent KV cache already holds everything through the previous
+    // assistant's generated tokens. Close that turn — the model emits <|im_end|>
+    // when it stops on the stop sequence, so add it only if it didn't (n_predict
+    // cap) — then append the new user turn and the assistant header. Concatenated
+    // onto the KV this reproduces exactly what BuildChatMLPrompt would have built.
+    std::string d = m_kv_last_ended_with_stop ? "\n" : "<|im_end|>\n";
+    d += "<|im_start|>user\n" + user_text + "<|im_end|>\n<|im_start|>assistant\n";
+    return d;
+}
+
 void MainPageController::SaveCurrentConversation(bool partial) {
     if (m_current.id.empty())
         return;
@@ -494,6 +505,7 @@ void MainPageController::NewChat() {
     if (m_is_running.load())
         return;                // don't allow while running
     SaveCurrentConversation(); // save current (no-op if empty)
+    m_kv_valid = false;        // new conversation → discard reused KV
     m_current = xllama::ui::Conversation{};
     m_current.id = xllama::ui::ChatHistory::NewId();
     m_outputBody.Blocks().Clear();
@@ -534,6 +546,7 @@ void MainPageController::RenderConversation() {
 
 void MainPageController::LoadConversation(const std::string& id) {
     SaveCurrentConversation();
+    m_kv_valid = false; // switching conversations → the reused KV no longer applies
     m_current = m_history.Load(id);
     if (m_current.id.empty()) {
         m_current.id = id;
@@ -803,6 +816,9 @@ void MainPageController::LoadSettings() {
                 if (!m.empty())
                     m_model_filename = ::xllama::utf8_to_wstring(m);
             }
+        } else if (key == "kv_reuse") {
+            std::string v = settings_read_token(json, pos);
+            m_kv_reuse = (v == "true" || v == "1");
         } else if (key == "sampling") {
             // Parse nested object {"temperature":0.8, ...}
             if (pos < json.size() && json[pos] == '{') {
@@ -872,6 +888,7 @@ void MainPageController::SaveSettings() {
             "{\n"
             "  \"system_prompt\": \"%s\",\n"
             "  \"model\": \"%s\",\n"
+            "  \"kv_reuse\": %s,\n"
             "  \"sampling\": {\n"
             "    \"temperature\": %.2f,\n"
             "    \"top_p\": %.2f,\n"
@@ -881,9 +898,13 @@ void MainPageController::SaveSettings() {
             "  }\n"
             "}\n",
             settings_json_escape(m_system_prompt).c_str(), settings_json_escape(model_utf8).c_str(),
-            static_cast<double>(m_temperature), static_cast<double>(m_top_p), m_top_k,
-            static_cast<double>(m_repetition_penalty), m_n_predict);
+            m_kv_reuse ? "true" : "false", static_cast<double>(m_temperature),
+            static_cast<double>(m_top_p), m_top_k, static_cast<double>(m_repetition_penalty),
+            m_n_predict);
     fclose(f);
+    // Any settings change (system prompt, model, sampling) invalidates the KV
+    // cache bound to the old settings — force a fresh generator next turn.
+    m_kv_valid = false;
 }
 
 winrt::fire_and_forget MainPageController::ShowSettings() {
@@ -943,6 +964,13 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
     auto topKSlider = make_slider(m_top_k, 1.0, 200.0, 1.0, L"Top-k (1–200)");
     auto nPredSlider = make_slider(m_n_predict, 16.0, 2048.0, 16.0, L"Max new tokens (16–2048)");
 
+    // --- KV-cache reuse toggle (continuous decoding) ---
+    winrt::Windows::UI::Xaml::Controls::ToggleSwitch kvToggle;
+    kvToggle.Header(winrt::box_value(L"KV-cache reuse (faster multi-turn)"));
+    kvToggle.OnContent(winrt::box_value(L"On"));
+    kvToggle.OffContent(winrt::box_value(L"Off"));
+    kvToggle.IsOn(m_kv_reuse);
+
     winrt::Windows::UI::Xaml::Controls::StackPanel panel;
     panel.Orientation(Orientation::Vertical);
     panel.Spacing(12);
@@ -953,6 +981,7 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
     panel.Children().Append(topKSlider);
     panel.Children().Append(repSlider);
     panel.Children().Append(nPredSlider);
+    panel.Children().Append(kvToggle);
 
     winrt::Windows::UI::Xaml::Controls::ScrollViewer sv;
     sv.Content(panel);
@@ -986,6 +1015,7 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
     self->m_top_k = static_cast<int>(topKSlider.Value());
     self->m_repetition_penalty = static_cast<float>(repSlider.Value());
     self->m_n_predict = static_cast<int>(nPredSlider.Value());
+    self->m_kv_reuse = kvToggle.IsOn();
     self->SaveSettings();
     self->SetStatus(L"Settings saved", StatusKind::Success);
 }
@@ -1283,7 +1313,8 @@ fire_and_forget MainPageController::CheckBenchMode() {
 bool MainPageController::EnsureSession(const std::string& model, std::string* err_out) {
     if (m_session && m_session_model == model)
         return true;
-    m_session.reset(); // free before creating new (avoid 2× model in RAM)
+    m_session.reset();  // free before creating new (avoid 2× model in RAM)
+    m_kv_valid = false; // new session object → no reusable KV carries over
     xllama::SessionParams sp;
     sp.model_path = model;
     sp.n_ctx = 2048;
@@ -1345,9 +1376,18 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
         m_current.title = xllama::ui::ChatHistory::TitleFrom(user_text);
     }
     int n_dropped = 0;
-    std::string prompt = BuildChatMLPrompt(user_text, &n_dropped);
+    std::string full_prompt = BuildChatMLPrompt(user_text, &n_dropped);
     if (n_dropped > 0)
         SetStatus(L"Context trimmed — " + std::to_wstring(n_dropped) + L" old turn(s) dropped");
+
+    // KV-cache reuse decision (continuous decoding). Reuse only when enabled, the
+    // persistent generator already holds this conversation (m_kv_valid), and no
+    // turn was evicted this round (RewindTo cannot drop from the head, so eviction
+    // forces a full re-prefill). A reuse turn appends only the delta; otherwise we
+    // (re)prefill the full prompt — which also (re)seeds the persistent generator.
+    bool do_reuse = m_kv_reuse && m_kv_valid && n_dropped == 0;
+    bool kv_reuse = m_kv_reuse;
+    std::string delta_prompt = do_reuse ? BuildDeltaPrompt(user_text) : std::string();
 
     // Record user message in history AFTER building prompt (avoids duplicate)
     {
@@ -1361,7 +1401,7 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
     std::string model = ::xllama::wstring_to_utf8(m_model_filename);
     auto dispatcher = m_root.Dispatcher();
 
-    std::thread([self, prompt, model, dispatcher]() {
+    std::thread([self, full_prompt, delta_prompt, do_reuse, kv_reuse, model, dispatcher]() {
         try {
             std::string load_err;
             if (!self->EnsureSession(model, &load_err)) {
@@ -1373,32 +1413,52 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
                 return;
             }
 
-            xllama::GenerateParams gp;
-            gp.prompt = prompt;
-            gp.n_predict = self->m_n_predict;
-            gp.temperature = self->m_temperature;
-            gp.top_p = self->m_top_p;
-            gp.top_k = self->m_top_k;
-            gp.repetition_penalty = self->m_repetition_penalty;
-            gp.abort_flag = &self->m_abort;
-            gp.stop_sequences.push_back("<|im_end|>");
-
-            gp.on_status = [self, dispatcher](const std::string& s) {
+            auto on_status = [self, dispatcher](const std::string& s) {
                 auto ws = ::xllama::utf8_to_wstring(s);
                 StatusKind k =
                     (s.rfind("error:", 0) == 0) ? StatusKind::Error : StatusKind::Working;
                 dispatcher.RunAsync(CoreDispatcherPriority::Normal,
                                     [self, ws, k]() { self->SetStatus(ws, k); });
             };
-
             // Token accumulation — no per-token RunAsync dispatch (batched by flush timer)
-            gp.on_token = [self](const std::string& tok) {
+            auto on_token = [self](const std::string& tok) {
                 self->m_tokens_received.fetch_add(1, std::memory_order_relaxed);
                 std::lock_guard<std::mutex> lk(self->m_token_mutex);
                 self->m_token_buffer += tok;
             };
 
-            auto res = self->m_session->generate(gp);
+            auto run_turn = [&](const std::string& p, bool reuse, bool reset) {
+                xllama::GenerateParams gp;
+                gp.prompt = p;
+                gp.n_predict = self->m_n_predict;
+                gp.temperature = self->m_temperature;
+                gp.top_p = self->m_top_p;
+                gp.top_k = self->m_top_k;
+                gp.repetition_penalty = self->m_repetition_penalty;
+                gp.abort_flag = &self->m_abort;
+                gp.stop_sequences.push_back("<|im_end|>");
+                gp.reuse_kv = reuse;
+                gp.reset_kv = reset;
+                gp.on_status = on_status;
+                gp.on_token = on_token;
+                return self->m_session->generate(gp);
+            };
+
+            xllama::InferenceResult res;
+            if (do_reuse) {
+                res = run_turn(delta_prompt, /*reuse=*/true, /*reset=*/false);
+                // A continuation that fails before emitting any token (e.g. appending
+                // to a finished generator) falls back to a full re-prefill. No tokens
+                // were streamed yet, so the UI stays clean.
+                if (!res.success && res.n_eval == 0) {
+                    ::xllama::log_output("[xllama] KV reuse failed, retrying with full prefill\n");
+                    res = run_turn(full_prompt, /*reuse=*/kv_reuse, /*reset=*/true);
+                }
+            } else {
+                // First turn / post-reset: seed the persistent generator (reuse+reset)
+                // when KV reuse is enabled, else a pure stateless turn.
+                res = run_turn(full_prompt, /*reuse=*/kv_reuse, /*reset=*/kv_reuse);
+            }
 
             std::wstring metrics;
             if (res.success) {
@@ -1424,6 +1484,15 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
                                         ? StatusKind::Info
                                         : (res.success ? StatusKind::Success : StatusKind::Error));
                     self->SetRunning(false); // also stops timer + flushes remaining tokens
+                    // KV-reuse bookkeeping: the persistent generator now holds this
+                    // turn only if it completed cleanly. On failure or abort, force a
+                    // fresh generator (full re-prefill) next turn.
+                    if (self->m_kv_reuse && res.success && !was_aborted) {
+                        self->m_kv_valid = true;
+                        self->m_kv_last_ended_with_stop = res.ended_with_stop;
+                    } else {
+                        self->m_kv_valid = false;
+                    }
                     // Save assistant response (partial-flagged if user aborted)
                     if (!output_text.empty()) {
                         xllama::ui::ChatMessage amsg;

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -506,6 +506,7 @@ void MainPageController::NewChat() {
         return;                // don't allow while running
     SaveCurrentConversation(); // save current (no-op if empty)
     m_kv_valid = false;        // new conversation → discard reused KV
+    m_active_model.clear();    // re-decide EP routing for the new conversation
     m_current = xllama::ui::Conversation{};
     m_current.id = xllama::ui::ChatHistory::NewId();
     m_outputBody.Blocks().Clear();
@@ -546,7 +547,8 @@ void MainPageController::RenderConversation() {
 
 void MainPageController::LoadConversation(const std::string& id) {
     SaveCurrentConversation();
-    m_kv_valid = false; // switching conversations → the reused KV no longer applies
+    m_kv_valid = false;     // switching conversations → the reused KV no longer applies
+    m_active_model.clear(); // re-decide EP routing for the loaded conversation
     m_current = m_history.Load(id);
     if (m_current.id.empty()) {
         m_current.id = id;
@@ -819,6 +821,17 @@ void MainPageController::LoadSettings() {
         } else if (key == "kv_reuse") {
             std::string v = settings_read_token(json, pos);
             m_kv_reuse = (v == "true" || v == "1");
+        } else if (key == "routing") {
+            std::string v = settings_read_token(json, pos);
+            if (!v.empty())
+                m_routing = std::stoi(v);
+        } else if (key == "gpu_model") {
+            if (pos < json.size() && json[pos] == '"') {
+                ++pos;
+                std::string g = settings_read_string(json, pos);
+                if (!g.empty())
+                    m_gpu_model = g;
+            }
         } else if (key == "sampling") {
             // Parse nested object {"temperature":0.8, ...}
             if (pos < json.size() && json[pos] == '{') {
@@ -889,6 +902,8 @@ void MainPageController::SaveSettings() {
             "  \"system_prompt\": \"%s\",\n"
             "  \"model\": \"%s\",\n"
             "  \"kv_reuse\": %s,\n"
+            "  \"routing\": %d,\n"
+            "  \"gpu_model\": \"%s\",\n"
             "  \"sampling\": {\n"
             "    \"temperature\": %.2f,\n"
             "    \"top_p\": %.2f,\n"
@@ -898,9 +913,9 @@ void MainPageController::SaveSettings() {
             "  }\n"
             "}\n",
             settings_json_escape(m_system_prompt).c_str(), settings_json_escape(model_utf8).c_str(),
-            m_kv_reuse ? "true" : "false", static_cast<double>(m_temperature),
-            static_cast<double>(m_top_p), m_top_k, static_cast<double>(m_repetition_penalty),
-            m_n_predict);
+            m_kv_reuse ? "true" : "false", m_routing, settings_json_escape(m_gpu_model).c_str(),
+            static_cast<double>(m_temperature), static_cast<double>(m_top_p), m_top_k,
+            static_cast<double>(m_repetition_penalty), m_n_predict);
     fclose(f);
     // Any settings change (system prompt, model, sampling) invalidates the KV
     // cache bound to the old settings — force a fresh generator next turn.
@@ -971,6 +986,16 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
     kvToggle.OffContent(winrt::box_value(L"Off"));
     kvToggle.IsOn(m_kv_reuse);
 
+    // --- EP routing ComboBox (experimental; needs the DML fp16 model on device) ---
+    winrt::Windows::UI::Xaml::Controls::ComboBox routingBox;
+    routingBox.Header(winrt::box_value(L"EP routing (per conversation)"));
+    routingBox.FontSize(16);
+    routingBox.HorizontalAlignment(HorizontalAlignment::Stretch);
+    routingBox.Items().Append(winrt::box_value(L"CPU only (default)"));
+    routingBox.Items().Append(winrt::box_value(L"GPU only (DML)"));
+    routingBox.Items().Append(winrt::box_value(L"Auto (long prompts → GPU)"));
+    routingBox.SelectedIndex(m_routing >= 0 && m_routing <= 2 ? m_routing : 0);
+
     winrt::Windows::UI::Xaml::Controls::StackPanel panel;
     panel.Orientation(Orientation::Vertical);
     panel.Spacing(12);
@@ -982,6 +1007,7 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
     panel.Children().Append(repSlider);
     panel.Children().Append(nPredSlider);
     panel.Children().Append(kvToggle);
+    panel.Children().Append(routingBox);
 
     winrt::Windows::UI::Xaml::Controls::ScrollViewer sv;
     sv.Content(panel);
@@ -1016,6 +1042,10 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
     self->m_repetition_penalty = static_cast<float>(repSlider.Value());
     self->m_n_predict = static_cast<int>(nPredSlider.Value());
     self->m_kv_reuse = kvToggle.IsOn();
+    int ri = routingBox.SelectedIndex();
+    self->m_routing = (ri >= 0 && ri <= 2) ? ri : 0;
+    // Routing is per-conversation: a change applies from the next new/loaded chat
+    // (m_active_model stays fixed for the conversation in progress).
     self->SaveSettings();
     self->SetStatus(L"Settings saved", StatusKind::Success);
 }
@@ -1380,6 +1410,22 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
     if (n_dropped > 0)
         SetStatus(L"Context trimmed — " + std::to_wstring(n_dropped) + L" old turn(s) dropped");
 
+    // Stage 3: decide EP routing once per conversation (sticky — the KV cache is
+    // per-EP). m_active_model is cleared on new/loaded chat, so this fires on the
+    // first turn and stays fixed after. Default (m_routing==0) keeps the CPU model.
+    if (m_active_model.empty()) {
+        constexpr int kRoutingTokThreshold = 500; // ~crossover from the v0.3.6 matrix
+        if (m_routing == 1) {
+            m_active_model = ::xllama::utf8_to_wstring(m_gpu_model);
+        } else if (m_routing == 2) {
+            int est_tok = static_cast<int>(full_prompt.size() / 4);
+            m_active_model = est_tok > kRoutingTokThreshold ? ::xllama::utf8_to_wstring(m_gpu_model)
+                                                            : m_model_filename;
+        } else {
+            m_active_model = m_model_filename;
+        }
+    }
+
     // KV-cache reuse decision (continuous decoding). Reuse only when enabled, the
     // persistent generator already holds this conversation (m_kv_valid), and no
     // turn was evicted this round (RewindTo cannot drop from the head, so eviction
@@ -1398,7 +1444,8 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
         m_current.messages.push_back(std::move(umsg));
     }
 
-    std::string model = ::xllama::wstring_to_utf8(m_model_filename);
+    std::string model =
+        ::xllama::wstring_to_utf8(m_active_model.empty() ? m_model_filename : m_active_model);
     auto dispatcher = m_root.Dispatcher();
 
     std::thread([self, full_prompt, delta_prompt, do_reuse, kv_reuse, model, dispatcher]() {

--- a/uwp/MainPage.h
+++ b/uwp/MainPage.h
@@ -55,6 +55,8 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     void RenderConversation();
     void AddUserParagraph(std::wstring const& text);
     std::string BuildChatMLPrompt(const std::string& user_text, int* out_dropped = nullptr) const;
+    // Only the new turn's ChatML tokens, appended to the reused KV cache.
+    std::string BuildDeltaPrompt(const std::string& user_text) const;
     void LoadSettings();
     void SaveSettings();
     winrt::fire_and_forget ShowSettings();
@@ -83,6 +85,18 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     // Persistent inference session — loaded once, reused across chat turns.
     std::unique_ptr<xllama::Session> m_session;
     std::string m_session_model;
+
+    // KV-cache reuse (continuous decoding) state.
+    //   m_kv_reuse: feature toggle (settings.json "kv_reuse", default true).
+    //   m_kv_valid: the session's persistent generator currently holds the KV for
+    //               m_current through the last completed turn — the next turn can
+    //               append only its delta. Cleared on new/loaded chat, settings
+    //               change, abort, context eviction, or any generator failure.
+    //   m_kv_last_ended_with_stop: whether the last turn stopped on <|im_end|>
+    //               (already in KV) vs the n_predict cap (not) — drives the delta.
+    bool m_kv_reuse{true};
+    bool m_kv_valid{false};
+    bool m_kv_last_ended_with_stop{false};
 
     // Token streaming state (written from bg thread, flushed on UI thread via timer)
     std::mutex m_token_mutex;

--- a/uwp/MainPage.h
+++ b/uwp/MainPage.h
@@ -98,6 +98,16 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     bool m_kv_valid{false};
     bool m_kv_last_ended_with_stop{false};
 
+    // Per-conversation CPU/GPU routing (Stage 3). The GPU (DML fp16) EP wins the
+    // prefill of long prompts; the CPU EP wins decode. Routing is decided at a
+    // conversation's first turn and sticky for its lifetime (the KV cache is
+    // per-EP). m_routing: 0 = CPU only (default = current behaviour), 1 = GPU
+    // only, 2 = auto (route by first-prompt length). m_active_model holds the
+    // routed model dir for the current conversation.
+    int m_routing{0};
+    std::string m_gpu_model{"smollm2-360m-dml-fp16"};
+    std::wstring m_active_model;
+
     // Token streaming state (written from bg thread, flushed on UI thread via timer)
     std::mutex m_token_mutex;
     std::string m_token_buffer;

--- a/uwp/inference-bridge.cpp
+++ b/uwp/inference-bridge.cpp
@@ -6,12 +6,114 @@
 #include "xllama/inference.h"
 #include "xllama/path_utils.h"
 #include "xllama/platform.h"
+#include "xllama/session.h"
 #include "xllama/utf8_utils.h"
 
 #include <cstdio>
+#include <ctime>
 #include <string>
 
 namespace xllama::bridge {
+
+#ifdef XLLAMA_UWP
+namespace {
+
+std::string read_local_file(const char* name) {
+    std::string out;
+    std::string p = resolve_local_path(name);
+    FILE* f = _wfopen(utf8_to_wstring(p).c_str(), L"r");
+    if (!f)
+        return out;
+    char buf[8192];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof(buf), f)) > 0)
+        out.append(buf, n);
+    fclose(f);
+    while (!out.empty() && (out.back() == '\n' || out.back() == '\r' || out.back() == ' '))
+        out.pop_back();
+    return out;
+}
+
+std::string chatml(const std::string& sys, const std::string& user) {
+    return "<|im_start|>system\n" + sys + "<|im_end|>\n<|im_start|>user\n" + user +
+           "<|im_end|>\n<|im_start|>assistant\n";
+}
+
+// Multi-turn TTFT bench: measures turn-2 prefill with KV reuse (append only the
+// new turn) against the cold baseline (full re-prefill of the 2-turn context),
+// on the same persistent Session. The ratio is the KV-reuse win. Writes
+// bench-kv-result.csv (+ .done) and logs the numbers.
+void run_kv_bench(const std::string& model_name, const std::string& sys, const std::string& u1,
+                  const std::string& u2, int n_threads, const char* host) {
+    std::string err;
+    ::xllama::SessionParams sp;
+    sp.model_path = model_name;
+    sp.n_ctx = 2048;
+    sp.n_threads = n_threads;
+    auto sess = ::xllama::Session::create(sp, &err);
+    if (!sess) {
+        log_output("[xllama] kv-bench: session create failed: " + err + "\n");
+        return;
+    }
+
+    auto mkgp = [&](const std::string& p, bool reuse, bool reset) {
+        ::xllama::GenerateParams gp;
+        gp.prompt = p;
+        gp.n_predict = 96;
+        gp.reuse_kv = reuse;
+        gp.reset_kv = reset;
+        gp.stop_sequences.push_back("<|im_end|>");
+        return gp;
+    };
+
+    // Turn 1: seed the persistent generator.
+    auto r1 = sess->generate(mkgp(chatml(sys, u1), /*reuse=*/true, /*reset=*/true));
+    // Turn 2 (KV reuse): append only the new turn's delta.
+    std::string delta = (r1.ended_with_stop ? std::string("\n") : std::string("<|im_end|>\n")) +
+                        "<|im_start|>user\n" + u2 + "<|im_end|>\n<|im_start|>assistant\n";
+    auto r2 = sess->generate(mkgp(delta, /*reuse=*/true, /*reset=*/false));
+    // Turn 2 (cold): full re-prefill of the whole 2-turn context — the pre-Stage-2
+    // behaviour. Uses turn-1's actual output so the token count matches.
+    std::string full2 = "<|im_start|>system\n" + sys + "<|im_end|>\n<|im_start|>user\n" + u1 +
+                        "<|im_end|>\n<|im_start|>assistant\n" + r1.output_text +
+                        "<|im_end|>\n<|im_start|>user\n" + u2 +
+                        "<|im_end|>\n<|im_start|>assistant\n";
+    auto r2c = sess->generate(mkgp(full2, /*reuse=*/true, /*reset=*/true));
+
+    double speedup = (r2.t_p_eval_ms > 0) ? r2c.t_p_eval_ms / r2.t_p_eval_ms : 0.0;
+    char lb[320];
+    snprintf(lb, sizeof(lb),
+             "[xllama] kv-bench: turn2 prefill reuse=%.1fms (%d tok) cold=%.1fms (%d tok) "
+             "speedup=%.2fx\n",
+             r2.t_p_eval_ms, r2.n_p_eval, r2c.t_p_eval_ms, r2c.n_p_eval, speedup);
+    log_output(lb);
+
+    const std::string csv = resolve_local_path("bench-kv-result.csv");
+    FILE* fp = _wfopen(utf8_to_wstring(csv).c_str(), L"w");
+    if (fp) {
+        time_t now = time(nullptr);
+        char date_buf[32];
+        strftime(date_buf, sizeof(date_buf), "%Y-%m-%dT%H:%M:%SZ", gmtime(&now));
+        fputs("model,prefill1_ms,n_p1,prefill2_reuse_ms,n_p2_reuse,prefill2_cold_ms,n_p2_cold,"
+              "speedup,decode_tok_s,n_ctx,host,date\n",
+              fp);
+        double dtok = (r2.n_eval > 0 && r2.t_eval_ms > 0) ? r2.n_eval / (r2.t_eval_ms / 1000.0) : 0;
+        fprintf(fp, "%s,%.1f,%d,%.1f,%d,%.1f,%d,%.2f,%.2f,%d,%s,%s\n", model_name.c_str(),
+                r1.t_p_eval_ms, r1.n_p_eval, r2.t_p_eval_ms, r2.n_p_eval, r2c.t_p_eval_ms,
+                r2c.n_p_eval, speedup, dtok, sp.n_ctx, host ? host : "unknown", date_buf);
+        fclose(fp);
+        FILE* done =
+            _wfopen(utf8_to_wstring(resolve_local_path("bench-kv-result.csv.done")).c_str(), L"w");
+        if (done) {
+            fputs("done\n", done);
+            fclose(done);
+        }
+        log_output("[xllama] bench-kv-result.csv written\n");
+    }
+}
+
+} // namespace
+#endif // XLLAMA_UWP
 
 // ---------------------------------------------------------------------------
 // main_loop (called from UWP bench mode background thread)
@@ -80,6 +182,24 @@ void main_loop() {
             if (fread(buf, 1, sizeof(buf) - 1, tf) > 0)
                 bench_threads = std::atoi(buf);
             fclose(tf);
+        }
+    }
+
+    // Multi-turn TTFT bench (Stage 2b): if bench_turns.txt is present it holds the
+    // turn-2 user prompt; prompt.txt supplies turn 1. Measures the KV-reuse win
+    // and skips the normal single-turn bench.
+    {
+        std::string turn2 = read_local_file("bench_turns.txt");
+        if (!turn2.empty()) {
+            char host_buf2[64];
+            if (bench_threads > 0)
+                snprintf(host_buf2, sizeof(host_buf2), "xbox-series-s-t%d", bench_threads);
+            else
+                snprintf(host_buf2, sizeof(host_buf2), "xbox-series-s");
+            log_output("[xllama] kv-bench model: " + model_name + "\n");
+            run_kv_bench(model_name, "You are a helpful AI assistant.", user_prompt, turn2,
+                         bench_threads, host_buf2);
+            return;
         }
     }
 

--- a/uwp/packages.config
+++ b/uwp/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
   <package id="Microsoft.AI.DirectML" version="1.15.4" targetFramework="native" />
   <package id="Microsoft.ML.OnnxRuntime.DirectML" version="1.24.4" targetFramework="native" />
-  <package id="Microsoft.ML.OnnxRuntimeGenAI.DirectML" version="0.13.2" targetFramework="native" />
+  <package id="Microsoft.ML.OnnxRuntimeGenAI.DirectML" version="0.14.1" targetFramework="native" />
 </packages>

--- a/uwp/xllama.vcxproj
+++ b/uwp/xllama.vcxproj
@@ -66,8 +66,8 @@
           Condition="Exists('packages\Microsoft.AI.DirectML.1.15.4\build\native\Microsoft.AI.DirectML.props')" />
   <Import Project="packages\Microsoft.ML.OnnxRuntime.DirectML.1.24.4\build\native\Microsoft.ML.OnnxRuntime.DirectML.props"
           Condition="Exists('packages\Microsoft.ML.OnnxRuntime.DirectML.1.24.4\build\native\Microsoft.ML.OnnxRuntime.DirectML.props')" />
-  <Import Project="packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.13.2\build\native\Microsoft.ML.OnnxRuntimeGenAI.DirectML.props"
-          Condition="Exists('packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.13.2\build\native\Microsoft.ML.OnnxRuntimeGenAI.DirectML.props')" />
+  <Import Project="packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.14.1\build\native\Microsoft.ML.OnnxRuntimeGenAI.DirectML.props"
+          Condition="Exists('packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.14.1\build\native\Microsoft.ML.OnnxRuntimeGenAI.DirectML.props')" />
 
   <!-- =====================================================================
        Package / signing
@@ -95,7 +95,7 @@
         $(ProjectDir)Generated Files;
         $(IntDir)Generated Files;
         $(ProjectDir)..\include;
-        $(ProjectDir)packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.13.2\build\native\include;
+        $(ProjectDir)packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.14.1\build\native\include;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>
@@ -135,7 +135,7 @@
            (not win10-x64) for their native binaries. -->
       <AdditionalLibraryDirectories>
         $(ProjectDir)packages\Microsoft.ML.OnnxRuntime.DirectML.1.24.4\runtimes\win-x64\native;
-        $(ProjectDir)packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.13.2\runtimes\win-x64\native;
+        $(ProjectDir)packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.14.1\runtimes\win-x64\native;
         %(AdditionalLibraryDirectories)
       </AdditionalLibraryDirectories>
       <AdditionalDependencies>WindowsApp.lib;onnxruntime.lib;onnxruntime-genai.lib;dxgi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -217,8 +217,8 @@
       <DeploymentContent>true</DeploymentContent>
       <TargetPath>onnxruntime.dll</TargetPath>
     </None>
-    <None Include="packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.13.2\runtimes\win-x64\native\onnxruntime-genai.dll"
-          Condition="Exists('packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.13.2\runtimes\win-x64\native\onnxruntime-genai.dll')">
+    <None Include="packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.14.1\runtimes\win-x64\native\onnxruntime-genai.dll"
+          Condition="Exists('packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.14.1\runtimes\win-x64\native\onnxruntime-genai.dll')">
       <DeploymentContent>true</DeploymentContent>
       <TargetPath>onnxruntime-genai.dll</TargetPath>
     </None>
@@ -291,7 +291,7 @@
           Condition="Exists('packages\Microsoft.AI.DirectML.1.15.4\build\native\Microsoft.AI.DirectML.targets')" />
   <Import Project="packages\Microsoft.ML.OnnxRuntime.DirectML.1.24.4\build\native\Microsoft.ML.OnnxRuntime.DirectML.targets"
           Condition="Exists('packages\Microsoft.ML.OnnxRuntime.DirectML.1.24.4\build\native\Microsoft.ML.OnnxRuntime.DirectML.targets')" />
-  <Import Project="packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.13.2\build\native\Microsoft.ML.OnnxRuntimeGenAI.DirectML.targets"
-          Condition="Exists('packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.13.2\build\native\Microsoft.ML.OnnxRuntimeGenAI.DirectML.targets')" />
+  <Import Project="packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.14.1\build\native\Microsoft.ML.OnnxRuntimeGenAI.DirectML.targets"
+          Condition="Exists('packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.14.1\build\native\Microsoft.ML.OnnxRuntimeGenAI.DirectML.targets')" />
 
 </Project>


### PR DESCRIPTION
Three-stage performance architecture work. **All commits compile green in CI (build-linux + build-uwp).** On-console validation is pending (needs the Xbox) — see the per-stage checklist below.

## Stages

**Stage 1 — ORT GenAI 0.13.2 → 0.14.1** (`0.3.7.0`)
NuGet bump (packages.config + 8 vcxproj path refs). 0.14.x cuts per-token CPU overhead in `GenerateNextToken`/`SampleTopP` (the v0.3.6 decode bottleneck) and is the prerequisite for continuous decoding. No breaking C-API changes; existing model dirs load unchanged.

**Stage 2 — KV-cache reuse across chat turns** (`0.3.8.0`)
`OrtSession` keeps its `OgaGenerator` alive across turns and appends only the new turn's tokens instead of re-prefilling the full ChatML history every turn. Turn-N TTFT drops from re-processing ~all prior tokens (~1.8k at budget) to just the delta.
- `GenerateParams.reuse_kv/reset_kv`; `InferenceResult.ended_with_stop` + prefill telemetry now on the interactive path.
- Stateless path preserved for `reuse_kv=false`. KV invalidated on new/loaded chat, settings change, abort, context eviction (RewindTo can't drop from the head), or any failure.
- **Correctness guard**: a continuation that fails before the first token auto-falls back to a full re-prefill — worst case is the old behaviour, never a wrong result.
- `kv_reuse` settings toggle (default on).

**Stage 2b — multi-turn TTFT bench**
`bench_turns.txt` triggers a 2-turn run on one persistent session, measuring turn-2 prefill with reuse vs cold. Writes `bench-kv-result.csv` with a `speedup` column. Measures the Stage 2 win on console instead of assuming it.

**Stage 3 — per-conversation CPU/GPU routing** (`0.3.9.0`, default off)
Route long-prompt conversations to DML fp16 (wins prefill 1.8× at ~1k tok), chat to CPU int4 (wins decode); sticky per conversation. Settings `routing` (0=CPU default / 1=GPU / 2=auto) + `gpu_model`. Default CPU = unchanged behaviour.

## On-console validation (pending)
- [ ] Stage 1: rerun CPU + DML bench matrix, compare decode tok/s to v0.3.6 baselines.
- [ ] Stage 2: deploy 0.3.9.0; run the multi-turn bench (`bench_turns.txt`) → confirm `speedup > 1`; hold a 3–4 turn chat and confirm coherent output with `kv_reuse` on.
- [ ] Stage 3: put the DML fp16 model on device, set routing=auto, confirm long prompts pick GPU and TTFT improves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)