### PR TITLE
feat(image): plain ORT DirectML compute-bound spike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,33 @@ DML `accuracy_level=0` vs CPU's fused-int8 `=4`. Full analysis + config tests in
 decode is blocked by a DirectML kernel-design limit (out of our control), not a
 kernel we could contribute — CPU int4 stays the decode default.
 
+## [0.4.0.0] - 2026-07-08
+
+### Added — image-generation spike (plain ORT DirectML, new model axis)
+
+First step toward image/vision models on the console. The desk-check (§12) showed
+the GPU loses at text decode because that workload is M=1, dispatch-bound, and
+int4-DML is non-fused — the GPU's _worst_ case. Image generation (diffusion) is
+the opposite: compute-bound fp16 batch, the case where DML already wins (prefill).
+This spike tests that hypothesis cheaply before building a full diffusion pipeline.
+
+- `uwp/image-spike.cpp`: runs a compute-bound conv model through the **plain
+  ONNX Runtime DirectML** EP (not ORT GenAI — `onnxruntime.dll` was already a
+  dependency) plus a CPU EP control, measuring forward-pass latency + GFLOP/s.
+  Model `imgspike.onnx` (`scripts/gen_imgspike_model.py`, deterministic): 17
+  Conv(3×3,64ch)+Relu on 1×3×512×512 fp16, ~309 GFLOP/forward — a faithful proxy
+  for one diffusion UNet step.
+- `uwp/App.cpp`: generalised the headless flag dispatch — `image.flag` →
+  `run_image_spike()`, `bench.flag` → `main_loop()` (shared `HeadlessView`, same
+  D3D12-clean host that avoids the 887A0036 compositor conflict).
+- `uwp/xllama.vcxproj`: added the ORT DirectML NuGet include dir + the new source.
+  `onnxruntime.lib` was already linked.
+- Writes `imgspike-result.csv` (+ `.done`): DML vs CPU ms, GFLOP/s, GPU speedup.
+- On-console validation pending: upload `imgspike.onnx` to LocalState + drop
+  `image.flag`, fetch the CSV. **Hypothesis**: DML ≫ CPU here (compute-bound), the
+  inverse of text decode — if confirmed, a distilled SD-Turbo/LCM diffusion
+  pipeline becomes the flagship GPU workload (Phase 5).
+
 ## [0.3.9.0] - 2026-07-08
 
 ### Added — per-conversation CPU/GPU routing (Stage 3, default off)

--- a/scripts/gen_imgspike_model.py
+++ b/scripts/gen_imgspike_model.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 Venere Labs
+# SPDX-License-Identifier: MIT
+#
+# Generates bench/models/imgspike.onnx: a compute-bound conv stack
+# (1x3x512x512 fp16, 17 Conv(3x3,64ch)+Relu layers, ~309 GFLOP/forward) used by
+# the image DirectML spike (uwp/image-spike.cpp) as a faithful proxy for one
+# diffusion UNet step. Deterministic (fixed seed); no torch/onnxscript needed.
+#
+# Usage:  python scripts/gen_imgspike_model.py [out.onnx]
+import sys
+import onnx
+import numpy as np
+from onnx import helper, TensorProto, numpy_helper
+
+H = W = 512
+CH = 64
+N = 16
+DT = TensorProto.FLOAT16
+out_path = sys.argv[1] if len(sys.argv) > 1 else "bench/models/imgspike.onnx"
+
+np.random.seed(0)
+nodes, inits = [], []
+
+
+def conv(nin, cin, cout, name, relu=True):
+    w = (np.random.randn(cout, cin, 3, 3).astype(np.float16)) * 0.05
+    b = np.zeros((cout,), np.float16)
+    inits.append(numpy_helper.from_array(w, name + "_w"))
+    inits.append(numpy_helper.from_array(b, name + "_b"))
+    out = name + "_o"
+    nodes.append(
+        helper.make_node(
+            "Conv",
+            [nin, name + "_w", name + "_b"],
+            [out],
+            kernel_shape=[3, 3],
+            pads=[1, 1, 1, 1],
+            name=name,
+        )
+    )
+    if not relu:
+        return out
+    r = name + "_r"
+    nodes.append(helper.make_node("Relu", [out], [r], name=name + "_relu"))
+    return r
+
+
+c = conv("input", 3, CH, "c0")
+for i in range(1, N):
+    c = conv(c, CH, CH, f"c{i}")
+# final conv to 3 channels, no relu; output name is "output"
+w = (np.random.randn(3, CH, 3, 3).astype(np.float16)) * 0.05
+b = np.zeros((3,), np.float16)
+inits += [numpy_helper.from_array(w, "cf_w"), numpy_helper.from_array(b, "cf_b")]
+nodes.append(
+    helper.make_node(
+        "Conv",
+        [c, "cf_w", "cf_b"],
+        ["output"],
+        kernel_shape=[3, 3],
+        pads=[1, 1, 1, 1],
+        name="cf",
+    )
+)
+
+g = helper.make_graph(
+    nodes,
+    "convspike",
+    [helper.make_tensor_value_info("input", DT, [1, 3, H, W])],
+    [helper.make_tensor_value_info("output", DT, [1, 3, H, W])],
+    inits,
+)
+m = helper.make_model(g, opset_imports=[helper.make_opsetid("", 17)])
+m.ir_version = 10
+onnx.checker.check_model(m)
+onnx.save(m, out_path)
+gflop = (N * CH * CH * 9 * H * W * 2) / 1e9
+print(f"saved {out_path}: {len(nodes)} nodes, ~{gflop:.0f} GFLOP/forward")

--- a/uwp/App.cpp
+++ b/uwp/App.cpp
@@ -136,13 +136,13 @@ void App::OnLaunched(LaunchActivatedEventArgs const&) {
 // D3D12-clean so the DML EP can initialise.
 // ---------------------------------------------------------------------------
 
-// Returns the wide path of LocalFolder\bench.flag if it exists, empty otherwise.
+// Returns the wide path of LocalFolder\<name> if it exists, empty otherwise.
 // Requires an initialised COM apartment (ApplicationData). Any exception =>
 // empty => normal interactive path (CheckBenchMode in MainPage stays as fallback).
-static std::wstring bench_flag_path_if_present() {
+static std::wstring flag_path_if_present(const wchar_t* name) {
     try {
         auto folder = winrt::Windows::Storage::ApplicationData::Current().LocalFolder();
-        std::wstring flag = std::wstring(folder.Path().c_str()) + L"\\bench.flag";
+        std::wstring flag = std::wstring(folder.Path().c_str()) + L"\\" + name;
         DWORD attr = GetFileAttributesW(flag.c_str());
         if (attr != INVALID_FILE_ATTRIBUTES && !(attr & FILE_ATTRIBUTE_DIRECTORY))
             return flag;
@@ -154,9 +154,15 @@ static std::wstring bench_flag_path_if_present() {
 // Minimal IFrameworkView: activates the CoreWindow (satisfies the PLM
 // activation watchdog, dismisses the splash) without a swapchain/compositor,
 // so no D3D12 device exists in-process. Same pattern as the UWP DX12 template.
-struct BenchView
-    : winrt::implements<BenchView, winrt::Windows::ApplicationModel::Core::IFrameworkViewSource,
+// Runs `m_entry` (bench main_loop or the image spike) on an MTA thread, then
+// exits the process — a D3D12-clean host for any DirectML workload.
+struct HeadlessView
+    : winrt::implements<HeadlessView, winrt::Windows::ApplicationModel::Core::IFrameworkViewSource,
                         winrt::Windows::ApplicationModel::Core::IFrameworkView> {
+    void (*m_entry)() = nullptr;
+    const char* m_label = "headless";
+    explicit HeadlessView(void (*entry)(), const char* label) : m_entry(entry), m_label(label) {}
+
     winrt::Windows::ApplicationModel::Core::IFrameworkView CreateView() {
         return *this;
     }
@@ -168,11 +174,13 @@ struct BenchView
         auto window = winrt::Windows::UI::Core::CoreWindow::GetForCurrentThread();
         window.Activate();
         auto dispatcher = window.Dispatcher();
-        std::thread([dispatcher]() {
-            winrt::init_apartment(); // MTA: main_loop uses ApplicationData (WinRT)
-            ::xllama::log_output("[xllama] headless bench: starting main_loop\n");
-            ::xllama::bridge::main_loop();
-            ::xllama::log_output("[xllama] headless bench: done, exiting\n");
+        void (*entry)() = m_entry;
+        const char* label = m_label;
+        std::thread([dispatcher, entry, label]() {
+            winrt::init_apartment(); // MTA: entry uses ApplicationData (WinRT)
+            ::xllama::log_output(std::string("[xllama] headless ") + label + ": starting\n");
+            entry();
+            ::xllama::log_output(std::string("[xllama] headless ") + label + ": done, exiting\n");
             dispatcher.RunAsync(winrt::Windows::UI::Core::CoreDispatcherPriority::Normal, [] {
                 winrt::Windows::ApplicationModel::Core::CoreApplication::Exit();
             });
@@ -188,13 +196,22 @@ struct BenchView
 int __stdcall wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
     try {
         winrt::init_apartment(); // MTA: needed for ApplicationData in the detection
-        std::wstring bench_flag = bench_flag_path_if_present();
+        // Consume the flag BEFORE the run (same semantics as CheckBenchMode):
+        // a later start without the flag goes back to interactive.
+        std::wstring image_flag = flag_path_if_present(L"image.flag");
+        if (!image_flag.empty()) {
+            _wremove(image_flag.c_str());
+            ::xllama::log_output("[xllama] image.flag detected -> headless image-spike mode\n");
+            winrt::Windows::ApplicationModel::Core::CoreApplication::Run(
+                winrt::make<HeadlessView>(&::xllama::bridge::run_image_spike, "image-spike"));
+            return 0; // not reached: CoreApplication::Exit terminates the process
+        }
+        std::wstring bench_flag = flag_path_if_present(L"bench.flag");
         if (!bench_flag.empty()) {
-            // Consume the flag BEFORE the run (same semantics as CheckBenchMode):
-            // a later start without the flag goes back to interactive.
             _wremove(bench_flag.c_str());
             ::xllama::log_output("[xllama] bench.flag detected -> headless bench mode\n");
-            winrt::Windows::ApplicationModel::Core::CoreApplication::Run(winrt::make<BenchView>());
+            winrt::Windows::ApplicationModel::Core::CoreApplication::Run(
+                winrt::make<HeadlessView>(&::xllama::bridge::main_loop, "bench"));
             return 0; // not reached: CoreApplication::Exit terminates the process
         }
         winrt::uninit_apartment(); // restore pre-existing thread state for XAML

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -10,7 +10,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="0.3.9.0"
+    Version="0.4.0.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity

--- a/uwp/image-spike.cpp
+++ b/uwp/image-spike.cpp
@@ -1,0 +1,160 @@
+// Copyright (c) 2024 Venere Labs
+// SPDX-License-Identifier: MIT
+// Image-generation spike: plain ONNX Runtime DirectML (NOT ORT GenAI).
+//
+// Runs a compute-bound conv stack (imgspike.onnx, ~309 GFLOP/forward, fp16,
+// 512x512 — a faithful proxy for one diffusion UNet step) through the DirectML
+// EP and a CPU EP control, measuring forward-pass latency. Purpose: test the
+// hypothesis that the RDNA 2 GPU wins on compute-bound fp16 batch workloads
+// (image gen) — the opposite of the M=1, dispatch-bound text decode where it
+// loses. Runs in the headless path (image.flag), so no XAML compositor D3D12
+// device exists to collide with ORT's DML device (cf. the 887A0036 finding).
+
+#include "inference-bridge.h"
+
+#ifdef XLLAMA_UWP
+
+// clang-format off
+    #include <windows.h>
+    #include <eh.h>
+    #include <onnxruntime_cxx_api.h>
+    #include <dml_provider_factory.h>
+// clang-format on
+
+    #include "xllama/path_utils.h"
+    #include "xllama/platform.h"
+    #include "xllama/utf8_utils.h"
+
+    #include <array>
+    #include <chrono>
+    #include <cstdio>
+    #include <ctime>
+    #include <string>
+    #include <vector>
+
+namespace xllama::bridge {
+
+namespace {
+
+// imgspike.onnx: 1x3x512x512 fp16, 17 Conv(3x3,64ch)+Relu layers.
+constexpr int kH = 512;
+constexpr int kW = 512;
+constexpr double kGFlop = 309.2; // ~ from the model's conv FLOP count
+
+struct SpikeRun {
+    const char* ep = "unknown";
+    bool ok = false;
+    double best_ms = 0.0;
+    std::string err;
+};
+
+// Run the model once (warmup) + `iters` timed forwards; return best latency.
+SpikeRun run_ep(Ort::Env& env, const std::wstring& model_path, bool use_dml, int iters) {
+    SpikeRun r;
+    r.ep = use_dml ? "directml" : "cpu";
+    try {
+        Ort::SessionOptions so;
+        // DirectML requires sequential execution and no memory pattern.
+        so.SetExecutionMode(ORT_SEQUENTIAL);
+        so.DisableMemPattern();
+        if (use_dml) {
+            Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_DML(so, /*device_id=*/0));
+        }
+        Ort::Session session(env, model_path.c_str(), so);
+
+        const size_t n = static_cast<size_t>(1) * 3 * kH * kW;
+        std::vector<Ort::Float16_t> input(n); // fp16 zeros — values irrelevant for timing
+        std::array<int64_t, 4> shape{1, 3, kH, kW};
+        Ort::MemoryInfo mem = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+        Ort::Value in = Ort::Value::CreateTensor<Ort::Float16_t>(mem, input.data(), n, shape.data(),
+                                                                 shape.size());
+        const char* in_names[] = {"input"};
+        const char* out_names[] = {"output"};
+
+        // Warmup (DML compiles shaders / builds the graph on the first run).
+        session.Run(Ort::RunOptions{nullptr}, in_names, &in, 1, out_names, 1);
+
+        double best = 1e30;
+        for (int i = 0; i < iters; ++i) {
+            auto t0 = std::chrono::steady_clock::now();
+            auto out = session.Run(Ort::RunOptions{nullptr}, in_names, &in, 1, out_names, 1);
+            auto t1 = std::chrono::steady_clock::now();
+            double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+            if (ms < best)
+                best = ms;
+        }
+        r.best_ms = best;
+        r.ok = true;
+    } catch (const Ort::Exception& e) {
+        r.err = e.what();
+    } catch (const std::exception& e) {
+        r.err = e.what();
+    }
+    return r;
+}
+
+} // namespace
+
+void run_image_spike() {
+    _set_se_translator([](unsigned int code, EXCEPTION_POINTERS*) {
+        char b[48];
+        snprintf(b, sizeof(b), "SEH 0x%08X", code);
+        throw std::runtime_error(b);
+    });
+
+    log_output("[xllama] image-spike: plain ORT DirectML conv model (~309 GFLOP/forward)\n");
+
+    std::wstring model_path = utf8_to_wstring(resolve_local_path("imgspike.onnx"));
+
+    SpikeRun dml, cpu;
+    try {
+        Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "imgspike");
+        dml = run_ep(env, model_path, /*use_dml=*/true, /*iters=*/5);
+        cpu = run_ep(env, model_path, /*use_dml=*/false, /*iters=*/3);
+    } catch (const std::exception& e) {
+        log_output(std::string("[xllama] image-spike: env/setup error: ") + e.what() + "\n");
+        return;
+    }
+
+    auto gflops = [](const SpikeRun& s) {
+        return s.ok && s.best_ms > 0 ? kGFlop / (s.best_ms / 1000.0) : 0.0;
+    };
+    double dml_gfs = gflops(dml), cpu_gfs = gflops(cpu);
+    double speedup = (dml.ok && cpu.ok && dml.best_ms > 0) ? cpu.best_ms / dml.best_ms : 0.0;
+
+    char lb[320];
+    snprintf(lb, sizeof(lb),
+             "[xllama] image-spike: DML %.1f ms (%.0f GFLOP/s, ok=%d) | CPU %.1f ms (%.0f "
+             "GFLOP/s, ok=%d) | GPU speedup %.1fx\n",
+             dml.best_ms, dml_gfs, dml.ok, cpu.best_ms, cpu_gfs, cpu.ok, speedup);
+    log_output(lb);
+    if (!dml.ok)
+        log_output("[xllama] image-spike: DML error: " + dml.err + "\n");
+    if (!cpu.ok)
+        log_output("[xllama] image-spike: CPU error: " + cpu.err + "\n");
+
+    // Write result CSV (+ .done marker), fetchable via Device Portal.
+    FILE* fp = _wfopen(utf8_to_wstring(resolve_local_path("imgspike-result.csv")).c_str(), L"w");
+    if (fp) {
+        time_t now = time(nullptr);
+        char date_buf[32];
+        strftime(date_buf, sizeof(date_buf), "%Y-%m-%dT%H:%M:%SZ", gmtime(&now));
+        fputs("ep,ok,forward_ms,gflop_s,resolution,gflop_forward,speedup_vs_cpu,date\n", fp);
+        fprintf(fp, "directml,%d,%.2f,%.1f,%dx%d,%.1f,%.2f,%s\n", dml.ok, dml.best_ms, dml_gfs, kW,
+                kH, kGFlop, speedup, date_buf);
+        fprintf(fp, "cpu,%d,%.2f,%.1f,%dx%d,%.1f,%.2f,%s\n", cpu.ok, cpu.best_ms, cpu_gfs, kW, kH,
+                kGFlop, 1.0, date_buf);
+        fclose(fp);
+        FILE* done =
+            _wfopen(utf8_to_wstring(resolve_local_path("imgspike-result.csv.done")).c_str(), L"w");
+        if (done) {
+            fputs("done\n", done);
+            fclose(done);
+        }
+        log_output("[xllama] imgspike-result.csv written\n");
+    }
+}
+
+} // namespace xllama::bridge
+
+#endif // XLLAMA_UWP

--- a/uwp/inference-bridge.h
+++ b/uwp/inference-bridge.h
@@ -19,4 +19,11 @@ inline InferenceResult run_inference(const InferenceParams& params) {
 // Called from UWP App on a background thread (bench mode).
 void main_loop();
 
+// Image-generation spike (Stage: image DirectML). Runs a compute-bound conv
+// model (proxy for a diffusion UNet step) through the plain ONNX Runtime
+// DirectML EP and a CPU EP control, measuring forward-pass latency + GFLOP/s to
+// test whether the GPU wins on compute-bound fp16 batch workloads (unlike M=1
+// text decode). Triggered by LocalFolder\image.flag in the headless path.
+void run_image_spike();
+
 } // namespace xllama::bridge

--- a/uwp/xllama.vcxproj
+++ b/uwp/xllama.vcxproj
@@ -96,6 +96,7 @@
         $(IntDir)Generated Files;
         $(ProjectDir)..\include;
         $(ProjectDir)packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.14.1\build\native\include;
+        $(ProjectDir)packages\Microsoft.ML.OnnxRuntime.DirectML.1.24.4\build\native\include;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>
@@ -268,6 +269,7 @@
     <ClCompile Include="..\src\bridge\utf8_utils.cpp" />
     <!-- cli.cpp uses POSIX getopt — Linux only, excluded from UWP target -->
     <ClCompile Include="inference-bridge.cpp" />
+    <ClCompile Include="image-spike.cpp" />
   </ItemGroup>
 
   <!-- xllama UWP app -->


### PR DESCRIPTION
First step toward image/vision models on the console — and the workload that should finally play to the GPU's strength. **CI green (build-linux + build-uwp).** Console validation pending.

## Why
The int4 desk-check (§12, on the perf branch) established that the GPU loses at text decode because that workload is its **worst case**: M=1, dispatch-bound, non-fused int4-DML. Image generation (diffusion) is the **opposite** — compute-bound fp16 batch, exactly where DML already wins (prefill, 1.8× at 1k tok). This spike tests that hypothesis cheaply before committing to a full diffusion pipeline.

## What
- `uwp/image-spike.cpp` — runs a compute-bound conv model through the **plain ONNX Runtime DirectML** EP (not ORT GenAI; `onnxruntime.dll`/`.lib` were already dependencies) + a CPU EP control, measuring forward-pass latency, GFLOP/s, and GPU speedup. Writes `imgspike-result.csv`.
- `imgspike.onnx` (`scripts/gen_imgspike_model.py`, deterministic, no torch): 17 Conv(3×3,64ch)+Relu on 1×3×512×512 fp16 = ~309 GFLOP/forward — a faithful proxy for one diffusion UNet step.
- `uwp/App.cpp` — generalised the headless dispatch: `image.flag` → `run_image_spike()`, `bench.flag` → `main_loop()`, via a shared `HeadlessView` (same D3D12-clean host that avoids the 887A0036 compositor conflict).
- vcxproj: ORT DirectML NuGet include dir + new source. AppxManifest → 0.4.0.0.

## On-console validation (pending)
1. `python scripts/gen_imgspike_model.py` → upload `imgspike.onnx` to LocalState.
2. Drop `image.flag`, launch the app (headless), fetch `imgspike-result.csv`.
3. **Expected**: DML ≫ CPU (compute-bound) — the inverse of text decode. If confirmed → a distilled SD-Turbo/LCM diffusion pipeline is the flagship GPU workload (Phase 5); an image generating on an Xbox is a far stronger demo/report artifact than tok/s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new headless image benchmark mode that can run from the app and export latency/throughput results for review.
  * Introduced CSV output and completion markers for easier retrieval of benchmark results.

* **Bug Fixes**
  * Improved mode selection so the app can launch the correct headless flow based on available trigger files.
  * Updated guidance to reflect verified console/device behavior, storage limits, and platform constraints.

* **Documentation**
  * Refreshed release notes, roadmap, and device-portal instructions with the latest verified findings and lifecycle notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->