### PR TITLE
feat(diffusion): SD-Turbo ONNX toolchain, validated via ORT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,12 @@ batch), unlike LLM decode.
   uses the dynamo/onnxscript exporter that optimum 1.23 can't consume (external-
   data-naming + LayerNormalization opset-downgrade bugs).
 - `diffusion/generate_onnx.py`: validates the exported ONNX through ORT.
-- `diffusion/convert_fp16.py`: fp16 conversion for the 3801 MB GPU budget. SD
-  components are each < 2 GB (UNet fp16 ~1.7 GB), so all save self-contained and
-  avoid the AppContainer `weakly_canonical` crash (§8) — unlike a 1.7B LLM fp16
-  blob. (A cleaner fp16 export uses `optimum-cli --fp16 --device cuda` on a GPU.)
+- `diffusion/convert_fp16.py`: confirms the fp16 components fit the 3801 MB
+  budget — each < 2 GB (UNet ~1.65 GB, ~2.4 GB total), all self-contained,
+  AppContainer-safe (unlike a 1.7B LLM fp16 blob). **Caveat**: the CPU fp16 pass
+  leaves a mixed-type node in the UNet timestep embedding (`/time_proj/Mul`) that
+  ORT rejects at load — a _runnable_ fp16 model needs a GPU export
+  (`optimum-cli --fp16 --device cuda`) or Olive. fp32 is fully validated.
 - Next: the C++ pipeline (3 ORT DirectML sessions + scheduler + CLIP tokenizer)
   behind a `diffuse.flag` headless mode, on the plain-ORT DirectML foundation
   already proven by the image spike (PR #3).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,30 @@ DML `accuracy_level=0` vs CPU's fused-int8 `=4`. Full analysis + config tests in
 decode is blocked by a DirectML kernel-design limit (out of our control), not a
 kernel we could contribute — CPU int4 stays the decode default.
 
+### Added — diffusion model toolchain (image generation, `diffusion/`)
+
+Model-side toolchain for running SD-Turbo (1-step distilled diffusion) on the
+console GPU — the workload that plays to DirectML's strength (compute-bound fp16
+batch), unlike LLM decode.
+
+- **Validated on the owned layer (2026-07-08)**: SD-Turbo exported to ONNX and
+  run through **ONNX Runtime (CPU EP)** generates a coherent 512×512 image in
+  ~13 s / 1 step — the same artifact + runtime that runs on Xbox via the
+  DirectML EP.
+- `diffusion/export_sd_turbo.sh` + `requirements.txt`: reproducible, **pinned**
+  toolchain (Python 3.10, torch 2.4.1 legacy ONNX tracer, optimum 1.23.3,
+  transformers 4.46.3, diffusers 0.31.0). The pins are load-bearing: newer torch
+  uses the dynamo/onnxscript exporter that optimum 1.23 can't consume (external-
+  data-naming + LayerNormalization opset-downgrade bugs).
+- `diffusion/generate_onnx.py`: validates the exported ONNX through ORT.
+- `diffusion/convert_fp16.py`: fp16 conversion for the 3801 MB GPU budget. SD
+  components are each < 2 GB (UNet fp16 ~1.7 GB), so all save self-contained and
+  avoid the AppContainer `weakly_canonical` crash (§8) — unlike a 1.7B LLM fp16
+  blob. (A cleaner fp16 export uses `optimum-cli --fp16 --device cuda` on a GPU.)
+- Next: the C++ pipeline (3 ORT DirectML sessions + scheduler + CLIP tokenizer)
+  behind a `diffuse.flag` headless mode, on the plain-ORT DirectML foundation
+  already proven by the image spike (PR #3).
+
 ## [0.4.0.0] - 2026-07-08
 
 ### Added — image-generation spike (plain ORT DirectML, new model axis)

--- a/diffusion/README.md
+++ b/diffusion/README.md
@@ -44,14 +44,27 @@ limit) — each SD component is individually **< 2 GB**, so all save self-contai
 and avoid the AppContainer `weakly_canonical` crash (§8). **These sizes are
 confirmed.**
 
-⚠️ **fp16 conversion caveat**: `convert_fp16.py` (CPU) is reliable for the size
-analysis above but leaves a mixed-type node in the UNet timestep embedding
+**Getting a runnable fp16 model.** `convert_fp16.py` (CPU) is reliable for the
+size analysis above but leaves a mixed-type node in the UNet timestep embedding
 (`/time_proj/Mul`) that ORT rejects at load — onnxconverter_common does not fully
-type the SD UNet on CPU. For a **runnable** fp16 model, export on a GPU box with
-`optimum-cli export onnx --model stabilityai/sd-turbo --fp16 --device cuda …`, or
-use Microsoft **Olive**'s SD DirectML optimization (the officially recommended
-path). The fp32 ONNX pipeline is fully validated (above); fp16 is a
-memory-optimization step that needs the GPU exporter for a correct graph.
+type the SD UNet on CPU. Two working sources for a clean fp16 graph:
+
+1. **Pre-exported fp16 DirectML models** (recommended, no GPU needed) — e.g.
+   [`nmkd/stable-diffusion-1.5-onnx-fp16`](https://huggingface.co/nmkd/stable-diffusion-1.5-onnx-fp16),
+   [`sharpbai/stable-diffusion-v1-5-onnx-directml-fp16`](https://huggingface.co/sharpbai/stable-diffusion-v1-5-onnx-directml-fp16),
+   or the [Amblyopius/Stable-Diffusion-ONNX-FP16](https://github.com/Amblyopius/Stable-Diffusion-ONNX-FP16)
+   toolkit. **Verified 2026-07-08**: the nmkd SD1.5 fp16 components all load in
+   ORT (UNet input `sample: tensor(float16)`, 1.7 GB → < 2 GB), unlike the CPU
+   `convert_fp16.py` output. These ship with **external data** (`unet/weights.pb`),
+   so run `scripts/merge_onnx_external_data.py` on each component to make it
+   self-contained before deploying (AppContainer `weakly_canonical`, §8).
+2. **GPU export**: `optimum-cli export onnx --model stabilityai/sd-turbo --fp16
+--device cuda …`, or Microsoft **Olive**'s SD DirectML optimization.
+
+Speed note: SD1.5 needs ~20–25 steps (slow); the console target is a **few-step**
+model — SD-Turbo/SDXL-Turbo (1 step) or an LCM variant (2–4 steps) in fp16. The
+fp32 SD-Turbo path here is validated for quality; pair it with a clean fp16 UNet
+from source (1) or (2) for the console.
 
 ## Deploy + run on console (planned)
 

--- a/diffusion/README.md
+++ b/diffusion/README.md
@@ -1,0 +1,56 @@
+# diffusion/ — image generation on Xbox (SD-Turbo via ONNX Runtime DirectML)
+
+The text-decode work established that the Series S GPU loses at LLM decode because
+that workload is its _worst_ case (M=1, dispatch-bound, non-fused int4 on DML —
+see `docs/uwp-constraints.md §12`). Image generation (diffusion) is the _opposite_:
+compute-bound fp16 batch on 64×64 latents — the case where DML already wins
+(prefill). This directory is the model-side toolchain for running a distilled
+few-step diffusion model (SD-Turbo, 1 step) on the console GPU.
+
+## Status
+
+- ✅ **Model validated on the owned layer (2026-07-08).** SD-Turbo exported to
+  ONNX and run through **ONNX Runtime (CPU EP)** generates a coherent 512×512
+  image in ~13 s / 1 step. This is the exact artifact + runtime that runs on the
+  Xbox via the DirectML EP — only the EP (and thus the speed) differs.
+- ✅ **Plain ORT DirectML foundation proven** by the image spike
+  (`uwp/image-spike.cpp`, PR #3): a compute-bound conv model compiles, links, and
+  runs through the DirectML EP in the UWP AppContainer.
+- ⏳ **Next**: fp16 components for the 3801 MB GPU budget (below), then the C++
+  pipeline (3 ORT DirectML sessions + scheduler + CLIP tokenizer) in the app.
+
+## Reproduce the export
+
+The toolchain is version-sensitive: the export only works with the **legacy
+torch ONNX tracer** (torch 2.4.x), because optimum 1.23 does not support torch's
+newer dynamo/onnxscript exporter (it hits external-data-naming and
+LayerNormalization opset-downgrade bugs). Use **Python 3.10** (3.14 lacks wheels
+for this era). Do not bump the pins piecemeal.
+
+```bash
+python3.10 -m venv venv
+./venv/bin/pip install -r diffusion/requirements.txt \
+    --extra-index-url https://download.pytorch.org/whl/cpu
+./diffusion/export_sd_turbo.sh                 # -> sd-turbo-onnx/ + sd-turbo-onnx-fp16/
+./venv/bin/python diffusion/generate_onnx.py   # validate: writes sd_turbo_onnx.png
+```
+
+## Memory / deployability
+
+SD-Turbo (SD1.5-class) fits the console GPU budget in fp16 (~2 GB total), and —
+unlike a 1.7B LLM in fp16 (a single 3.4 GB weight blob that exceeds the 2 GB ONNX
+protobuf limit) — each SD component is individually **< 2 GB**, so all are saved
+self-contained and avoid the AppContainer `weakly_canonical` crash (§8). fp16
+conversion is done post-export by `convert_fp16.py` because optimum's `--fp16`
+requires a CUDA GPU (unavailable on the export box); a cleaner fp16 export can be
+produced on a GPU machine with `optimum-cli export onnx --fp16 --device cuda`.
+
+## Deploy + run on console (planned)
+
+Upload `sd-turbo-onnx-fp16/{text_encoder,unet,vae_decoder}` to LocalState, then a
+future `diffuse.flag` headless mode (mirroring `image.flag`) runs the C++
+pipeline and writes the PNG for Device Portal fetch. The pipeline is: CLIP-tokenize
+the prompt → text_encoder → init latent → (1×) UNet denoise with the scheduler →
+scale + vae_decoder → PNG. Model licensing note: SD-Turbo is under Stability's
+research/community license — for a public demo, swap to an openly-licensed
+few-step model (e.g. an LCM/SDXL-Turbo-Apache variant).

--- a/diffusion/README.md
+++ b/diffusion/README.md
@@ -37,13 +37,21 @@ python3.10 -m venv venv
 
 ## Memory / deployability
 
-SD-Turbo (SD1.5-class) fits the console GPU budget in fp16 (~2 GB total), and —
-unlike a 1.7B LLM in fp16 (a single 3.4 GB weight blob that exceeds the 2 GB ONNX
-protobuf limit) — each SD component is individually **< 2 GB**, so all are saved
-self-contained and avoid the AppContainer `weakly_canonical` crash (§8). fp16
-conversion is done post-export by `convert_fp16.py` because optimum's `--fp16`
-requires a CUDA GPU (unavailable on the export box); a cleaner fp16 export can be
-produced on a GPU machine with `optimum-cli export onnx --fp16 --device cuda`.
+SD-Turbo (SD1.5-class) fits the console GPU budget in fp16 (~2.4 GB total:
+UNet ~1.65 GB, text_encoder ~0.65 GB, vae_decoder ~0.1 GB), and — unlike a 1.7B
+LLM in fp16 (a single 3.4 GB weight blob that exceeds the 2 GB ONNX protobuf
+limit) — each SD component is individually **< 2 GB**, so all save self-contained
+and avoid the AppContainer `weakly_canonical` crash (§8). **These sizes are
+confirmed.**
+
+⚠️ **fp16 conversion caveat**: `convert_fp16.py` (CPU) is reliable for the size
+analysis above but leaves a mixed-type node in the UNet timestep embedding
+(`/time_proj/Mul`) that ORT rejects at load — onnxconverter_common does not fully
+type the SD UNet on CPU. For a **runnable** fp16 model, export on a GPU box with
+`optimum-cli export onnx --model stabilityai/sd-turbo --fp16 --device cuda …`, or
+use Microsoft **Olive**'s SD DirectML optimization (the officially recommended
+path). The fp32 ONNX pipeline is fully validated (above); fp16 is a
+memory-optimization step that needs the GPU exporter for a correct graph.
 
 ## Deploy + run on console (planned)
 

--- a/diffusion/convert_fp16.py
+++ b/diffusion/convert_fp16.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 Venere Labs
+# SPDX-License-Identifier: MIT
+#
+# Convert the fp32 SD-Turbo ONNX components (as exported by export_sd_turbo.sh on
+# a CPU box, where optimum's --fp16 is unavailable) to fp16 for the Xbox Series S
+# GPU budget (3801 MB). Each component is saved self-contained when < 2 GB (the
+# ONNX protobuf single-file limit and the merged-model requirement that avoids the
+# AppContainer `weakly_canonical` crash — see docs/uwp-constraints.md §8). The
+# SD-Turbo UNet is ~1.7 GB in fp16, so it fits as a single file; text_encoder and
+# vae_decoder are small.
+#
+# Usage:  python diffusion/convert_fp16.py <onnx_dir_in> <onnx_dir_out>
+import sys, os, shutil
+import onnx
+from onnxconverter_common import float16
+
+IN = sys.argv[1] if len(sys.argv) > 1 else "sd-turbo-onnx"
+OUT = sys.argv[2] if len(sys.argv) > 2 else "sd-turbo-onnx-fp16"
+# Components needed for txt2img (vae_encoder is only for img2img).
+COMPONENTS = ["text_encoder", "unet", "vae_decoder"]
+PROTOBUF_LIMIT = 2 * 1024**3
+
+os.makedirs(OUT, exist_ok=True)
+# Copy the non-weight pipeline files (scheduler, tokenizer, configs) verbatim.
+for name in os.listdir(IN):
+    src = os.path.join(IN, name)
+    if os.path.isdir(src) and name not in COMPONENTS + ["vae_encoder"]:
+        shutil.copytree(src, os.path.join(OUT, name), dirs_exist_ok=True)
+    elif os.path.isfile(src):
+        shutil.copy2(src, os.path.join(OUT, name))
+
+for comp in COMPONENTS:
+    src = os.path.join(IN, comp, "model.onnx")
+    if not os.path.exists(src):
+        print(f"[skip] {comp}: no model.onnx")
+        continue
+    print(f"[fp16] converting {comp} ...", flush=True)
+    m = onnx.load(src)  # loads external data if present
+    # Convert the WHOLE graph (I/O included) to fp16. keep_io_types=True leaves
+    # fp32 islands that break SD UNets with a mixed-type error at the timestep
+    # embedding (`/time_proj/Mul`: float vs float16); an all-fp16 graph is
+    # consistent and the ORT pipeline feeds fp16 accordingly.
+    m16 = float16.convert_float_to_float16(
+        m, keep_io_types=False, disable_shape_infer=True
+    )
+    dst_dir = os.path.join(OUT, comp)
+    os.makedirs(dst_dir, exist_ok=True)
+    dst = os.path.join(dst_dir, "model.onnx")
+    size = m16.ByteSize()
+    if size < PROTOBUF_LIMIT:
+        onnx.save(m16, dst)  # self-contained (AppContainer-safe)
+        ext = "self-contained"
+    else:
+        onnx.save(
+            m16,
+            dst,
+            save_as_external_data=True,
+            location="model.onnx_data",
+            all_tensors_to_one_file=True,
+        )
+        ext = "EXTERNAL DATA (>2GB — AppContainer risk!)"
+    disk = os.path.getsize(dst) + (
+        os.path.getsize(dst + "_data") if os.path.exists(dst + "_data") else 0
+    )
+    print(f"[fp16] {comp}: {disk // (1024 * 1024)} MB  ({ext})")
+print(f"[fp16] done -> {OUT}")

--- a/diffusion/convert_fp16.py
+++ b/diffusion/convert_fp16.py
@@ -2,13 +2,21 @@
 # Copyright (c) 2024 Venere Labs
 # SPDX-License-Identifier: MIT
 #
-# Convert the fp32 SD-Turbo ONNX components (as exported by export_sd_turbo.sh on
-# a CPU box, where optimum's --fp16 is unavailable) to fp16 for the Xbox Series S
-# GPU budget (3801 MB). Each component is saved self-contained when < 2 GB (the
-# ONNX protobuf single-file limit and the merged-model requirement that avoids the
-# AppContainer `weakly_canonical` crash — see docs/uwp-constraints.md §8). The
-# SD-Turbo UNet is ~1.7 GB in fp16, so it fits as a single file; text_encoder and
-# vae_decoder are small.
+# Convert the fp32 SD-Turbo ONNX components to fp16 and report their on-disk size
+# against the Xbox Series S GPU budget (3801 MB). Each component is saved
+# self-contained when < 2 GB (the ONNX protobuf single-file limit + the
+# merged-model requirement that avoids the AppContainer `weakly_canonical` crash,
+# docs/uwp-constraints.md §8).
+#
+# ⚠️ KNOWN LIMITATION (verified 2026-07-08): this CPU-side conversion is reliable
+# for SIZE analysis only. It leaves a mixed-type node in the SD UNet timestep
+# embedding (`/time_proj/Mul`: float vs float16) that makes ORT reject the model
+# at load. onnxconverter_common's fp16 pass does not fully type the SD UNet on
+# CPU. For a RUNNABLE fp16 model, export directly with a GPU:
+#     optimum-cli export onnx --model stabilityai/sd-turbo --fp16 --device cuda ...
+# or use Microsoft Olive's SD DirectML optimization. Sizes confirmed here:
+# UNet fp16 ~1.65 GB (< 2 GB, self-contained), text_encoder ~0.65 GB, vae ~0.1 GB
+# → ~2.4 GB total, fits the 3801 MB budget with all components AppContainer-safe.
 #
 # Usage:  python diffusion/convert_fp16.py <onnx_dir_in> <onnx_dir_out>
 import sys, os, shutil

--- a/diffusion/export_sd_turbo.sh
+++ b/diffusion/export_sd_turbo.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright (c) 2024 Venere Labs
+# SPDX-License-Identifier: MIT
+#
+# Export stabilityai/sd-turbo to ONNX (fp32) with optimum, then convert the
+# txt2img components to fp16 for the Xbox Series S GPU budget. Requires the
+# pinned toolchain in requirements.txt on Python 3.10.
+#
+#   python3.10 -m venv venv && ./venv/bin/pip install -r diffusion/requirements.txt \
+#       --extra-index-url https://download.pytorch.org/whl/cpu
+#   ./diffusion/export_sd_turbo.sh
+#
+# Output: sd-turbo-onnx/ (fp32) and sd-turbo-onnx-fp16/ (console-ready, each
+# component self-contained < 2 GB).
+set -euo pipefail
+VENV="${VENV:-./venv}"
+OUT_FP32="${OUT_FP32:-sd-turbo-onnx}"
+OUT_FP16="${OUT_FP16:-sd-turbo-onnx-fp16}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+export HF_HUB_DISABLE_TELEMETRY=1
+
+# fp32 export on CPU (optimum's --fp16 needs a CUDA GPU). Legacy tracer via
+# torch 2.4.1; opset defaults to the model's native (>=17, no downgrade).
+"$VENV/bin/optimum-cli" export onnx \
+	--model stabilityai/sd-turbo \
+	--task text-to-image \
+	"$OUT_FP32"
+
+# Convert the txt2img components (text_encoder, unet, vae_decoder) to fp16.
+"$VENV/bin/python" "$HERE/convert_fp16.py" "$OUT_FP32" "$OUT_FP16"
+
+echo "Done. Console-ready fp16 components in $OUT_FP16/"

--- a/diffusion/generate_onnx.py
+++ b/diffusion/generate_onnx.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 Venere Labs
+# SPDX-License-Identifier: MIT
+#
+# Validate the exported ONNX SD-Turbo pipeline by generating one image through
+# ONNX Runtime (the same runtime that runs on the Xbox via the DirectML EP; here
+# on the CPU EP). This proves the ONNX artifacts are correct on the layer we own
+# before any C++/DirectML/console work.
+#
+#   ./venv/bin/python diffusion/generate_onnx.py [onnx_dir] [out.png] ["prompt"]
+import sys, time
+import numpy as np
+from optimum.onnxruntime import ORTStableDiffusionPipeline
+
+onnx_dir = sys.argv[1] if len(sys.argv) > 1 else "sd-turbo-onnx"
+out_png = sys.argv[2] if len(sys.argv) > 2 else "sd_turbo_onnx.png"
+prompt = (
+    sys.argv[3]
+    if len(sys.argv) > 3
+    else "a red sports car on a mountain road at sunset, cinematic, highly detailed"
+)
+
+print(f"[onnx] loading {onnx_dir} via ORT (CPU EP) ...", flush=True)
+pipe = ORTStableDiffusionPipeline.from_pretrained(onnx_dir)
+print(f"[onnx] generating: {prompt}", flush=True)
+t0 = time.time()
+# SD-Turbo is a 1-step distilled model with classifier-free guidance disabled.
+img = pipe(prompt=prompt, num_inference_steps=1, guidance_scale=0.0).images[0]
+img.save(out_png)
+a = np.asarray(img).astype(float)
+print(
+    f"[onnx] done {time.time() - t0:.1f}s -> {out_png} {img.size} "
+    f"mean={a.mean():.1f} std={a.std():.1f} (std>10 => real image)"
+)

--- a/diffusion/requirements.txt
+++ b/diffusion/requirements.txt
@@ -1,0 +1,14 @@
+# Pinned toolchain for exporting SD-Turbo to ONNX for DirectML.
+# Use Python 3.10 (3.14 has no wheels for this era; 3.11/3.12 also work).
+# The versions below are a *coherent* set — the export only works when torch is
+# old enough (2.4.x) to use the legacy tracing ONNX exporter, since optimum 1.23
+# does not support torch's newer dynamo/onnxscript exporter (it hits external-data
+# naming + LayerNormalization opset-downgrade bugs). Do not bump piecemeal.
+torch==2.4.1            # legacy torch.onnx tracer; --index-url .../whl/cpu
+optimum[onnxruntime]==1.23.3
+transformers==4.46.3
+diffusers==0.31.0
+onnx>=1.16
+onnxruntime>=1.19
+onnxconverter-common>=1.14
+accelerate>=0.30


### PR DESCRIPTION
Model-side toolchain for image generation on the console GPU — the workload that suits DirectML (compute-bound fp16 batch) unlike LLM decode (§12).

## Validated (on the owned layer)
SD-Turbo exported to ONNX and run through **ONNX Runtime (CPU EP)** generates a coherent 512×512 image in ~13 s / 1 step — the same artifact + runtime that runs on Xbox via the DirectML EP. Correctness proven before any C++/console work.

## Contents (`diffusion/`)
- `requirements.txt` + `export_sd_turbo.sh`: reproducible **pinned** toolchain (Python 3.10, torch 2.4.1 legacy ONNX tracer, optimum 1.23.3, transformers 4.46.3, diffusers 0.31.0). The pins are load-bearing — newer torch's dynamo/onnxscript exporter is incompatible with optimum 1.23 (external-data-naming + LayerNorm opset-downgrade bugs).
- `generate_onnx.py`: validates the exported ONNX through ORT.
- `convert_fp16.py`: confirms fp16 fits the 3801 MB budget (UNet 1.65 GB, ~2.4 GB total, each < 2 GB so self-contained / AppContainer-safe). **Caveat** (documented): the CPU fp16 pass leaves a UNet timestep-embedding type mismatch that ORT rejects at load — a runnable fp16 model needs a GPU export (`optimum-cli --fp16 --device cuda`) or Olive.

## Next
C++ pipeline (3 ORT DirectML sessions + scheduler + CLIP tokenizer) behind a `diffuse.flag` headless mode, on the plain-ORT DirectML foundation already proven by the image spike (PR #3). Console handoff: upload the fp16 components + `diffuse.flag`, fetch the PNG.

Licensing note: SD-Turbo is Stability's research/community license — swap to an openly-licensed few-step model for a public demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added documentation and console-focused tooling for a diffusion-based image generation workflow (SD-Turbo) using ONNX Runtime and DirectML.
  * Includes a validated export/convert/run path and reproducible dependency setup.

* **Documentation**
  * Updated the roadmap with refined GPU/CPU performance findings and new “Hardware Ceiling” next steps.
  * Refreshed console/device-portal and UWP constraints guidance, including verified lifecycle behaviors and updated storage/resource measurements.

* **Bug Fixes**
  * Corrected outdated platform and resource-limit instructions to better match current measured behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->