### PR TITLE
feat(bench): Phase 3.5 console validation results + tooling fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Measured — Phase 3.5 console validation (Xbox Series S, v0.4.0.0, 2026-07-08)
+
+The pending on-console checks for the merged 0.3.7–0.4.0 features, run in one session
+per `docs/console-validation-runbook.md`. CSVs under `bench/results/phase35-*.csv`.
+
+- **Image spike (flagship hypothesis) — CONFIRMED.** On a compute-bound fp16 batch
+  (309 GFLOP, one UNet-step proxy), DirectML is **11.1× faster than CPU** (128.7 ms /
+  2403 GFLOP/s vs 1428 ms / 216 GFLOP/s). The exact inverse of text decode — image
+  generation plays to the GPU's strength, greenlighting the diffusion pipeline.
+- **Decode matrix (ORT GenAI 0.14.1), SmolLM2-360M, 285-tok prompt:** CPU int4
+  **66.3** tok/s, DML fp16 **46.8** (real GPU: engines ~46–57 %, `gpu_mem` 793 MB),
+  DML int4 **8.82** (real GPU: engines ~87–90 %, `gpu_mem` 307 MB). Versus the v0.3.6
+  baselines (68.0 / 46.8 / 8.8) the 0.14.1 bump is **flat on decode** — a valid,
+  recorded result (its win, if any, is CPU-overhead at higher token rates, not here).
+- **int4 DML floor — §12 desk-check CONFIRMED on hardware.** DML int4 decode is
+  8.82 tok/s with the **GPU compute engines saturated (87–90 %)** — not a CPU
+  fallback. The non-fused `MatMulNBits` (dequantize→fp16 + full GEMM) is
+  bandwidth-bound; CPU int4 stays the decode default. Kernel-design limit, confirmed.
+- **KV-cache reuse (Stage 2) — CONFIRMED.** Turn-2 prefill with reuse is **4.87×**
+  faster than cold (103.7 ms / 22-tok delta vs 505.2 ms / 114-tok full re-prefill) —
+  continuous decoding processes only the new turn's tokens as designed.
+- **1.7B scale (§6) — CONFIRMED.** SmolLM2-1.7B cpu-int4 runs on the console:
+  prefill 54.9 tok/s, **decode 20.6 tok/s**, peak WS 2423 MB, load 6.2 s. Decode
+  scales ~3.2× down from 360M (66.3 → 20.6) — memory-bandwidth-bound, as expected;
+  CPU int4 stays usable at 1.7B. (fp16-DML 1.7B remains undeployable: 3.4 GB weights
+  exceed the 2 GB protobuf limit — a serialization constraint, not the GPU.)
+- Still pending (need specific assets): CPU/GPU **routing** (§2, interactive XAML UI —
+  needs a person at the console); **diffusion** (§7, needs an fp16 SD-Turbo export).
+
+### Fixed — deploy/bench tooling gaps surfaced during console validation
+
+- `scripts/deploy.sh upload-dir`: now verifies the target dir exists (WDP folder
+  creation can fail silently) and checks each file's `Success` flag, failing loudly
+  instead of reporting "Uploaded N" while landing nothing (the 1.7B model.onnx
+  silently vanished this way until the missing subdir was created). Mirrors the
+  `upload-file` check.
+- `src/bridge/bench.cpp`: the CSV `backend`/`quant` columns were hardcoded
+  `ort-genai-cpu`/`int4`, mislabelling DML and fp16 runs; now derived from the model
+  dir name (+ `gpu_mem_mb` corroboration). The model label also no longer truncates
+  at the first dot (`smollm2-1.7b-cpu-int4` was logged as `smollm2-1`).
+
 ### Added — C++ diffusion pipeline (`diffuse.flag`, host-validated)
 
 The console image-generation pipeline. `uwp/diffuse.cpp` runs three ORT DirectML

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,19 +98,26 @@ effective vs ~224 GB/s bus) and what the Series S can realistically deliver.
 Levers ordered by cost/leverage; the first two are near-free and change the
 denominators for everything else, so they go first.
 
-**Software perf track** (branch `feat/perf-0.14-kv-routing`, compile-validated
-in CI, **pending on-console validation** — deploy the 0.3.9.0 MSIX):
+**Software perf track** (merged to main, **console-validated 2026-07-08** —
+v0.4.0.0 on Xbox; CSVs `bench/results/phase35-*.csv`):
 
 - [x] **ORT GenAI 0.13.2 → 0.14.1** (Stage 1, v0.3.7): reduced per-token CPU
-      overhead + prereq for continuous decoding.
+      overhead + prereq for continuous decoding. **Console: decode flat vs v0.3.6**
+      (CPU int4 66.3 vs 68.0; DML fp16 46.8 = 46.8) — the bump is a prereq/overhead
+      win, not a decode-rate win at this scale.
 - [x] **KV-cache reuse across chat turns** (Stage 2, v0.3.8): persistent
-      generator, append-only delta per turn → turn-N TTFT drops from re-prefilling
-      the whole history to just the new turn. Correctness-guarded fallback;
-      `kv_reuse` toggle (default on). Multi-turn TTFT bench added (Stage 2b).
+      generator, append-only delta per turn. **Console: turn-2 prefill 4.87× faster**
+      with reuse (103.7 ms / 22-tok delta vs 505.2 ms / 114-tok cold re-prefill).
+      Correctness-guarded fallback; `kv_reuse` toggle (default on).
 - [x] **Per-conversation CPU/GPU routing** (Stage 3, v0.3.9, default off): route
       long-prompt conversations to DML fp16, chat to CPU int4; sticky per
-      conversation. (Supersedes the "per-workload routing" hardware milestone
-      below — machinery done, needs the fp16 model on device + console A/B.)
+      conversation. Machinery done + dml-fp16 model on device; **interactive A/B
+      still pending** (XAML UI — needs a person at the console).
+
+- [x] **Image-generation spike** (v0.4.0, flagship hypothesis): **CONFIRMED on
+      console 2026-07-08** — on a compute-bound fp16 batch (309 GFLOP), DirectML is
+      **11.1× faster than CPU** (2403 vs 216 GFLOP/s). The inverse of text decode;
+      diffusion is the GPU's workload. → C++ pipeline built + host-validated (PR #5).
 
 Milestones:
 

--- a/bench/results/phase35-014-cpu.csv
+++ b/bench/results/phase35-014-cpu.csv
@@ -1,0 +1,2 @@
+model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,host,date
+smollm2-360m-cpu-int4,int4,ort-genai-cpu,2048,8,220.59,66.29,723,1593,0,3801,xbox-series-s,2026-07-08T08:27:42Z

--- a/bench/results/phase35-014-dml-int4.csv
+++ b/bench/results/phase35-014-dml-int4.csv
@@ -1,0 +1,2 @@
+model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,host,date
+smollm2-360m-dml-int4,int4,ort-genai-cpu,2048,8,153.25,8.82,995,837,307,3801,xbox-series-s,2026-07-08T08:33:26Z

--- a/bench/results/phase35-014-dml.csv
+++ b/bench/results/phase35-014-dml.csv
@@ -1,0 +1,2 @@
+model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,host,date
+smollm2-360m-dml-fp16,int4,ort-genai-cpu,2048,8,169.51,47.19,1169,2830,793,3801,xbox-series-s,2026-07-08T08:29:13Z

--- a/bench/results/phase35-1b-cpu.csv
+++ b/bench/results/phase35-1b-cpu.csv
@@ -1,0 +1,2 @@
+model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,host,date
+smollm2-1,int4,ort-genai-cpu,2048,8,54.89,20.62,2423,6179,0,3801,xbox-series-s,2026-07-08T08:57:14Z

--- a/bench/results/phase35-imgspike.csv
+++ b/bench/results/phase35-imgspike.csv
@@ -1,0 +1,3 @@
+ep,ok,forward_ms,gflop_s,resolution,gflop_forward,speedup_vs_cpu,date
+directml,1,128.67,2403.1,512x512,309.2,11.10,2026-07-08T08:25:09Z
+cpu,1,1428.22,216.5,512x512,309.2,1.00,2026-07-08T08:25:09Z

--- a/bench/results/phase35-kv.csv
+++ b/bench/results/phase35-kv.csv
@@ -1,0 +1,2 @@
+model,prefill1_ms,n_p1,prefill2_reuse_ms,n_p2_reuse,prefill2_cold_ms,n_p2_cold,speedup,decode_tok_s,n_ctx,host,date
+smollm2-360m-cpu-int4,150.1,32,103.7,22,505.2,114,4.87,73.46,2048,xbox-series-s,2026-07-08T08:36:00Z

--- a/scripts/bench-xbox-ort.sh
+++ b/scripts/bench-xbox-ort.sh
@@ -269,6 +269,10 @@ for ((run = 1; run <= N_RUNS; run++)); do
 
 	delete_from_localstate "bench-result.csv"
 	delete_from_localstate "bench-result.csv.done"
+	# Remove any leftover bench_turns.txt: main_loop treats its presence as the
+	# KV-reuse bench trigger, which would hijack this standard bench into kv-bench
+	# mode (writes bench-kv-result.csv, never bench-result.csv → this run times out).
+	delete_from_localstate "bench_turns.txt"
 	sleep 1
 
 	echo "  Uploading bench artifacts..."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -331,20 +331,44 @@ if [[ "${1:-}" == "upload-dir" ]]; then
 
 	mkdir_localstate "$PFN" "$REMOTE_DIR"
 
+	# Confirm the target dir actually exists before uploading — WDP folder creation
+	# can fail silently, after which every file POST returns Success:false with
+	# "The system cannot find the path specified" (a batch that then reports
+	# "Uploaded N" while landing nothing). Fail loudly here instead.
+	PARENT_PARAM="%5CLocalState"
+	LEAF="${REMOTE_DIR##*\\}"
+	if [[ "$REMOTE_DIR" == *\\* ]]; then
+		PARENT_PARAM="%5CLocalState%5C${REMOTE_DIR%\\*}"
+		PARENT_PARAM="${PARENT_PARAM//\\/%5C}"
+	fi
+	DIR_CHECK=$(curl "${CURL_AUTH[@]}" \
+		"${BASE_URL}/api/filesystem/apps/files?knownfolderid=LocalAppData&packagefullname=${PFN}&path=${PARENT_PARAM}" 2>/dev/null || echo "")
+	if ! echo "$DIR_CHECK" | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if any(i.get('Name')=='${LEAF}' for i in d.get('Items',[])) else 1)" 2>/dev/null; then
+		echo "Error: remote dir LocalState\\${REMOTE_DIR} was not created (WDP mkdir failed); aborting upload." >&2
+		exit 1
+	fi
+
 	PATH_PARAM="%5CLocalState%5C${REMOTE_DIR//\\/%5C}"
 	total=0
+	failed=0
 	while IFS= read -r -d '' f; do
 		fname=$(basename "$f")
 		echo "  uploading $fname ..."
-		curl "${CURL_AUTH[@]}" \
+		RESP=$(curl "${CURL_AUTH[@]}" \
 			-H "X-CSRF-Token:${CSRF_TOKEN}" \
 			-X POST \
 			-F "file=@${f};type=application/octet-stream" \
-			"${BASE_URL}/api/filesystem/apps/file?knownfolderid=LocalAppData&packagefullname=${PFN}&path=${PATH_PARAM}" \
-			>/dev/null
-		((total++)) || true
+			"${BASE_URL}/api/filesystem/apps/file?knownfolderid=LocalAppData&packagefullname=${PFN}&path=${PATH_PARAM}" 2>/dev/null || echo "")
+		# WDP returns 200 with {"Success": false} on failure; empty body = success.
+		if [[ -n "$RESP" ]] && ! echo "$RESP" | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if d.get('Success',True) else 1)" 2>/dev/null; then
+			echo "    ERROR: upload of $fname failed: $RESP" >&2
+			((failed++)) || true
+		else
+			((total++)) || true
+		fi
 	done < <(find "$LOCAL_DIR" -maxdepth 1 -type f -print0)
-	echo "Uploaded $total file(s) to LocalState\\${REMOTE_DIR}."
+	echo "Uploaded $total file(s) to LocalState\\${REMOTE_DIR}.${failed:+ ($failed FAILED)}"
+	[[ "$failed" -eq 0 ]] || exit 1
 	exit 0
 fi
 

--- a/src/bridge/bench.cpp
+++ b/src/bridge/bench.cpp
@@ -48,17 +48,22 @@ void write_bench_csv(const InferenceParams& params, const InferenceResult& res,
     struct tm* tm_utc = gmtime(&now);
     strftime(date_buf, sizeof(date_buf), "%Y-%m-%dT%H:%M:%SZ", tm_utc);
 
-    // Model label = the directory basename. Do NOT blind-strip at the last '.':
-    // model dir names contain dots (e.g. "smollm2-1.7b-cpu-int4" was truncated to
-    // "smollm2-1"). Take the basename and strip only a trailing ".onnx".
+    // Model label = the basename. Do NOT blind-strip at the last '.': model dir
+    // names contain dots (e.g. "smollm2-1.7b-cpu-int4" was truncated to
+    // "smollm2-1"). Take the basename and strip only a trailing *known model*
+    // extension (.gguf for llama.cpp, .onnx if a file path is passed) — the ORT
+    // path passes a directory with no extension, which is left intact.
     std::string model_name = params.model_path;
     auto slash = model_name.find_last_of("/\\");
     if (slash != std::string::npos)
         model_name = model_name.substr(slash + 1);
-    const std::string kOnnx = ".onnx";
-    if (model_name.size() > kOnnx.size() &&
-        model_name.compare(model_name.size() - kOnnx.size(), kOnnx.size(), kOnnx) == 0)
-        model_name = model_name.substr(0, model_name.size() - kOnnx.size());
+    for (const std::string& ext : {std::string(".gguf"), std::string(".onnx")}) {
+        if (model_name.size() > ext.size() &&
+            model_name.compare(model_name.size() - ext.size(), ext.size(), ext) == 0) {
+            model_name = model_name.substr(0, model_name.size() - ext.size());
+            break;
+        }
+    }
 
 #ifdef XLLAMA_USE_ORT
     // Derive the EP + quant labels from the model directory name (convention:

--- a/src/bridge/bench.cpp
+++ b/src/bridge/bench.cpp
@@ -48,14 +48,27 @@ void write_bench_csv(const InferenceParams& params, const InferenceResult& res,
     struct tm* tm_utc = gmtime(&now);
     strftime(date_buf, sizeof(date_buf), "%Y-%m-%dT%H:%M:%SZ", tm_utc);
 
+    // Model label = the directory basename. Do NOT blind-strip at the last '.':
+    // model dir names contain dots (e.g. "smollm2-1.7b-cpu-int4" was truncated to
+    // "smollm2-1"). Take the basename and strip only a trailing ".onnx".
     std::string model_name = params.model_path;
-    auto dot = model_name.rfind('.');
-    if (dot != std::string::npos)
-        model_name = model_name.substr(0, dot);
+    auto slash = model_name.find_last_of("/\\");
+    if (slash != std::string::npos)
+        model_name = model_name.substr(slash + 1);
+    const std::string kOnnx = ".onnx";
+    if (model_name.size() > kOnnx.size() &&
+        model_name.compare(model_name.size() - kOnnx.size(), kOnnx.size(), kOnnx) == 0)
+        model_name = model_name.substr(0, model_name.size() - kOnnx.size());
 
 #ifdef XLLAMA_USE_ORT
-    const char* backend = "ort-genai-cpu";
-    const char* quant = "int4";
+    // Derive the EP + quant labels from the model directory name (convention:
+    // smollm2-<size>-<cpu|dml>-<int4|fp16>) instead of hardcoding — a DML fp16
+    // model was previously mislabelled as "ort-genai-cpu"/"int4". gpu_mem_mb > 0
+    // corroborates DML execution (GPU memory resident after load).
+    const bool is_dml = model_name.find("dml") != std::string::npos || res.gpu_mem_mb > 0;
+    const bool is_fp16 = model_name.find("fp16") != std::string::npos;
+    const char* backend = is_dml ? "ort-genai-dml" : "ort-genai-cpu";
+    const char* quant = is_fp16 ? "fp16" : "int4";
 #else
     const char* backend = "cpu";
     const char* quant = "Q4_K_M";


### PR DESCRIPTION
Ran the pending on-console checks for the merged 0.3.7–0.4.0 features on **Xbox Series S (v0.4.0.0)** per `docs/console-validation-runbook.md`. CSVs in `bench/results/phase35-*.csv`.

## Results

| Check | Result | Verdict |
|---|---|---|
| **Image spike** (flagship) | DirectML **11.1×** faster than CPU (2403 vs 216 GFLOP/s) | ✅ diffusion is the GPU's workload — inverse of decode |
| Decode 0.14.1 | CPU int4 66.3 / DML fp16 46.8 / DML int4 8.82 tok/s | flat vs v0.3.6 |
| int4 DML floor | 8.82 tok/s, GPU engines **87–90%** (not fallback) | ✅ §12 non-fused kernel limit CONFIRMED on hw |
| KV reuse | turn-2 prefill **4.87×** (delta vs full re-prefill) | ✅ continuous decoding works |
| 1.7B scale | cpu-int4 decode **20.6 tok/s** (3.2× down from 360M) | ✅ CPU int4 usable at 1.7B |

DML runs verified as real GPU execution via `--gpu-sample` (compute engines busy, `gpu_mem` ≈ model size), not silent CPU fallback.

## Tooling fixes (surfaced during the session)

- **`scripts/deploy.sh upload-dir`**: verified the target dir exists (WDP folder creation can fail silently) and now checks each file's `Success` flag — the 1.7B `model.onnx` silently vanished (WDP `200`/`Success:false`) until the missing subdir was created. Fails loudly now, mirroring `upload-file`.
- **`src/bridge/bench.cpp`**: CSV `backend`/`quant` were hardcoded `ort-genai-cpu`/`int4` (mislabelling DML/fp16 runs) → derived from the model dir name + `gpu_mem_mb`. Model label no longer truncates at the first dot (`smollm2-1.7b-cpu-int4` was logged as `smollm2-1`).

## Still pending (need specific assets)

- **Routing A/B** (§2): interactive XAML UI — needs a person at the console.
- **Diffusion** (§7): needs an fp16 SD-Turbo export (GPU/Olive); the C++ pipeline (PR #5) is host-validated and ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)