### PR TITLE
feat(models): manifest.json catalogue — de-hardcode model management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ out/
 # Models (large GGUF files)
 *.gguf
 models/
+# ...but the model catalogue is source, not a model artifact
+!uwp/models/
+uwp/models/*
+!uwp/models/manifest.json
 
 # Visual Studio
 .vs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,25 @@ image for the same prompt/seed). Fixes required on the way, all measured:
   i64/f32/f16 timestep), `diffuse-steps.txt`/`diffuse-seed.txt`, and per-stage
   telemetry (`diffuse-result.csv`).
 
+### Added — model catalogue (`models/manifest.json`), model management de-hardcoded
+
+The model list, download source, and downloadability gate were hardcoded in four
+places; they now come from one catalogue file.
+
+- `uwp/models/manifest.json`: name/display/`hf_base_url`/file-list per model,
+  bundled in the MSIX (both variants) at `InstalledPath\models\manifest.json`;
+  a `LocalState\manifest.json` uploaded via Device Portal **overrides it without
+  a reinstall**. Parsed with WinRT `Windows::Data::Json` (`LoadModelManifest`,
+  `uwp/model-downloader.cpp`) with a built-in fallback so the app never starts
+  with an empty catalogue.
+- Settings ComboBox is populated from the catalogue (plus the active model as a
+  "(custom)" entry if it isn't listed — e.g. a dir uploaded under a new name);
+  replaces the static 3-entry `kModels[]`.
+- `EnsureModelAsync` downloads **any** catalogue entry with an `hf_base_url`
+  (replaces the single-model `kDownloadableModel` gate + hardcoded repo URL +
+  `SmolLM2_360M_Files()`); entries without a URL keep the USB/Device-Portal
+  guidance error.
+
 ### Measured — Phase 3.5 console validation (Xbox Series S, v0.4.0.0, 2026-07-08)
 
 The pending on-console checks for the merged 0.3.7–0.4.0 features, run in one session

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -932,20 +932,23 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
     modelBox.Header(winrt::box_value(L"Model"));
     modelBox.FontSize(16);
     modelBox.HorizontalAlignment(HorizontalAlignment::Stretch);
-    struct ModelEntry {
-        const wchar_t* display;
-        const wchar_t* key;
-    };
-    static const ModelEntry kModels[] = {
-        {L"SmolLM2-360M (bundled)", L"smollm2-360m-cpu-int4"},
-        {L"SmolLM2-1.7B (USB)", L"smollm2-1.7b-cpu-int4"},
-        {L"SmolLM2-360M (HF download)", L"smollm2-360m-cpu-int4-hf"},
-    };
+    // Model list comes from the catalogue (models/manifest.json; LocalState
+    // override wins). If the active model is not in the catalogue (e.g. a dir
+    // uploaded via Device Portal under a custom name), append it so the current
+    // selection is always representable.
+    auto manifest = ::xllama::LoadModelManifest();
+    std::vector<std::wstring> model_keys;
     int model_sel = 0;
-    for (int i = 0; i < 3; ++i) {
-        modelBox.Items().Append(winrt::box_value(winrt::hstring(kModels[i].display)));
-        if (m_model_filename == kModels[i].key)
-            model_sel = i;
+    for (auto const& e : manifest) {
+        modelBox.Items().Append(winrt::box_value(winrt::hstring(e.display)));
+        if (m_model_filename == e.name)
+            model_sel = (int)model_keys.size();
+        model_keys.push_back(e.name);
+    }
+    if (!m_model_filename.empty() && !::xllama::FindManifestEntry(manifest, m_model_filename)) {
+        modelBox.Items().Append(winrt::box_value(winrt::hstring(m_model_filename + L" (custom)")));
+        model_sel = (int)model_keys.size();
+        model_keys.push_back(m_model_filename);
     }
     modelBox.SelectedIndex(model_sel);
 
@@ -1027,8 +1030,8 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
 
     // Read back values
     int mi = modelBox.SelectedIndex();
-    if (mi >= 0 && mi < 3) {
-        std::wstring new_model = kModels[mi].key;
+    if (mi >= 0 && mi < (int)model_keys.size()) {
+        std::wstring new_model = model_keys[mi];
         if (new_model != self->m_model_filename) {
             self->m_model_filename = new_model;
             self->m_modelText.Text(new_model);
@@ -1222,10 +1225,12 @@ fire_and_forget MainPageController::EnsureModelAsync() {
             co_return;
         }
     }
-    // Neither found: only the bundled 360M model can be auto-downloaded from HF.
-    // Larger models (e.g. 1.7B) must be provided via USB — show a clear error.
-    static constexpr wchar_t kDownloadableModel[] = L"smollm2-360m-cpu-int4";
-    if (model_name != kDownloadableModel) {
+    // Neither found: consult the model catalogue (models/manifest.json) — any
+    // entry with an hf_base_url can be auto-downloaded; anything else must be
+    // provided via USB or Device Portal upload.
+    auto manifest = ::xllama::LoadModelManifest();
+    const ::xllama::ManifestEntry* entry = ::xllama::FindManifestEntry(manifest, model_name);
+    if (!entry || entry->hf_base_url.empty() || entry->files.empty()) {
         self->SetStatus(L"Model '" + model_name +
                             L"' not found.\n"
                             L"Connect USB with xllama/models/" +
@@ -1237,7 +1242,7 @@ fire_and_forget MainPageController::EnsureModelAsync() {
 
     co_await resume_background();
 
-    // Auto-download: SmolLM2-360M from HuggingFace.
+    // Auto-download from the catalogue entry's Hugging Face repo.
     co_await resume_foreground(dispatcher);
     self->SetStatus(L"Downloading model...", StatusKind::Working);
     self->m_loadingBar.IsIndeterminate(false);
@@ -1259,14 +1264,10 @@ fire_and_forget MainPageController::EnsureModelAsync() {
         }
     }
 
-    // Build HF raw URL for the model repo.
-    std::wstring hf_repo_url = L"https://huggingface.co/homen3/"
-                               L"SmolLM2-360M-Instruct-ort-genai-int4-cpu/resolve/main";
-
     co_await resume_foreground(dispatcher);
 
     co_await ModelDownloader::DownloadAsync(
-        hf_repo_url, local_model_dir, SmolLM2_360M_Files(), dispatcher,
+        entry->hf_base_url, local_model_dir, entry->files, dispatcher,
         [self](uint64_t done, uint64_t total) {
             // progress callback — called on UI thread
             if (total > 0) {

--- a/uwp/model-downloader.cpp
+++ b/uwp/model-downloader.cpp
@@ -11,6 +11,8 @@
     #include "xllama/platform.h"
     #include "xllama/utf8_utils.h"
 
+    #include <winrt/Windows.Data.Json.h>
+
     #include <filesystem>
 
 using namespace winrt;
@@ -197,6 +199,89 @@ IAsyncAction ModelDownloader::DownloadAsync(std::wstring hf_repo_url, std::wstri
 
     co_await resume_foreground(dispatcher);
     on_done(true, L"");
+}
+
+// ---------------------------------------------------------------------------
+// Model catalogue (models/manifest.json)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Parse a manifest JSON document into entries; returns empty on any shape error.
+std::vector<ManifestEntry> parse_manifest(winrt::hstring const& text) {
+    using winrt::Windows::Data::Json::JsonObject;
+    std::vector<ManifestEntry> out;
+    JsonObject root{nullptr};
+    if (!JsonObject::TryParse(text, root))
+        return out;
+    if (!root.HasKey(L"models"))
+        return out;
+    for (auto const& item : root.GetNamedArray(L"models")) {
+        auto obj = item.GetObject();
+        ManifestEntry e;
+        e.name = obj.GetNamedString(L"name", L"");
+        if (e.name.empty())
+            continue;
+        e.display = obj.GetNamedString(L"display", winrt::hstring(e.name));
+        e.hf_base_url = obj.GetNamedString(L"hf_base_url", L"");
+        if (obj.HasKey(L"files")) {
+            for (auto const& f : obj.GetNamedArray(L"files")) {
+                auto fo = f.GetObject();
+                ModelFile mf;
+                mf.filename = fo.GetNamedString(L"filename", L"");
+                mf.approx_bytes = (uint64_t)fo.GetNamedNumber(L"approx_bytes", 0);
+                if (!mf.filename.empty())
+                    e.files.push_back(std::move(mf));
+            }
+        }
+        out.push_back(std::move(e));
+    }
+    return out;
+}
+
+std::vector<ManifestEntry> read_manifest_file(std::wstring const& path) {
+    FILE* fp = _wfopen(path.c_str(), L"rb");
+    if (!fp)
+        return {};
+    std::string bytes;
+    char buf[4096];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof(buf), fp)) > 0)
+        bytes.append(buf, n);
+    fclose(fp);
+    return parse_manifest(winrt::hstring(utf8_to_wstring(bytes)));
+}
+
+} // namespace
+
+std::vector<ManifestEntry> LoadModelManifest() {
+    // 1. LocalState override (uploadable via Device Portal, no reinstall).
+    auto local = winrt::Windows::Storage::ApplicationData::Current().LocalFolder();
+    auto entries = read_manifest_file(std::wstring(local.Path().c_str()) + L"\\manifest.json");
+    if (!entries.empty()) {
+        log_output("[manifest] using LocalState\\manifest.json override\n");
+        return entries;
+    }
+    // 2. Bundled catalogue.
+    auto pkg = winrt::Windows::ApplicationModel::Package::Current();
+    entries =
+        read_manifest_file(std::wstring(pkg.InstalledPath().c_str()) + L"\\models\\manifest.json");
+    if (!entries.empty())
+        return entries;
+    // 3. Built-in fallback — the historical hardcoded catalogue, so the app
+    // never starts with an empty model list even on a broken deployment.
+    log_output("[manifest] WARNING: no manifest.json found, using built-in fallback\n");
+    ManifestEntry e;
+    e.name = L"smollm2-360m-cpu-int4";
+    e.display = L"SmolLM2 360M (CPU int4)";
+    e.hf_base_url = L"https://huggingface.co/homen3/"
+                    L"SmolLM2-360M-Instruct-ort-genai-int4-cpu/resolve/main";
+    e.files = {
+        {L"genai_config.json", 2'000},     {L"tokenizer.json", 2'400'000},
+        {L"tokenizer_config.json", 3'000}, {L"special_tokens_map.json", 1'000},
+        {L"model.onnx", 422'000'000},
+    };
+    return {e};
 }
 
 } // namespace xllama

--- a/uwp/model-downloader.h
+++ b/uwp/model-downloader.h
@@ -40,13 +40,28 @@ class ModelDownloader {
                   std::function<void(bool, std::wstring)> on_done);
 };
 
-// File manifest for SmolLM2-360M-Instruct-ort-genai-int4-cpu (merged model.onnx).
-inline std::vector<ModelFile> SmolLM2_360M_Files() {
-    return {
-        {L"genai_config.json", 2'000},     {L"tokenizer.json", 2'400'000},
-        {L"tokenizer_config.json", 3'000}, {L"special_tokens_map.json", 1'000},
-        {L"model.onnx", 422'000'000}, // ~403 MB merged
-    };
+// One entry of the model catalogue (models/manifest.json). An empty hf_base_url
+// means the model cannot be auto-downloaded (USB/Device-Portal provisioning only).
+struct ManifestEntry {
+    std::wstring name;
+    std::wstring display;
+    std::wstring hf_base_url;
+    std::vector<ModelFile> files;
+};
+
+// Load the model catalogue: LocalState\manifest.json (uploadable via Device
+// Portal, no reinstall) overrides InstalledPath\models\manifest.json (bundled).
+// Falls back to a built-in single-entry catalogue (the historical hardcoded
+// SmolLM2-360M) if neither parses, so the app never starts with an empty list.
+std::vector<ManifestEntry> LoadModelManifest();
+
+// Find an entry by model dir name; nullptr-like (empty name) if absent.
+inline const ManifestEntry* FindManifestEntry(const std::vector<ManifestEntry>& m,
+                                              const std::wstring& name) {
+    for (const auto& e : m)
+        if (e.name == name)
+            return &e;
+    return nullptr;
 }
 
 } // namespace xllama

--- a/uwp/models/manifest.json
+++ b/uwp/models/manifest.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "Model catalogue for xllama. Bundled at InstalledPath\\models\\manifest.json; a LocalState\\manifest.json (uploadable via Device Portal, no reinstall) overrides it entirely. Entries without hf_base_url are USB/Device-Portal-provisioned only. approx_bytes drives the download progress bar.",
+  "models": [
+    {
+      "name": "smollm2-360m-cpu-int4",
+      "display": "SmolLM2 360M (CPU int4)",
+      "hf_base_url": "https://huggingface.co/homen3/SmolLM2-360M-Instruct-ort-genai-int4-cpu/resolve/main",
+      "files": [
+        { "filename": "genai_config.json", "approx_bytes": 2000 },
+        { "filename": "tokenizer.json", "approx_bytes": 2400000 },
+        { "filename": "tokenizer_config.json", "approx_bytes": 3000 },
+        { "filename": "special_tokens_map.json", "approx_bytes": 1000 },
+        { "filename": "model.onnx", "approx_bytes": 422000000 }
+      ]
+    },
+    {
+      "name": "smollm2-360m-dml-fp16",
+      "display": "SmolLM2 360M (GPU fp16, routing)"
+    },
+    {
+      "name": "smollm2-1.7b-cpu-int4",
+      "display": "SmolLM2 1.7B (CPU int4)"
+    }
+  ]
+}

--- a/uwp/xllama.vcxproj
+++ b/uwp/xllama.vcxproj
@@ -259,6 +259,16 @@
     </None>
   </ItemGroup>
 
+  <!-- Model catalogue: always bundled (both variants) at InstalledPath\models\manifest.json.
+       A LocalState\manifest.json uploaded via Device Portal overrides it (see
+       LoadModelManifest in model-downloader.cpp). -->
+  <ItemGroup>
+    <None Include="models\manifest.json">
+      <DeploymentContent>true</DeploymentContent>
+      <TargetPath>models\manifest.json</TargetPath>
+    </None>
+  </ItemGroup>
+
   <!-- xllama shared bridge -->
   <ItemGroup>
     <ClCompile Include="..\src\bridge\inference.cpp" />


### PR DESCRIPTION
The model list, download source, and downloadability gate lived in four hardcoded places (`SmolLM2_360M_Files()`, the HF repo URL, the `kDownloadableModel` gate, the static `kModels[]` ComboBox). They now come from one catalogue:

- **`uwp/models/manifest.json`** — name / display / `hf_base_url` / file-list per model. Bundled in **both** MSIX variants at `InstalledPath\models\manifest.json`; a `LocalState\manifest.json` uploaded via Device Portal **overrides it without a reinstall**. Parsed with WinRT `Windows::Data::Json` (`LoadModelManifest`); built-in single-entry fallback keeps the app usable on a broken deployment.
- Settings **ComboBox** populated from the catalogue, plus a "(custom)" entry when the active model isn't listed (e.g. a dir uploaded under a new name).
- **`EnsureModelAsync`** downloads *any* catalogue entry with an `hf_base_url` via the existing generic `DownloadAsync`; entries without a URL keep the USB/Device-Portal guidance error.

Groundwork for the nobundle default (Exp 2 validation next) and the v1.0.0 model-manifest milestone (ROADMAP Phase 4).

`.gitignore` gains an exception: `uwp/models/manifest.json` is source, not a model artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)