### PR TITLE
feat(ui): image generation dialog — view + stage headless GPU generation

### DIFF
--- a/docs/console-validation-runbook.md
+++ b/docs/console-validation-runbook.md
@@ -59,22 +59,40 @@ turn-2 cold re-prefills the full 2-turn context, reuse only the ~10-token delta.
 confirm multi-turn **coherence** (read the log's decoded turn-2 output) before trusting
 `kv_reuse` as the interactive default.
 
-## 2. PR #2 — CPU/GPU routing (Stage 3, interactive)
+## 2. PR #2 — CPU/GPU routing (Stage 3, interactive, ~10 min at the console)
 
 **Validates**: the `routing=2` (auto) path picks GPU (DML fp16) for long prompts and CPU
 for decode, sticky per conversation.
 
-Prereq: the DML fp16 model must be on device. Upload the 360M DML fp16 dir:
+Prereqs (both already satisfied on the current console): `smollm2-360m-dml-fp16` in
+`LocalState\models\`, and the routing setting. The setting can be **preloaded via WDP**
+so the person at the console only pastes a prompt:
 
 ```bash
-python3 scripts/merge_onnx_external_data.py ~/.cache/.../smollm2-360m-dml-fp16   # if external data
-./scripts/deploy.sh upload-dir <dir>/ "$PFN" "models\\smollm2-360m-dml-fp16"
+source ~/.config/xllama/xbox-env
+PFN=$(./scripts/deploy.sh pfn)
+cat > /tmp/settings.json <<'JSON'
+{
+  "system_prompt": "You are a helpful assistant.",
+  "model": "smollm2-360m-cpu-int4",
+  "kv_reuse": true,
+  "routing": 2,
+  "gpu_model": "smollm2-360m-dml-fp16",
+  "sampling": { "temperature": 0.70, "top_p": 0.90, "top_k": 40,
+                "repetition_penalty": 1.10, "n_predict": 256 }
+}
+JSON
+./scripts/deploy.sh upload-file /tmp/settings.json "$PFN" ""
 ```
 
-In-app: ⚙ Settings → routing = **auto** → send a long (>~500 tok) prompt, then a short
-follow-up. **Looking for**: log shows the first turn routed to `smollm2-360m-dml-fp16`
-(GPU) and TTFT improved vs CPU-only on the long prompt; the conversation stays on its
-routed EP (sticky). New chat re-decides.
+Then, at the console: launch xllama → paste a **long** prompt (>~500 tokens — e.g. the
+content of `bench/prompts/standard-512.txt`) → send; then a short follow-up; then **+ New**
+and a short prompt. Fetch the log afterwards (`deploy.sh get-log`).
+
+**Looking for** (in the log): the long-prompt conversation's first turn routed to
+`smollm2-360m-dml-fp16` (GPU) with a better TTFT than the CPU baseline at that length;
+the follow-up stays on the same EP (sticky); the new chat with a short prompt routes back
+to CPU. Flip `routing` back to `0` (Settings) afterwards if desired.
 
 ## 3. PR #2 — 0.14.1 decode overhead → refresh the v0.3.6 matrix
 

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -10,7 +10,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="0.4.2.0"
+    Version="0.4.3.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -13,6 +13,8 @@
     #include "xllama/platform.h"
     #include "xllama/utf8_utils.h"
 
+    #include <winrt/Windows.UI.Xaml.Media.Imaging.h>
+
     #include <cstdio>
     #include <ctime>
     #include <filesystem>
@@ -160,6 +162,11 @@ void MainPageController::BuildUI() {
     m_historyButton.MinWidth(100);
     m_historyButton.Margin(ThicknessHelper::FromLengths(0, 0, 12, 0));
 
+    m_imageButton = Button();
+    m_imageButton.Content(winrt::box_value(L"[*]  Image"));
+    m_imageButton.MinWidth(100);
+    m_imageButton.Margin(ThicknessHelper::FromLengths(0, 0, 12, 0));
+
     m_runButton = Button();
     m_runButton.Content(winrt::box_value(L"▶  Run"));
     m_runButton.MinWidth(120);
@@ -174,6 +181,7 @@ void MainPageController::BuildUI() {
     btnPanel.Children().Append(m_settingsButton);
     btnPanel.Children().Append(m_newChatButton);
     btnPanel.Children().Append(m_historyButton);
+    btnPanel.Children().Append(m_imageButton);
     btnPanel.Children().Append(m_runButton);
     btnPanel.Children().Append(m_cancelButton);
 
@@ -234,6 +242,10 @@ void MainPageController::Init() {
     m_historyButton.Click([self](IInspectable const&, RoutedEventArgs const&) {
         if (auto s = self.lock())
             s->ShowHistory();
+    });
+    m_imageButton.Click([self](IInspectable const&, RoutedEventArgs const&) {
+        if (auto s = self.lock())
+            s->ShowImageDialog();
     });
 
     // B button: cancel inference if running, otherwise let system exit the app
@@ -1051,6 +1063,120 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
     // (m_active_model stays fixed for the conversation in progress).
     self->SaveSettings();
     self->SetStatus(L"Settings saved", StatusKind::Success);
+}
+
+// ---------------------------------------------------------------------------
+// ShowImageDialog — view the last generated image and stage a new headless
+// generation. DML cannot initialise inside the XAML process (887A0036), so
+// "Generate" writes the diffusion inputs + diffuse.flag and restarts the app:
+// the restart boots headless (App.cpp flag dispatch), runs the GPU pipeline,
+// and exits; the image appears here on the next launch.
+// ---------------------------------------------------------------------------
+
+winrt::fire_and_forget MainPageController::ShowImageDialog() {
+    auto self = shared_from_this();
+    if (m_is_running.load())
+        co_return;
+
+    winrt::Windows::UI::Xaml::Controls::StackPanel panel;
+    panel.Orientation(Orientation::Vertical);
+    panel.Spacing(12);
+
+    // Last generated image (if any) — loaded from LocalState via a stream so a
+    // regenerated file is never masked by URI caching.
+    winrt::Windows::UI::Xaml::Controls::TextBlock imgStatus;
+    imgStatus.TextWrapping(TextWrapping::Wrap);
+    panel.Children().Append(imgStatus);
+    try {
+        auto local = ApplicationData::Current().LocalFolder();
+        auto file = co_await local.GetFileAsync(L"diffuse-out.png");
+        auto stream = co_await file.OpenAsync(winrt::Windows::Storage::FileAccessMode::Read);
+        winrt::Windows::UI::Xaml::Media::Imaging::BitmapImage bmp;
+        co_await bmp.SetSourceAsync(stream);
+        winrt::Windows::UI::Xaml::Controls::Image img;
+        img.Source(bmp);
+        img.MaxHeight(320);
+        imgStatus.Text(L"Last generated image (512×512):");
+        panel.Children().Append(img);
+    } catch (...) {
+        imgStatus.Text(L"No image generated yet.");
+    }
+
+    winrt::Windows::UI::Xaml::Controls::TextBox promptBox;
+    promptBox.Header(winrt::box_value(L"Image prompt"));
+    promptBox.Text(L"a red sports car on a mountain road at sunset");
+    promptBox.TextWrapping(TextWrapping::Wrap);
+    promptBox.AcceptsReturn(false);
+    promptBox.FontSize(16);
+    panel.Children().Append(promptBox);
+
+    winrt::Windows::UI::Xaml::Controls::Slider stepsSlider;
+    stepsSlider.Minimum(1);
+    stepsSlider.Maximum(4);
+    stepsSlider.StepFrequency(1);
+    stepsSlider.Value(1);
+    stepsSlider.Header(winrt::box_value(L"Steps (SD-Turbo: 1 is enough)"));
+    panel.Children().Append(stepsSlider);
+
+    winrt::Windows::UI::Xaml::Controls::TextBlock note;
+    note.TextWrapping(TextWrapping::Wrap);
+    note.Opacity(0.7);
+    note.Text(L"Generate restarts the app to run the GPU pipeline (it cannot run inside "
+              L"this window). When the console returns to Dev Home, relaunch xllama and "
+              L"reopen this dialog to view the result (~15 s).");
+    panel.Children().Append(note);
+
+    winrt::Windows::UI::Xaml::Controls::ScrollViewer sv;
+    sv.Content(panel);
+    sv.MaxHeight(480);
+    sv.VerticalScrollBarVisibility(ScrollBarVisibility::Auto);
+
+    winrt::Windows::UI::Xaml::Controls::ContentDialog dlg;
+    dlg.Title(winrt::box_value(L"Image generation (SD-Turbo on GPU)"));
+    dlg.Content(sv);
+    dlg.PrimaryButtonText(L"Generate (restarts app)");
+    dlg.CloseButtonText(L"Close");
+    dlg.XamlRoot(m_root.XamlRoot());
+
+    auto result = co_await dlg.ShowAsync();
+    if (result != winrt::Windows::UI::Xaml::Controls::ContentDialogResult::Primary)
+        co_return;
+
+    // Stage the headless generation inputs. The flag is written LAST so a
+    // partially staged run can never trigger.
+    auto write_local = [](const wchar_t* name, const std::string& bytes) {
+        FILE* fp = _wfopen(local_wpath(name).c_str(), L"wb");
+        if (!fp)
+            return false;
+        fwrite(bytes.data(), 1, bytes.size(), fp);
+        fclose(fp);
+        return true;
+    };
+    std::string prompt_utf8 = ::xllama::wstring_to_utf8(std::wstring(promptBox.Text().c_str()));
+    if (prompt_utf8.empty())
+        prompt_utf8 = "a red sports car on a mountain road at sunset";
+    const int steps = (int)stepsSlider.Value();
+    // Fresh seed per generation so repeated prompts give new images.
+    const unsigned seed = (unsigned)(GetTickCount64() % 1'000'000'000ULL);
+    bool ok = write_local(L"prompt.txt", prompt_utf8) &&
+              write_local(L"diffuse-steps.txt", std::to_string(steps)) &&
+              write_local(L"diffuse-seed.txt", std::to_string(seed)) &&
+              write_local(L"diffuse-model.txt", "sd-turbo-fp16") &&
+              write_local(L"diffuse.flag", "diffuse");
+    if (!ok) {
+        self->SetStatus(L"Could not stage the generation files", StatusKind::Error);
+        co_return;
+    }
+
+    self->SetStatus(L"Restarting to generate on GPU...", StatusKind::Working);
+    auto reason =
+        co_await winrt::Windows::ApplicationModel::Core::CoreApplication::RequestRestartAsync(
+            L"diffuse");
+    // Only reached if the restart was denied (e.g. not permitted right now):
+    // the flag is staged, so a manual relaunch will still run the generation.
+    (void)reason;
+    self->SetStatus(L"Restart not permitted — quit and relaunch xllama to generate",
+                    StatusKind::Error);
 }
 
 // ---------------------------------------------------------------------------

--- a/uwp/MainPage.h
+++ b/uwp/MainPage.h
@@ -60,6 +60,10 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     void LoadSettings();
     void SaveSettings();
     winrt::fire_and_forget ShowSettings();
+    // Image generation UX: shows the last diffuse-out.png and stages a new
+    // headless generation (diffuse.flag + restart) — DML cannot run in the XAML
+    // process (887A0036), so the UI orchestrates the headless pipeline.
+    winrt::fire_and_forget ShowImageDialog();
     void SaveCurrentConversation(bool partial = false);
     // Must be called from background thread; builds/rebuilds m_session if needed.
     bool EnsureSession(const std::string& model, std::string* err_out = nullptr);
@@ -79,6 +83,7 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     winrt::Windows::UI::Xaml::Controls::Button m_newChatButton{nullptr};
     winrt::Windows::UI::Xaml::Controls::Button m_historyButton{nullptr};
     winrt::Windows::UI::Xaml::Controls::Button m_settingsButton{nullptr};
+    winrt::Windows::UI::Xaml::Controls::Button m_imageButton{nullptr};
     winrt::Windows::UI::Xaml::DispatcherTimer m_flush_timer{nullptr};
     winrt::event_token m_flush_tick_token{};
 


### PR DESCRIPTION
New **[*] Image** button opens a dialog that:

- shows the last `diffuse-out.png` (loaded via file stream — a regenerated image is never masked by URI caching);
- stages a new generation: prompt TextBox, steps slider (1–4), fresh seed per run.

**Generate (restarts app)**: writes the diffusion inputs, then `diffuse.flag` **last** (a partially staged run can never trigger), and calls `CoreApplication::RequestRestartAsync`. DML cannot initialise inside the XAML process (the 887A0036 finding), so the UI orchestrates the headless pipeline: the restart boots headless (App.cpp flag dispatch), generates on the GPU (~15 s incl. load, measured in PR #7), exits; the image appears in the dialog on the next launch. If the restart is denied, the flag stays staged and a manual relaunch runs the generation — documented in-dialog.

Also: runbook §2 now ships a WDP-preloadable `settings.json` so the interactive routing A/B needs only pasting a prompt at the console. Version → 0.4.3.0.

Console validation next (one interactive session): routing A/B (§2) + this dialog's two-launch flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)