### PR TITLE
feat(llamacpp): UWP build lane — static ggml/llama CPU backend variant

### DIFF
--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -15,7 +15,9 @@ jobs:
         # bundled: MSIX with SmolLM2 model in InstalledPath (default artifact).
         # nobundle: MSIX without the model — EnsureModelAsync must reach the
         # USB/HF-download fallbacks; used to validate Exp 2 on console.
-        variant: [bundled, nobundle]
+        # llamacpp: nobundle MSIX with the ggml/llama CPU text backend
+        # (XLLAMA_USE_ORT=0) — the CPU A/B lane; needs the submodule + patches.
+        variant: [bundled, nobundle, llamacpp]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -49,6 +51,13 @@ jobs:
           python -m pip install --quiet onnx
           python scripts/merge_onnx_external_data.py models/smollm2-360m-cpu-int4
 
+      - name: Checkout llama.cpp submodule + apply AppContainer guards
+        if: matrix.variant == 'llamacpp'
+        shell: bash
+        run: |
+          git submodule update --init --depth 1 llama.cpp
+          bash scripts/apply-uwp-patches.sh
+
       - name: Restore NuGet packages
         shell: pwsh
         working-directory: uwp
@@ -58,12 +67,15 @@ jobs:
         shell: pwsh
         # -NoBundledModel also belts-and-braces the nobundle variant: even if a
         # cached model directory existed, the MSBuild property excludes it.
-        run: ./scripts/build-uwp.ps1 -Configuration Release -Platform x64 -NoBundledModel:$('${{ matrix.variant }}' -eq 'nobundle')
+        run: >-
+          ./scripts/build-uwp.ps1 -Configuration Release -Platform x64
+          -NoBundledModel:$('${{ matrix.variant }}' -ne 'bundled')
+          -Backend $('${{ matrix.variant }}' -eq 'llamacpp' ? 'llamacpp' : 'ort')
 
       - uses: actions/upload-artifact@v7
         if: success()
         with:
-          name: xllama-appx${{ matrix.variant == 'nobundle' && '-nobundle' || '' }}
+          name: xllama-appx${{ matrix.variant != 'bundled' && format('-{0}', matrix.variant) || '' }}
           # Include .msix (main package), .appx (VCLibs deps), and .cer
           # (public key of the test certificate that must be trusted on the
           # Xbox before deploying — installed via Device Portal API).

--- a/patches/0001-uwp-appcontainer-guards.patch
+++ b/patches/0001-uwp-appcontainer-guards.patch
@@ -76,3 +76,43 @@ index 128883b41..8496adb5c 100644
          HKEY hKey;
          if (RegOpenKeyEx(HKEY_LOCAL_MACHINE,
                          TEXT("HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0"),
+diff --git a/src/llama-mmap.cpp b/src/llama-mmap.cpp
+index ed572da7f..c4305dc71 100644
+--- a/src/llama-mmap.cpp
++++ b/src/llama-mmap.cpp
+@@ -530,7 +530,7 @@ struct llama_mmap::impl {
+             }
+         }
+     }
+-#elif defined(_WIN32)
++#elif defined(_WIN32) && (!defined(WINAPI_FAMILY) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))
+     HANDLE hMapping = nullptr;
+ 
+     impl(struct llama_file * file, size_t prefetch, bool numa) {
+@@ -625,7 +625,7 @@ void * llama_mmap::addr() const { return pimpl->addr; }
+ 
+ void llama_mmap::unmap_fragment(size_t first, size_t last) { pimpl->unmap_fragment(first, last); }
+ 
+-#if defined(_POSIX_MEMLOCK_RANGE) || defined(_WIN32)
++#if defined(_POSIX_MEMLOCK_RANGE) || (defined(_WIN32) && (!defined(WINAPI_FAMILY) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)))
+ const bool llama_mmap::SUPPORTED  = true;
+ #else
+ const bool llama_mmap::SUPPORTED  = false;
+@@ -679,7 +679,7 @@ struct llama_mlock::impl {
+             LLAMA_LOG_WARN("warning: failed to munlock buffer: %s\n", std::strerror(errno));
+         }
+     }
+-#elif defined(_WIN32)
++#elif defined(_WIN32) && (!defined(WINAPI_FAMILY) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))
+     static size_t lock_granularity() {
+         SYSTEM_INFO si;
+         GetSystemInfo(&si);
+@@ -768,7 +768,7 @@ llama_mlock::~llama_mlock() = default;
+ void llama_mlock::init(void * ptr) { pimpl->init(ptr); }
+ void llama_mlock::grow_to(size_t target_size) { pimpl->grow_to(target_size); }
+ 
+-#if defined(_POSIX_MEMLOCK_RANGE) || defined(_WIN32)
++#if defined(_POSIX_MEMLOCK_RANGE) || (defined(_WIN32) && (!defined(WINAPI_FAMILY) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)))
+ const bool llama_mlock::SUPPORTED = true;
+ #else
+ const bool llama_mlock::SUPPORTED = false;

--- a/patches/0001-uwp-appcontainer-guards.patch
+++ b/patches/0001-uwp-appcontainer-guards.patch
@@ -1,3 +1,37 @@
+diff --git a/ggml/src/ggml-backend-dl.cpp b/ggml/src/ggml-backend-dl.cpp
+index a65cf0090..82ae1a24c 100644
+--- a/ggml/src/ggml-backend-dl.cpp
++++ b/ggml/src/ggml-backend-dl.cpp
+@@ -2,6 +2,20 @@
+ 
+ #ifdef _WIN32
+ 
++#if defined(WINAPI_FAMILY) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
++
++// AppContainer (UWP/Xbox): SetErrorMode/SEM_FAILCRITICALERRORS are desktop-only
++// and error dialogs cannot appear anyway; only packaged DLLs are loadable.
++dl_handle * dl_load_library(const fs::path & path) {
++    return LoadPackagedLibrary(path.wstring().c_str(), 0);
++}
++
++void * dl_get_sym(dl_handle * handle, const char * name) {
++    return (void *) GetProcAddress(handle, name);
++}
++
++#else
++
+ dl_handle * dl_load_library(const fs::path & path) {
+     // suppress error dialogs for missing DLLs
+     DWORD old_mode = SetErrorMode(SEM_FAILCRITICALERRORS);
+@@ -25,6 +39,8 @@ void * dl_get_sym(dl_handle * handle, const char * name) {
+     return p;
+ }
+ 
++#endif // WINAPI_FAMILY app partition
++
+ const char * dl_error() {
+     return "";
+ }
 diff --git a/ggml/src/ggml-cpu/ggml-cpu.c b/ggml/src/ggml-cpu/ggml-cpu.c
 index cd5c61a81..5d550eafb 100644
 --- a/ggml/src/ggml-cpu/ggml-cpu.c

--- a/patches/0001-uwp-appcontainer-guards.patch
+++ b/patches/0001-uwp-appcontainer-guards.patch
@@ -1,0 +1,44 @@
+diff --git a/ggml/src/ggml-cpu/ggml-cpu.c b/ggml/src/ggml-cpu/ggml-cpu.c
+index cd5c61a81..5d550eafb 100644
+--- a/ggml/src/ggml-cpu/ggml-cpu.c
++++ b/ggml/src/ggml-cpu/ggml-cpu.c
+@@ -2489,9 +2489,17 @@ static bool ggml_thread_apply_affinity(bool * mask) {
+ 
+     DWORD_PTR m = (DWORD_PTR)bitmask;
+ 
++#if defined(WINAPI_FAMILY) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
++    // AppContainer (UWP/Xbox): SetThreadAffinityMask is unavailable; let the
++    // system scheduler place threads.
++    (void) h;
++    (void) m;
++    return true;
++#else
+     m = SetThreadAffinityMask(h, m);
+ 
+     return m != 0;
++#endif
+ }
+ 
+ static bool ggml_thread_apply_priority(int32_t prio) {
+@@ -2511,7 +2519,7 @@ static bool ggml_thread_apply_priority(int32_t prio) {
+         // Newer Windows 11 versions aggressively park (offline) CPU cores and often place
+         // all our threads onto the first 4 cores which results in terrible performance with
+         // n_threads > 4
+-        #if _WIN32_WINNT >= 0x0602
++        #if _WIN32_WINNT >= 0x0602 && (!defined(WINAPI_FAMILY) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))
+         THREAD_POWER_THROTTLING_STATE t;
+         ZeroMemory(&t, sizeof(t));
+         t.Version     = THREAD_POWER_THROTTLING_CURRENT_VERSION;
+diff --git a/ggml/src/ggml-cpu/ggml-cpu.cpp b/ggml/src/ggml-cpu/ggml-cpu.cpp
+index 128883b41..8496adb5c 100644
+--- a/ggml/src/ggml-cpu/ggml-cpu.cpp
++++ b/ggml/src/ggml-cpu/ggml-cpu.cpp
+@@ -318,7 +318,7 @@ struct ggml_backend_cpu_device_context {
+             }
+             fclose(f);
+         }
+-#elif defined(_WIN32)
++#elif defined(_WIN32) && (!defined(WINAPI_FAMILY) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP))
+         HKEY hKey;
+         if (RegOpenKeyEx(HKEY_LOCAL_MACHINE,
+                         TEXT("HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0"),

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,31 +1,27 @@
 # patches/
 
-Root-level placeholder. UWP-specific patches against the pinned `llama.cpp` submodule live in `uwp/patches/llama.cpp/`.
+UWP/AppContainer patches against the pinned `llama.cpp` submodule, used by the
+`llamacpp` build variant (`uwp/ggml-uwp.vcxproj`, `XLLAMA_USE_ORT=0`).
 
 ## Active patches
 
-Three patches are maintained in `uwp/patches/llama.cpp/`:
+| File                                 | Description                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `0001-uwp-appcontainer-guards.patch` | Guard the three Win32 desktop-only APIs with `WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)`: the registry CPU-name lookup (`ggml-cpu.cpp`), `SetThreadAffinityMask` (`ggml-cpu.c` — AppContainer falls back to the system scheduler), and `SetThreadInformation(ThreadPowerThrottling)` (`ggml-cpu.c`). |
 
-| File | Description |
-|------|-------------|
-| `0001-uwp-ggml-backend-dl-remove-winevt.patch` | Remove WinEvt dependency from ggml backend dynamic loading |
-| `0002-uwp-ggml-cpu-cpp-no-registry.patch` | Remove registry access in ggml CPU implementation |
-| `0003-uwp-ggml-cpu-c-no-thread-affinity-throttling.patch` | Remove thread affinity / throttling APIs blocked in UWP sandbox |
+Regenerated 2026-07-08 against submodule `9a532ae4b` (the three earlier per-file
+patches previously referenced here were stale and no longer existed on disk; the
+WinEvt / `dl_load_library` issue is avoided at build level instead — the UWP
+variant compiles the CPU backend statically, no dynamic backend loading).
 
 ## Applying
 
 ```bash
-./scripts/apply-uwp-patches.sh
+./scripts/apply-uwp-patches.sh   # idempotent; used by the llamacpp CI variant
 ```
 
-Or manually:
-```bash
-cd llama.cpp
-git apply ../uwp/patches/llama.cpp/*.patch
-```
+## Rebasing after a submodule bump
 
-## Status
-
-These patches are **not applied for the current UWP build** (which uses ORT GenAI, not llama.cpp). They are kept for any future evaluation of the llama.cpp path on UWP.
-
-The patches apply cleanly against the pinned submodule commit. If `llama.cpp` is updated, rebase them with `git am --rebase`.
+The patch is a plain `git diff`. If it no longer applies, redo the three guards
+by hand (they are one-liners plus a small `#if` block — see the patch body) and
+regenerate with `git -C llama.cpp diff > patches/0001-uwp-appcontainer-guards.patch`.

--- a/scripts/apply-uwp-patches.sh
+++ b/scripts/apply-uwp-patches.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# apply-uwp-patches.sh — apply the AppContainer guards to the llama.cpp submodule.
+#
+# The UWP (Xbox) build compiles ggml/llama sources directly (uwp/ggml-uwp.vcxproj);
+# three Win32 desktop-only APIs must be guarded with WINAPI_FAMILY_PARTITION so the
+# sources build and run inside the AppContainer (see patches/README.md).
+#
+# Idempotent: skips if the patch is already applied. Run from anywhere.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PATCH="$ROOT/patches/0001-uwp-appcontainer-guards.patch"
+
+cd "$ROOT/llama.cpp"
+if git apply --reverse --check "$PATCH" 2>/dev/null; then
+	echo "apply-uwp-patches: already applied — nothing to do."
+	exit 0
+fi
+git apply --check "$PATCH"
+git apply "$PATCH"
+echo "apply-uwp-patches: applied $(basename "$PATCH") to llama.cpp @ $(git rev-parse --short HEAD)"

--- a/scripts/build-uwp.ps1
+++ b/scripts/build-uwp.ps1
@@ -165,6 +165,17 @@ if ($NoBundledModel) {
 if ($Backend -eq "llamacpp") {
     Write-Host "Backend: llama.cpp CPU (XLLAMA_USE_ORT=0)"
     $MsBuildArgs += "/p:XllamaBackend=llamacpp"
+    # Pre-build the static ggml/llama lib explicitly: the solution maps it
+    # ActiveCfg-only (no Build.0 — the ORT variants must not compile it, the
+    # submodule may be absent there), so the solution build resolves the
+    # ProjectReference path but does not build the lib itself (LNK1181).
+    $GgmlProj = Join-Path $RepoRoot "uwp/ggml-uwp.vcxproj"
+    Write-Host "Pre-building ggml-uwp.vcxproj ($Configuration|$Platform) ..."
+    & $MsBuild $GgmlProj "/p:Configuration=$Configuration" "/p:Platform=$Platform" "/m" "/nologo"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "ggml-uwp build failed ($LASTEXITCODE)"
+        exit $LASTEXITCODE
+    }
 }
 
 $buildExitCode = 0

--- a/scripts/build-uwp.ps1
+++ b/scripts/build-uwp.ps1
@@ -29,7 +29,11 @@ param(
     [string]$Configuration  = "Release",
     [string]$Platform       = "x64",
     [switch]$ForceNewCert   = $false,
-    [switch]$NoBundledModel = $false
+    [switch]$NoBundledModel = $false,
+    # 'ort' (default) or 'llamacpp' (ggml/llama CPU backend, XLLAMA_USE_ORT=0;
+    # requires the llama.cpp submodule + scripts/apply-uwp-patches.sh).
+    [ValidateSet("ort", "llamacpp")]
+    [string]$Backend        = "ort"
 )
 
 $ErrorActionPreference = "Stop"
@@ -157,6 +161,10 @@ $MsBuildArgs = @(
 )
 if ($NoBundledModel) {
     $MsBuildArgs += "/p:XllamaNoBundledModel=true"
+}
+if ($Backend -eq "llamacpp") {
+    Write-Host "Backend: llama.cpp CPU (XLLAMA_USE_ORT=0)"
+    $MsBuildArgs += "/p:XllamaBackend=llamacpp"
 }
 
 $buildExitCode = 0

--- a/uwp/ggml-uwp.vcxproj
+++ b/uwp/ggml-uwp.vcxproj
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- =====================================================================
+       ggml-uwp — static, CPU-only build of ggml + llama for the AppContainer.
+       Compiled from the llama.cpp submodule sources (patched via
+       scripts/apply-uwp-patches.sh — three desktop-only APIs guarded, see
+       patches/README.md). No dynamic backend loading (the CPU backend is
+       registered statically via GGML_USE_CPU), no CUDA/Metal/DML — this is the
+       llama.cpp CPU A/B lane (ROADMAP Phase 3.5), built only when the app
+       project is invoked with /p:XllamaBackend=llamacpp.
+       ===================================================================== -->
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{B7E11D2A-4C63-4A0E-9D1F-2A6C58F0AA31}</ProjectGuid>
+    <RootNamespace>ggmluwp</RootNamespace>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
+    <AppContainerApplication>true</AppContainerApplication>
+    <ApplicationType>Windows Store</ApplicationType>
+    <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.19041.0</WindowsTargetPlatformMinVersion>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>
+        $(ProjectDir)..\llama.cpp\include;
+        $(ProjectDir)..\llama.cpp\src;
+        $(ProjectDir)..\llama.cpp\ggml\include;
+        $(ProjectDir)..\llama.cpp\ggml\src;
+        $(ProjectDir)..\llama.cpp\ggml\src\ggml-cpu;
+        %(AdditionalIncludeDirectories)
+      </AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>
+        NOMINMAX;
+        WIN32_LEAN_AND_MEAN;
+        _CRT_SECURE_NO_WARNINGS;
+        GGML_USE_CPU;
+        GGML_STATIC;
+        GGML_VERSION=&quot;uwp-static&quot;;
+        GGML_COMMIT=&quot;9a532ae4b&quot;;
+        %(PreprocessorDefinitions)
+      </PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <!-- Not C++/CX; pure C and C++ sources. -->
+      <CompileAsWinRT>false</CompileAsWinRT>
+      <!-- Preserve directory structure in .obj paths: ggml-cpu\quants.c and
+           ggml-cpu\arch\x86\quants.c (and repack.cpp) share basenames. -->
+      <ObjectFileName>$(IntDir)%(RelativeDir)</ObjectFileName>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <AdditionalOptions>/utf-8 /bigobj %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <!-- AVX2 for Zen 2 (Xbox Series S CPU) — mirrors the main project. -->
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <AdditionalOptions>/arch:AVX2 /Oi /Ot /utf-8 /bigobj %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <!-- ggml core -->
+  <ItemGroup>
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml.c" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml.cpp" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-alloc.c" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-backend.cpp" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-backend-dl.cpp" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-backend-meta.cpp" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-backend-reg.cpp" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-opt.cpp" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-quants.c" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-threading.cpp" />
+    <ClCompile Include="..\llama.cpp\ggml\src\gguf.cpp" />
+  </ItemGroup>
+
+  <!-- ggml CPU backend (+ x86 arch kernels; AMX/KleidiAI/SpacemiT/llamafile excluded) -->
+  <ItemGroup>
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-cpu\binary-ops.cpp" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-cpu\ggml-cpu.c" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-cpu\ggml-cpu.cpp" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-cpu\hbm.cpp" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-cpu\ops.cpp" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-cpu\quants.c" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-cpu\repack.cpp" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-cpu\traits.cpp" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-cpu\unary-ops.cpp" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-cpu\vec.cpp" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-cpu\arch\x86\cpu-feats.cpp" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-cpu\arch\x86\quants.c" />
+    <ClCompile Include="..\llama.cpp\ggml\src\ggml-cpu\arch\x86\repack.cpp" />
+  </ItemGroup>
+
+  <!-- llama -->
+  <ItemGroup>
+    <ClCompile Include="..\llama.cpp\src\llama.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-adapter.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-arch.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-batch.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-chat.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-context.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-cparams.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-grammar.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-graph.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-hparams.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-impl.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-io.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-kv-cache.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-kv-cache-iswa.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-memory.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-memory-hybrid.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-memory-hybrid-iswa.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-memory-recurrent.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-mmap.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-model.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-model-loader.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-model-saver.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-quant.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-sampler.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-vocab.cpp" />
+    <ClCompile Include="..\llama.cpp\src\unicode.cpp" />
+    <ClCompile Include="..\llama.cpp\src\unicode-data.cpp" />
+  </ItemGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/uwp/xllama.sln
+++ b/uwp/xllama.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "xllama", "xllama.vcxproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ggml-uwp", "ggml-uwp.vcxproj", "{B7E11D2A-4C63-4A0E-9D1F-2A6C58F0AA31}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Release|x64 = Release|x64
@@ -15,6 +17,8 @@ Global
         {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|x64.Build.0 = Release|x64
         {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.ActiveCfg = Debug|x64
         {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|x64.Build.0 = Debug|x64
+        {B7E11D2A-4C63-4A0E-9D1F-2A6C58F0AA31}.Release|x64.ActiveCfg = Release|x64
+        {B7E11D2A-4C63-4A0E-9D1F-2A6C58F0AA31}.Debug|x64.ActiveCfg = Debug|x64
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/uwp/xllama.vcxproj
+++ b/uwp/xllama.vcxproj
@@ -281,10 +281,15 @@
     </None>
   </ItemGroup>
 
-  <!-- llama.cpp CPU backend (llamacpp variant only) -->
+  <!-- llama.cpp CPU backend (llamacpp variant only). ggml-uwp.vcxproj is not a
+       solution member, so the solution's project-configuration mapping does not
+       cover it — without SetConfiguration/SetPlatform the reference builds as
+       the MSBuild default Debug|Win32 (MSB8013). -->
   <ItemGroup Condition="'$(XllamaBackend)' == 'llamacpp'">
     <ProjectReference Include="ggml-uwp.vcxproj">
       <Project>{B7E11D2A-4C63-4A0E-9D1F-2A6C58F0AA31}</Project>
+      <SetConfiguration>Configuration=$(Configuration)</SetConfiguration>
+      <SetPlatform>Platform=$(Platform)</SetPlatform>
     </ProjectReference>
   </ItemGroup>
 

--- a/uwp/xllama.vcxproj
+++ b/uwp/xllama.vcxproj
@@ -35,6 +35,16 @@
     <WindowsTargetPlatformMinVersion>10.0.19041.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
 
+  <!-- Backend selection: 'ort' (default, ORT GenAI text inference) or 'llamacpp'
+       (ggml/llama CPU backend from the submodule, XLLAMA_USE_ORT=0 — the CPU A/B
+       lane; requires the submodule checked out + scripts/apply-uwp-patches.sh).
+       Plain ORT (image spike, diffusion) stays linked in both. -->
+  <PropertyGroup>
+    <XllamaBackend Condition="'$(XllamaBackend)' == ''">ort</XllamaBackend>
+    <XllamaUseOrt Condition="'$(XllamaBackend)' == 'llamacpp'">0</XllamaUseOrt>
+    <XllamaUseOrt Condition="'$(XllamaUseOrt)' == ''">1</XllamaUseOrt>
+  </PropertyGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
 
   <!-- =====================================================================
@@ -95,6 +105,8 @@
         $(ProjectDir)Generated Files;
         $(IntDir)Generated Files;
         $(ProjectDir)..\include;
+        $(ProjectDir)..\llama.cpp\include;
+        $(ProjectDir)..\llama.cpp\ggml\include;
         $(ProjectDir)packages\Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.14.1\build\native\include;
         $(ProjectDir)packages\Microsoft.ML.OnnxRuntime.DirectML.1.24.4\build\native\include;
         %(AdditionalIncludeDirectories)
@@ -104,7 +116,7 @@
         WIN32_LEAN_AND_MEAN;
         _CRT_SECURE_NO_WARNINGS;
         XLLAMA_UWP=1;
-        XLLAMA_USE_ORT=1;
+        XLLAMA_USE_ORT=$(XllamaUseOrt);
         %(PreprocessorDefinitions)
       </PreprocessorDefinitions>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -267,6 +279,13 @@
       <DeploymentContent>true</DeploymentContent>
       <TargetPath>models\manifest.json</TargetPath>
     </None>
+  </ItemGroup>
+
+  <!-- llama.cpp CPU backend (llamacpp variant only) -->
+  <ItemGroup Condition="'$(XllamaBackend)' == 'llamacpp'">
+    <ProjectReference Include="ggml-uwp.vcxproj">
+      <Project>{B7E11D2A-4C63-4A0E-9D1F-2A6C58F0AA31}</Project>
+    </ProjectReference>
   </ItemGroup>
 
   <!-- xllama shared bridge -->


### PR DESCRIPTION
The llama.cpp **CPU A/B lane** (ROADMAP Phase 3.5: the only remaining decode lever after §12 killed int4-DML; target ~2× over ORT's AVX2 `MatMulNBits` → ~130 tok/s at 360M).

- **`patches/0001-uwp-appcontainer-guards.patch`** (regenerated against submodule `9a532ae4b` — the three per-file patches the old README referenced no longer existed on disk): `WINAPI_FAMILY_PARTITION` guards for the registry CPU-name lookup, `SetThreadAffinityMask` (AppContainer → system scheduler), `ThreadPowerThrottling`. `scripts/apply-uwp-patches.sh` is idempotent; patch verified to apply/reverse cleanly.
- **`uwp/ggml-uwp.vcxproj`**: static AppContainer lib — ggml core + CPU backend (+ x86 arch kernels; AMX/KleidiAI/SpacemiT/llamafile excluded) + the 27 llama sources. AVX2 (`/arch:AVX2`, Zen 2), static backend registration (`GGML_USE_CPU`, no `dl_load_library`), per-directory obj names (`quants.c`/`repack.cpp` basename collisions).
- **`uwp/xllama.vcxproj`**: new `XllamaBackend` property (`ort` default | `llamacpp`); `XLLAMA_USE_ORT` follows it; conditional `ProjectReference`. **Plain ORT (image spike, diffusion) stays linked in both variants** — a llamacpp MSIX still generates images on the GPU.
- **CI**: new `llamacpp` matrix variant (nobundle; checks out the submodule + applies the patch) → `xllama-appx-llamacpp` artifact.

The bridge's `XLLAMA_USE_ORT=0` path (`src/bridge/session.cpp`) already compiles against this exact submodule on Linux CI; this lane validates it under MSVC/UWP. Expect CI iteration on the ggml source set — that's the purpose of the lane.

Console next (after green): upload a SmolLM2-360M `Q4_K_M` GGUF + `bench.flag` → decode A/B vs ORT 66.3 tok/s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)