### PR TITLE
fix(models): drop nonexistent special_tokens_map.json from the catalogue

### DIFF
--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -10,7 +10,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="0.4.3.0"
+    Version="0.4.4.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity

--- a/uwp/model-downloader.cpp
+++ b/uwp/model-downloader.cpp
@@ -276,10 +276,13 @@ std::vector<ManifestEntry> LoadModelManifest() {
     e.display = L"SmolLM2 360M (CPU int4)";
     e.hf_base_url = L"https://huggingface.co/homen3/"
                     L"SmolLM2-360M-Instruct-ort-genai-int4-cpu/resolve/main";
+    // NOTE: no special_tokens_map.json — the HF repo does not have one (the old
+    // hardcoded list requested it and got HTTP 404, breaking every download).
     e.files = {
-        {L"genai_config.json", 2'000},     {L"tokenizer.json", 2'400'000},
-        {L"tokenizer_config.json", 3'000}, {L"special_tokens_map.json", 1'000},
-        {L"model.onnx", 422'000'000},
+        {L"genai_config.json", 2'000},
+        {L"tokenizer.json", 3'600'000},
+        {L"tokenizer_config.json", 1'000},
+        {L"model.onnx", 417'404'408},
     };
     return {e};
 }

--- a/uwp/models/manifest.json
+++ b/uwp/models/manifest.json
@@ -6,11 +6,22 @@
       "display": "SmolLM2 360M (CPU int4)",
       "hf_base_url": "https://huggingface.co/homen3/SmolLM2-360M-Instruct-ort-genai-int4-cpu/resolve/main",
       "files": [
-        { "filename": "genai_config.json", "approx_bytes": 2000 },
-        { "filename": "tokenizer.json", "approx_bytes": 2400000 },
-        { "filename": "tokenizer_config.json", "approx_bytes": 3000 },
-        { "filename": "special_tokens_map.json", "approx_bytes": 1000 },
-        { "filename": "model.onnx", "approx_bytes": 422000000 }
+        {
+          "filename": "genai_config.json",
+          "approx_bytes": 1456
+        },
+        {
+          "filename": "tokenizer.json",
+          "approx_bytes": 3522871
+        },
+        {
+          "filename": "tokenizer_config.json",
+          "approx_bytes": 453
+        },
+        {
+          "filename": "model.onnx",
+          "approx_bytes": 417404408
+        }
       ]
     },
     {


### PR DESCRIPTION
The nobundle console validation (Exp 2) surfaced that the **HF auto-download was broken from the start**:

1. The file list requested `special_tokens_map.json`, which **does not exist** in the homen3 repo → HTTP 404 aborts the download after `tokenizer_config.json` (silent in the log; visible only in the UI status).
2. The repo's `model.onnx` is a 238 KB stub with 418 MB external data (`model.onnx.data`) — even a successful download would produce a model the AppContainer cannot load (§8 `weakly_canonical`).

This PR fixes the **client half**: catalogue + built-in fallback list now match the repo's real files with real sizes. The **repo half** (uploading a merged self-contained `model.onnx`, 417 404 408 bytes, already prepared and verified locally) needs HF write credentials — pending.

The validation session that caught this is exactly what Exp 2 was for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)