### PR TITLE
chore: bump 0.4.5.0

### DIFF
--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -10,7 +10,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="0.4.4.0"
+    Version="0.4.5.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity


### PR DESCRIPTION
Version bump for the llamacpp bench console deploy (0.4.4.0 is already installed; a same-version reinstall purges LocalState — 2.4 GB of models).

🤖 Generated with [Claude Code](https://claude.com/claude-code)