### PR TITLE
fix(llamacpp): tokenize size-query returns a negated count, not an error

### DIFF
--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -5,6 +5,7 @@
 #include "xllama/path_utils.h"
 #include "xllama/platform.h"
 
+#include <cstdint>
 #include <cstdio>
 #include <string>
 
@@ -276,11 +277,16 @@ InferenceResult run_inference(const InferenceParams& params) {
     int32_t n_tokens =
         llama_tokenize(vocab, params.prompt.c_str(), static_cast<int32_t>(params.prompt.size()),
                        nullptr, 0, true, false);
-    if (n_tokens < 0) {
-        res.error_msg = "tokenization size query failed";
-        log_output("[xllama] tokenization size query failed\n");
+    if (n_tokens == INT32_MIN) {
+        res.error_msg = "tokenization overflow";
+        log_output("[xllama] tokenization overflow\n");
         return res;
     }
+    // Size query with a null buffer returns the NEGATED required token count
+    // (llama.h: "Returns a negative number on failure - the number of tokens
+    // that would have been returned"). Negative here is the expected answer,
+    // not an error.
+    n_tokens = -n_tokens;
 
     std::vector<llama_token> tokens(static_cast<size_t>(n_tokens));
     n_tokens =

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <string>
 
 // ---------------------------------------------------------------------------
@@ -343,10 +344,12 @@ class LlamaSession final : public Session {
         int32_t n_tokens =
             llama_tokenize(vocab, gp.prompt.c_str(), static_cast<int32_t>(gp.prompt.size()),
                            nullptr, 0, true, false);
-        if (n_tokens < 0) {
-            res.error_msg = "tokenize size failed";
+        if (n_tokens == INT32_MIN) {
+            res.error_msg = "tokenize overflow";
             return res;
         }
+        // Size query returns the negated required count (see llama.h) — not an error.
+        n_tokens = -n_tokens;
 
         std::vector<llama_token> tokens(static_cast<size_t>(n_tokens));
         n_tokens = llama_tokenize(vocab, gp.prompt.c_str(), static_cast<int32_t>(gp.prompt.size()),

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -10,7 +10,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="0.4.5.0"
+    Version="0.4.6.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity


### PR DESCRIPTION
First on-console run of the llama backend died at `tokenization size query failed`: `llama_tokenize(nullptr, 0)` returns the **negated required token count** by contract (llama.h), and both bridge call sites treated any negative as fatal. Negated back; `INT32_MIN` kept as a real overflow error.

**Validated locally end-to-end**: the Linux CLI (same code path, same submodule) loads the SmolLM2-360M Q4_K_M GGUF and answers a ChatML prompt correctly ("The capital of France is Paris."). Bump 0.4.6.0 for the console redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)