### PR TITLE
feat(llamacpp): own chrono telemetry in the llama path

### DIFF
--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -5,6 +5,7 @@
 #include "xllama/path_utils.h"
 #include "xllama/platform.h"
 
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <string>
@@ -299,12 +300,17 @@ InferenceResult run_inference(const InferenceParams& params) {
     }
     tokens.resize(static_cast<size_t>(n_tokens));
 
+    log_output(("[xllama] prompt tokens: " + std::to_string(tokens.size()) + "\n").c_str());
+    const auto t_prompt0 = std::chrono::steady_clock::now();
     llama_batch batch = llama_batch_get_one(tokens.data(), static_cast<int32_t>(tokens.size()));
     if (llama_decode(ctx.get(), batch) != 0) {
         res.error_msg = "prompt decode failed";
         log_output("[xllama] prompt decode failed\n");
         return res;
     }
+    const double prompt_ms =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_prompt0)
+            .count();
 
     const llama_sampler_chain_params sparams = llama_sampler_chain_default_params();
     LlamaSamplerPtr sampler(llama_sampler_chain_init(sparams));
@@ -312,13 +318,16 @@ InferenceResult run_inference(const InferenceParams& params) {
     llama_sampler_chain_add(sampler.get(), llama_sampler_init_dist(params.seed));
 
     int n_generated = 0;
+    const auto t_gen0 = std::chrono::steady_clock::now();
     while (n_generated < params.n_predict) {
         if (params.abort_flag && params.abort_flag->load())
             break;
 
         llama_token token = llama_sampler_sample(sampler.get(), ctx.get(), -1);
-        if (llama_vocab_is_eog(vocab, token))
+        if (llama_vocab_is_eog(vocab, token)) {
+            log_output(("[xllama] EOG after " + std::to_string(n_generated) + " tokens\n").c_str());
             break;
+        }
 
         char buf[256] = {};
         int len = llama_token_to_piece(vocab, token, buf, sizeof(buf) - 1, 0, false);
@@ -341,11 +350,16 @@ InferenceResult run_inference(const InferenceParams& params) {
 
     std::fputc('\n', stdout);
 
+    const double gen_ms =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_gen0)
+            .count();
+    // Own chrono timing: llama_context_default_params().no_perf disables the
+    // built-in perf counters, so llama_perf_context reports zeros by default.
     llama_perf_context_data perf = llama_perf_context(ctx.get());
-    res.t_load_ms = perf.t_load_ms;
-    res.t_p_eval_ms = perf.t_p_eval_ms;
-    res.t_eval_ms = perf.t_eval_ms;
-    res.n_p_eval = perf.n_p_eval;
+    res.t_load_ms = perf.t_load_ms > 0 ? perf.t_load_ms : 0.0;
+    res.t_p_eval_ms = prompt_ms;
+    res.t_eval_ms = gen_ms;
+    res.n_p_eval = static_cast<int32_t>(tokens.size());
     res.n_eval = n_generated;
     res.peak_ws_mb = peak_working_set_mb();
     res.success = true;

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -10,7 +10,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="0.4.6.0"
+    Version="0.4.7.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity


### PR DESCRIPTION
no_perf (default) hides llama's perf counters → CSV showed 0.0 tok/s even on success. Own steady_clock timing (like the ORT path) + prompt-token/EOG logs. Validated on the Linux CLI (212/34.2 tok/s @8t on dev machine). Bump 0.4.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inference timing and logging for non-ORT runs, including clearer prompt token counts and generation stop details.
  * Updated recorded timing values so performance metrics better reflect actual prompt processing and generation time.
* **Chores**
  * Bumped the app package version to `0.4.7.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->