### PR TITLE
feat(models): self-hosted distribution via GitHub Release; drop the MSIX bundle

### DIFF
--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -12,51 +12,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # bundled: MSIX with SmolLM2 model in InstalledPath (default artifact).
-        # nobundle: MSIX without the model — EnsureModelAsync must reach the
-        # USB/HF-download fallbacks; used to validate Exp 2 on console.
-        # llamacpp: nobundle MSIX with the ggml/llama CPU text backend
-        # (XLLAMA_USE_ORT=0) — the CPU A/B lane; needs the submodule + patches.
-        variant: [bundled, nobundle, llamacpp]
+        # default: MSIX without a bundled model — models are downloaded on first
+        # launch from the catalogue (Exp 2 validated on console 2026-07-08).
+        # llamacpp: same, with the ggml/llama CPU text backend (XLLAMA_USE_ORT=0)
+        # — the CPU A/B lane; needs the submodule + patches.
+        variant: [default, llamacpp]
     steps:
       - uses: actions/checkout@v6
         with:
           # llama.cpp submodule not needed for UWP ORT build; skip to save ~40s
           submodules: false
           fetch-depth: 1
-
-      - name: Cache SmolLM2-360M ONNX INT4 model (embedded)
-        if: matrix.variant == 'bundled'
-        id: cache-model
-        uses: actions/cache@v4
-        with:
-          path: models/smollm2-360m-cpu-int4
-          key: smollm2-360m-ort-genai-int4-cpu-embedded-v1
-
-      - name: Download SmolLM2-360M ONNX INT4 model
-        if: matrix.variant == 'bundled' && steps.cache-model.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: |
-          python -m pip install --quiet huggingface_hub
-          python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='homen3/SmolLM2-360M-Instruct-ort-genai-int4-cpu', local_dir='models/smollm2-360m-cpu-int4'); print('Download complete')"
-
-      - name: Merge ONNX external data into model.onnx
-        # ORT's ValidateExternalDataPath calls weakly_canonical() which walks path segments
-        # from the root. On Xbox AppContainer the intermediate Q:\Users\UserMgr0 segment is
-        # inaccessible, causing "Access is denied". Merging model.onnx.data into model.onnx
-        # makes the model self-contained so ValidateExternalDataPath is never called.
-        if: matrix.variant == 'bundled' && steps.cache-model.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: |
-          python -m pip install --quiet onnx
-          python scripts/merge_onnx_external_data.py models/smollm2-360m-cpu-int4
-
-      - name: Checkout llama.cpp submodule + apply AppContainer guards
-        if: matrix.variant == 'llamacpp'
-        shell: bash
-        run: |
-          git submodule update --init --depth 1 llama.cpp
-          bash scripts/apply-uwp-patches.sh
 
       - name: Restore NuGet packages
         shell: pwsh
@@ -69,13 +35,12 @@ jobs:
         # cached model directory existed, the MSBuild property excludes it.
         run: >-
           ./scripts/build-uwp.ps1 -Configuration Release -Platform x64
-          -NoBundledModel:$('${{ matrix.variant }}' -ne 'bundled')
           -Backend $('${{ matrix.variant }}' -eq 'llamacpp' ? 'llamacpp' : 'ort')
 
       - uses: actions/upload-artifact@v7
         if: success()
         with:
-          name: xllama-appx${{ matrix.variant != 'bundled' && format('-{0}', matrix.variant) || '' }}
+          name: xllama-appx${{ matrix.variant == 'llamacpp' && '-llamacpp' || '' }}
           # Include .msix (main package), .appx (VCLibs deps), and .cer
           # (public key of the test certificate that must be trusted on the
           # Xbox before deploying — installed via Device Portal API).

--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -24,6 +24,13 @@ jobs:
           submodules: false
           fetch-depth: 1
 
+      - name: Checkout llama.cpp submodule + apply AppContainer guards
+        if: matrix.variant == 'llamacpp'
+        shell: bash
+        run: |
+          git submodule update --init --depth 1 llama.cpp
+          bash scripts/apply-uwp-patches.sh
+
       - name: Restore NuGet packages
         shell: pwsh
         working-directory: uwp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Measured — in-app model download validated end-to-end on console (Exp 2 ✅)
+
+The nobundle app on the Xbox downloaded the full SmolLM2-360M model (4 files,
+417 MB merged `model.onnx`) from the **GitHub Release catalogue** inside the
+AppContainer — `[manifest] using LocalState\manifest.json override` → all files
+byte-exact on device → `.complete` written. Distribution is now self-hosted:
+
+- **`models-v1` GitHub Release** carries the merged, AppContainer-safe model
+  assets (the upstream HF repo ships a non-merged `model.onnx` stub + external
+  data that §8 cannot load — that path stays broken upstream and is no longer
+  referenced).
+- `uwp/models/manifest.json` and the built-in fallback now point at the release
+  URL; the LocalState manifest override was exactly the mechanism used to
+  validate before flipping the default.
+- **The MSIX no longer bundles a model** (ROADMAP Phase 4 milestone): first
+  launch downloads from the catalogue; USB/Device-Portal provisioning unchanged.
+  CI matrix simplified to `default` (nobundle) + `llamacpp`; the `xllama-appx`
+  artifact is now the 19 MB no-model package.
+
+### Measured — diffusion steps/seed plumbing on console
+
+`diffuse-steps.txt=2` / `diffuse-seed.txt=777` with a new prompt produced a
+coherent new 512×512 image in **7.7 s** (UNet 2.08 s/step ×2 — per-step cost
+scales as expected; te/vae unchanged).
+
+
 ### Measured — llama.cpp CPU A/B on console: parity, not 2× (hypothesis falsified)
 
 llama.cpp **runs on the Xbox in AppContainer** (first time): static ggml+llama

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -196,9 +196,9 @@ Milestones:
 - [x] `EnsureModelAsync()` bootstrap: LocalState → InstalledPath → HF download fallback chain
 - [x] USB external drive fallback at `E:\xllama\models\<name>` in `resolve_model_path` (Exp 3)
 - [x] No-bundle build variant to unblock Exp 2: `build-uwp.ps1 -NoBundledModel` (MSBuild `XllamaNoBundledModel=true` excludes the model ItemGroup); CI publishes `xllama-appx-nobundle` alongside `xllama-appx`
-- [ ] Validate Exp 2 on console: deploy the `xllama-appx-nobundle` MSIX, confirm HF HTTPS download works from Xbox AppContainer
-- [ ] Remove model bundle from MSIX once Exp 2 is validated (delete ItemGroup in `xllama.vcxproj`)
-- [ ] `model-manifest.json`: configurable model list (HF repo + file list) for model switching
+- [x] Validate Exp 2 on console — ✅ 2026-07-08: the nobundle app downloaded the full model (417 MB merged) from the GitHub Release catalogue inside the AppContainer, byte-exact, `.complete` written. (The upstream HF repo turned out to ship a non-merged model.onnx + a file list with a nonexistent entry — the download had been broken from the start; distribution moved to Release assets.)
+- [x] Remove model bundle from MSIX — ✅ 2026-07-08 (ItemGroup deleted; CI matrix simplified to default+llamacpp; `xllama-appx` is now the 19 MB no-model package)
+- [x] `model-manifest.json` — ✅ 2026-07-08 (`uwp/models/manifest.json` catalogue + LocalState override; ComboBox and downloader de-hardcoded)
 - [ ] Demo video: model loaded and running on Xbox hardware
 - [ ] Technical report (arXiv or GitHub Discussions)
 - [ ] Tagged v1.0.0 release with pre-built MSIX and model manifest

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -10,7 +10,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="0.4.7.0"
+    Version="0.4.8.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity

--- a/uwp/model-downloader.cpp
+++ b/uwp/model-downloader.cpp
@@ -274,8 +274,8 @@ std::vector<ManifestEntry> LoadModelManifest() {
     ManifestEntry e;
     e.name = L"smollm2-360m-cpu-int4";
     e.display = L"SmolLM2 360M (CPU int4)";
-    e.hf_base_url = L"https://huggingface.co/homen3/"
-                    L"SmolLM2-360M-Instruct-ort-genai-int4-cpu/resolve/main";
+    e.hf_base_url = L"https://github.com/gianlucamazza/xllama/"
+                    L"releases/download/models-v1";
     // NOTE: no special_tokens_map.json — the HF repo does not have one (the old
     // hardcoded list requested it and got HTTP 404, breaking every download).
     e.files = {

--- a/uwp/models/manifest.json
+++ b/uwp/models/manifest.json
@@ -4,7 +4,7 @@
     {
       "name": "smollm2-360m-cpu-int4",
       "display": "SmolLM2 360M (CPU int4)",
-      "hf_base_url": "https://huggingface.co/homen3/SmolLM2-360M-Instruct-ort-genai-int4-cpu/resolve/main",
+      "hf_base_url": "https://github.com/gianlucamazza/xllama/releases/download/models-v1",
       "files": [
         {
           "filename": "genai_config.json",

--- a/uwp/xllama.vcxproj
+++ b/uwp/xllama.vcxproj
@@ -259,18 +259,9 @@
     </None>
   </ItemGroup>
 
-  <!-- SmolLM2-360M-Instruct INT4 CPU model bundled in MSIX (403 MB on-disk).
-       Files land in Package.InstalledPath\models\smollm2-360m-cpu-int4\
-       which is the fallback path in resolve_model_path() when LocalState has no model.
-       Exists() guards local builds where the model hasn't been generated yet.
-       XllamaNoBundledModel=true (build-uwp.ps1 -NoBundledModel) excludes the bundle
-       so EnsureModelAsync reaches the USB/HF-download fallbacks (Exp 2 validation). -->
-  <ItemGroup Condition="Exists('..\models\smollm2-360m-cpu-int4') And '$(XllamaNoBundledModel)' != 'true'">
-    <None Include="..\models\smollm2-360m-cpu-int4\*">
-      <DeploymentContent>true</DeploymentContent>
-      <TargetPath>models\smollm2-360m-cpu-int4\%(Filename)%(Extension)</TargetPath>
-    </None>
-  </ItemGroup>
+  <!-- No model is bundled in the MSIX (Exp 2 validated 2026-07-08): the app
+       downloads models on first launch from the catalogue (models/manifest.json,
+       GitHub Release assets) or accepts USB/Device-Portal provisioning. -->
 
   <!-- Model catalogue: always bundled (both variants) at InstalledPath\models\manifest.json.
        A LocalState\manifest.json uploaded via Device Portal overrides it (see


### PR DESCRIPTION
## Exp 2 — VALIDATED on console ✅

The nobundle app downloaded the **full SmolLM2-360M model (417 MB merged `model.onnx`, 4 files, byte-exact)** from the [`models-v1` GitHub Release](https://github.com/gianlucamazza/xllama/releases/tag/models-v1) **inside the AppContainer**, driven by the manifest catalogue:

```
[manifest] using LocalState\manifest.json override
[downloader] genai_config.json done … tokenizer.json … tokenizer_config.json …
[downloader] model.onnx done (420929188 bytes total) → .complete
```

The LocalState manifest override was exactly the validation mechanism before flipping the repo default.

## Changes

- `manifest.json` + built-in fallback → **release URL** (the upstream HF repo ships a non-merged `model.onnx` stub + external data that §8 cannot load — the old path was broken from day one and is no longer referenced).
- **MSIX bundle removed** (ROADMAP Phase 4 milestone): first launch downloads from the catalogue; USB/WDP provisioning unchanged.
- CI matrix simplified: `default` (no model) + `llamacpp`; the `xllama-appx` artifact is now the ~19 MB package.
- Bonus measured: `diffuse-steps/seed` plumbing on console — 2 steps, new seed → new coherent 512² image in 7.7 s (2.08 s/UNet-step).

Bump 0.4.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now downloads its model on first launch from an online catalogue instead of relying on a bundled model.
  * Added support for alternative model source locations, including release-based downloads.

* **Bug Fixes**
  * Improved model setup reliability for first-time app launches.
  * Updated packaging so the app installs smaller and completes model setup separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->