### PR TITLE
feat(diffusion): in-process experiment flag + progress/cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-_(nothing yet)_
+### Added — in-process diffusion experiment (`diffuse-inproc.flag`)
+
+The 887A0036 device conflict (§7) was measured with ORT **GenAI**'s
+Agility-factory device; the diffusion pipeline uses **plain ORT DML**, which may
+coexist with the XAML compositor device. `diffuse-inproc.flag` runs
+`run_diffuse()` on a background MTA thread inside the live XAML process to
+falsify the inherited headless requirement. If it passes on console, image
+generation becomes in-app — no restart flow. Runbook §7b; on-console validation
+pending.
+
+### Added — diffusion progress + cancellation
+
+`diffuse-progress.txt` reports the live stage (`start` / `text_encoder` /
+`unet s/N` / `vae` / `done` / `cancelled` / `error`); `diffuse-cancel.flag`
+(consumed) aborts between UNet steps. Works in both the headless and the
+in-process paths; stale `.done`/cancel artifacts are cleared at run start.
 
 ## [1.0.0] - 2026-07-08
 
@@ -43,7 +58,6 @@ byte-exact on device → `.complete` written. Distribution is now self-hosted:
 coherent new 512×512 image in **7.7 s** (UNet 2.08 s/step ×2 — per-step cost
 scales as expected; te/vae unchanged).
 
-
 ### Measured — llama.cpp CPU A/B on console: parity, not 2× (hypothesis falsified)
 
 llama.cpp **runs on the Xbox in AppContainer** (first time): static ggml+llama
@@ -70,7 +84,6 @@ lane (`uwp/ggml-uwp.vcxproj`, `patches/0001-uwp-appcontainer-guards.patch`, CI
   hid all timings (own chrono now, like the ORT path); ggml.c/ggml.cpp and
   ggml-cpu.c/.cpp same-dir obj collisions silently dropped every C symbol; the
   128 `src/models/*.cpp` per-arch files were missing from the static lib.
-
 
 ### Measured — image generation on console (v0.4.2.0, 2026-07-08) 🎨
 

--- a/docs/console-validation-runbook.md
+++ b/docs/console-validation-runbook.md
@@ -216,6 +216,24 @@ done
 - If the image is noise, check the log for a tokenizer/model-shape mismatch (non-fp16
   model, `hidden_dim` ≠ 1024, wrong scheduler class).
 
+### 7b. In-process experiment (`diffuse-inproc.flag`) — PENDING
+
+Falsification run for `docs/uwp-constraints.md` §7 "Open experiment": does plain ORT DML
+coexist with the XAML compositor device? Same inputs as §7, but write
+`diffuse-inproc.flag` **instead of** `diffuse.flag`, then `deploy.sh start-app` — the app
+starts the normal XAML UI and runs the pipeline on a background thread in the same
+process.
+
+- Poll `diffuse-progress.txt` (`start` → `text_encoder` → `unet s/N` → `vae` → `done`);
+  `diffuse-cancel.flag` aborts between UNet steps (progress `cancelled`).
+- **PASS**: log shows `diffuse-inproc.flag detected` + per-stage ms + `wrote
+diffuse-out.png` with the XAML window still up; PNG matches the §7 headless output for
+  the same prompt/seed/steps.
+- **FAIL**: `diffuse: ORT error: ... 887A0036` (device conflict also affects plain ORT —
+  the headless flow stays) or `8007000E` during VAE (GPU budget with compositor:
+  headroom, not device, is the blocker).
+- Either outcome: record it in `docs/uwp-constraints.md` §7 and close the experiment.
+
 ## Closeout
 
 For each step: append the median CSV row under `bench/results/`, flip the matching

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -179,6 +179,18 @@ GenAI release, the interactive (XAML) app can use DML without the headless
 path — practically relevant only if a larger model ever makes DML
 competitive (CPU is 8× faster at 360M scale).
 
+**Open experiment — plain ORT DML in the XAML process (`diffuse-inproc.flag`)**:
+the conflict above was measured with **ORT GenAI**, whose DML EP goes through the
+Agility device factory. The diffusion pipeline (`uwp/diffuse.cpp`) uses **plain
+ORT DirectML** (`OrtSessionOptionsAppendExecutionProvider_DML`, ORT 1.24.4) —
+potentially the same plain-`D3D12CreateDevice` path that coexisted with the
+compositor in Exp 1. The headless requirement for diffusion was inherited from
+the GenAI finding, never falsified for plain ORT. `diffuse-inproc.flag`
+(`App.cpp`) runs `run_diffuse()` on a background MTA thread inside the live XAML
+process to test exactly that. If it holds, image generation becomes in-app (no
+restart flow); watch GPU headroom — compositor + 2.4 GB of sequential-lifetime
+weights inside the 3801 MB budget. **Pending console run.**
+
 **Diagnosis**: SEH `0xC0000005` in `OgaCreateModel`. WDP minidump (`type=2`) and the `xllama.log` entry `OgaCreateModel failed: ...` confirm the cause.
 
 **Source note**: the GPU budget (3801 MB) is measured per-process via

--- a/uwp/App.cpp
+++ b/uwp/App.cpp
@@ -14,6 +14,10 @@
 
     #include <thread>
 
+// Defined in the headless section below; also used by the in-process
+// diffusion experiment in App::OnLaunched.
+static std::wstring flag_path_if_present(const wchar_t* name);
+
 using namespace winrt;
 using namespace winrt::Windows::ApplicationModel::Activation;
 using namespace winrt::Windows::UI::Xaml;
@@ -105,6 +109,25 @@ void App::OnLaunched(LaunchActivatedEventArgs const&) {
         log_write("[xllama] Window.Content set\n");
         Window::Current().Activate();
         log_write("[xllama] Window activated\n");
+
+        // §7 experiment: the 887A0036 device conflict was measured with ORT
+        // GenAI's Agility-factory device; diffuse.cpp uses plain ORT DML, whose
+        // device may coexist with the compositor device the line above just
+        // created. diffuse-inproc.flag runs the diffusion pipeline on a
+        // background MTA thread INSIDE the XAML process to test exactly that.
+        // Consumed before the run, same semantics as the headless flags.
+        std::wstring inproc = flag_path_if_present(L"diffuse-inproc.flag");
+        if (!inproc.empty()) {
+            _wremove(inproc.c_str());
+            log_write("[xllama] diffuse-inproc.flag detected -> in-process diffusion "
+                      "(compositor alive)\n");
+            std::thread([] {
+                winrt::init_apartment(); // MTA: run_diffuse uses ApplicationData
+                ::xllama::bridge::run_diffuse();
+                ::xllama::log_output("[xllama] diffuse-inproc: run returned (result/error above; "
+                                     "XAML window still up)\n");
+            }).detach();
+        }
     } catch (winrt::hresult_error const& e) {
         char buf[512];
         snprintf(buf, sizeof(buf), "[xllama] OnLaunched hresult 0x%08X: %ls\n",

--- a/uwp/diffuse.cpp
+++ b/uwp/diffuse.cpp
@@ -290,8 +290,8 @@ void run_diffuse() {
                        std::to_string((int)ms_since(t_load0)) + " ms\n");
 
             for (size_t s = 0; s < sched.timesteps().size(); ++s) {
-                const std::string step_label = std::to_string(s + 1) + "/" +
-                                               std::to_string(sched.timesteps().size());
+                const std::string step_label =
+                    std::to_string(s + 1) + "/" + std::to_string(sched.timesteps().size());
                 if (cancel_requested()) {
                     log_output("[xllama] diffuse: cancelled at unet step " + step_label + "\n");
                     write_progress("cancelled");

--- a/uwp/diffuse.cpp
+++ b/uwp/diffuse.cpp
@@ -24,8 +24,16 @@
 // embeddings + guidance blend), out of scope for the console demo.
 //
 // Inputs (LocalState): prompt.txt, diffuse-model.txt (model dir name),
-// diffuse-steps.txt (default 1), diffuse-seed.txt (default 42).
-// Outputs: diffuse-out.png (+ .done) and diffuse-result.csv with per-stage ms.
+// diffuse-steps.txt (default 1), diffuse-seed.txt (default 42);
+// diffuse-cancel.flag aborts between UNet steps (consumed).
+// Outputs: diffuse-out.png (+ .done), diffuse-result.csv with per-stage ms,
+// diffuse-progress.txt with the live stage (start/text_encoder/unet s/N/vae/
+// done/cancelled/error).
+//
+// Entry points: headless via diffuse.flag (no compositor, the proven path) or
+// in-process via diffuse-inproc.flag (App.cpp §7 experiment: plain ORT DML vs
+// the XAML compositor device — unlike GenAI's Agility-factory device, plain
+// ORT may coexist; pending console validation).
 
 #include "inference-bridge.h"
 
@@ -163,6 +171,29 @@ double ms_since(std::chrono::steady_clock::time_point t0) {
     return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
 }
 
+// Progress/cancel plumbing for UI or Device-Portal pollers.
+// diffuse-progress.txt holds the current stage: "start", "text_encoder",
+// "unet <s>/<N>", "vae", then "done" / "cancelled" / "error".
+void write_progress(const std::string& stage) {
+    FILE* fp = _wfopen(utf8_to_wstring(resolve_local_path("diffuse-progress.txt")).c_str(), L"w");
+    if (fp) {
+        fputs(stage.c_str(), fp);
+        fputc('\n', fp);
+        fclose(fp);
+    }
+}
+
+// diffuse-cancel.flag (written by the UI/WDP, consumed here) aborts the run
+// between UNet steps — the only boundary where a multi-second run can stop
+// cleanly without tearing down a session mid-Run.
+bool cancel_requested() {
+    const std::wstring flag = utf8_to_wstring(resolve_local_path("diffuse-cancel.flag"));
+    if (GetFileAttributesW(flag.c_str()) == INVALID_FILE_ATTRIBUTES)
+        return false;
+    _wremove(flag.c_str());
+    return true;
+}
+
 } // namespace
 
 void run_diffuse() {
@@ -179,6 +210,12 @@ void run_diffuse() {
     const int seed = read_int_file("diffuse-seed.txt", 42, 0, 1'000'000'000);
     log_output("[xllama] diffuse: model='" + dir + "' steps=" + std::to_string(steps) +
                " seed=" + std::to_string(seed) + " prompt='" + prompt + "'\n");
+
+    // Fresh run: stale completion marker and a leftover cancel flag from a
+    // previous run must not leak into this one.
+    _wremove(utf8_to_wstring(resolve_local_path("diffuse-out.png.done")).c_str());
+    (void)cancel_requested();
+    write_progress("start");
 
     try {
         auto model = [&](const char* comp) {
@@ -199,6 +236,7 @@ void run_diffuse() {
         // 2026-07-08). Sequential lifetime frees ~2.3 GB before the VAE runs.
 
         // ---- Text encoder: input_ids[1,77] -> last_hidden_state[1,77,H] -----
+        write_progress("text_encoder");
         auto t_load0 = std::chrono::steady_clock::now();
         std::vector<float> hidden; // [1,77,H]
         double te_ms = 0.0;
@@ -252,6 +290,14 @@ void run_diffuse() {
                        std::to_string((int)ms_since(t_load0)) + " ms\n");
 
             for (size_t s = 0; s < sched.timesteps().size(); ++s) {
+                const std::string step_label = std::to_string(s + 1) + "/" +
+                                               std::to_string(sched.timesteps().size());
+                if (cancel_requested()) {
+                    log_output("[xllama] diffuse: cancelled at unet step " + step_label + "\n");
+                    write_progress("cancelled");
+                    return;
+                }
+                write_progress("unet " + step_label);
                 // scale_model_input on a copy (UNet sees the scaled latent).
                 std::vector<float> scaled = latent;
                 sched.scale_model_input(scaled);
@@ -291,6 +337,7 @@ void run_diffuse() {
         } // release UNet weights (~1.65 GB) before the VAE's 512x512 activations
 
         // ---- VAE decode: latent/scale [1,4,64,64] -> sample[1,3,512,512] -----
+        write_progress("vae");
         for (auto& v : latent)
             v = v / (float)kVaeScale;
         std::vector<float> img; // [1,3,512,512] in [-1,1]
@@ -360,13 +407,17 @@ void run_diffuse() {
             }
             log_output("[xllama] diffuse: wrote diffuse-out.png (" + std::to_string(kImageHW) +
                        "x" + std::to_string(kImageHW) + ")\n");
+            write_progress("done");
         } else {
             log_output("[xllama] diffuse: PNG write failed\n");
+            write_progress("error");
         }
     } catch (const Ort::Exception& e) {
         log_output(std::string("[xllama] diffuse: ORT error: ") + e.what() + "\n");
+        write_progress("error");
     } catch (const std::exception& e) {
         log_output(std::string("[xllama] diffuse: error: ") + e.what() + "\n");
+        write_progress("error");
     }
 }
 


### PR DESCRIPTION
## Summary
- `diffuse-inproc.flag`: runs the diffusion pipeline on a background MTA thread **inside the XAML process** — falsification experiment for the §7 headless requirement (measured with GenAI's Agility-factory device, never with the plain ORT DML this pipeline uses). Runbook §7b documents PASS/FAIL criteria; console run pending.
- `diffuse-progress.txt`: live stage (`start`/`text_encoder`/`unet s/N`/`vae`/`done`/`cancelled`/`error`), works headless and in-proc.
- `diffuse-cancel.flag` (consumed): clean abort between UNet steps.
- Stale `.done`/cancel artifacts cleared at run start.

## Test plan
- CI compile (UWP default + llamacpp lanes)
- Console: §7b run once the Xbox is back online (PASS → in-app generation follow-up; FAIL → record in §7, headless stays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new in-app diffusion launch mode that runs in the background during the live app session.
  * Added live progress reporting and the ability to cancel an ongoing diffusion run.

* **Bug Fixes**
  * Cleans up stale run artifacts at startup so results and cancellation state stay accurate.
  * Improves failure reporting by marking unsuccessful runs clearly in progress updates.

* **Documentation**
  * Updated the validation runbook and platform notes with the new experiment flow and outcome criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->