### PR TITLE
docs: post-release hygiene (ROADMAP closeout + Phase 5 tracker)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -168,9 +168,9 @@ Milestones:
       `bench/results/phase35-llamacpp-scaling.csv`): t1 **19.9**, t4 **51.5**,
       t6 **62.9** tok/s; **t7/t8 livelock** (ggml spin-wait threadpool
       oversubscribes the ~6 cores Dev Mode leaves the app — no thread affinity in
-      AppContainer). Versus ORT int4 @8t (66.3): **parity, not 2×** — Q4_K_M does
+      AppContainer). Versus ORT int4 @8t (66.3): **parity, not 2×** — Q4*K_M does
       not extract more bandwidth than ORT's `MatMulNBits` on this machine; both
-      saturate ~13 GB/s effective. Prefill is _worse_ (141 vs 220 tok/s).
+      saturate ~13 GB/s effective. Prefill is \_worse* (141 vs 220 tok/s).
       **Verdict: ORT GenAI stays the text backend** (better prefill, KV-reuse,
       routing, DML); the llamacpp lane remains in CI as a bench-only variant.
       Fixed on the way (all real bugs): `#ifdef XLLAMA_USE_ORT` vs `=0`,
@@ -200,5 +200,26 @@ Milestones:
 - [x] Remove model bundle from MSIX — ✅ 2026-07-08 (ItemGroup deleted; CI matrix simplified to default+llamacpp; `xllama-appx` is now the 19 MB no-model package)
 - [x] `model-manifest.json` — ✅ 2026-07-08 (`uwp/models/manifest.json` catalogue + LocalState override; ComboBox and downloader de-hardcoded)
 - [ ] Demo video: model loaded and running on Xbox hardware
-- [ ] Technical report (arXiv or GitHub Discussions)
-- [ ] Tagged v1.0.0 release with pre-built MSIX and model manifest
+- [x] Technical report — ✅ 2026-07-08 draft written (`docs/technical-report.md`,
+      the measured story 0.3.x→1.0); publication venue (GitHub Discussions vs
+      arXiv) still to pick
+- [x] Tagged v1.0.0 release — ✅ 2026-07-08 (`gh release view v1.0.0`: 19 MB
+      MSIX + `.cer` + VCLibs x64; models on the `models-v1` release)
+
+## Phase 5 — Post-1.0 improvements 🚧 IN PROGRESS (2026-07-09)
+
+- [ ] **In-process diffusion experiment** (`diffuse-inproc.flag`, PR #20): does
+      plain ORT DML coexist with the XAML compositor? PASS → in-app image
+      generation, no restart flow (runbook §7b; `docs/uwp-constraints.md` §7
+      "Open experiment"). Console run pending.
+- [x] Diffusion progress/cancel plumbing (`diffuse-progress.txt`,
+      `diffuse-cancel.flag`) — PR #20
+- [ ] Interactive validations at the pad: §2 routing A/B + Image dialog flow
+- [ ] Closure benches: int4 `block_size=128` / `accuracy_level=4` (§12
+      confirm/refute) + first `load_ms` baseline
+- [ ] If §2 shows `887A0036` on the GPU turn in XAML: vendor the patched GenAI
+      DLL (PR microsoft/onnxruntime-genai#2280, console-validated) until the
+      fix ships upstream
+- [ ] `diffusion/requirements.txt` toolchain bump + re-validation (dependabot:
+      27 dev-only alerts; pins are a coherent export set — bump requires
+      re-running export → convert → validate_pipeline)

--- a/diffusion/requirements.txt
+++ b/diffusion/requirements.txt
@@ -4,6 +4,13 @@
 # old enough (2.4.x) to use the legacy tracing ONNX exporter, since optimum 1.23
 # does not support torch's newer dynamo/onnxscript exporter (it hits external-data
 # naming + LayerNormalization opset-downgrade bugs). Do not bump piecemeal.
+#
+# SECURITY NOTE (2026-07-09): dependabot flags CVEs on these pins (torch 2.4.1,
+# transformers 4.46.3, diffusers 0.31.0). Accepted risk: this is an OFFLINE,
+# host-only export toolchain — never shipped in the app, only fed first-party
+# checkpoints (stabilityai/sd-turbo safetensors); the deserialization/remote
+# vectors don't apply. Bumping requires re-validating the whole recipe
+# (export → convert_fp16 → validate_pipeline); tracked in ROADMAP Phase 5.
 torch==2.4.1            # legacy torch.onnx tracer; --index-url .../whl/cpu
 optimum[onnxruntime]==1.23.3
 transformers==4.46.3


### PR DESCRIPTION
## Summary
- ROADMAP Phase 4: flip the two stale checkboxes (technical report drafted, v1.0.0 tagged — both done 2026-07-08)
- New Phase 5 tracker: in-proc diffusion experiment (PR #20), interactive validations, closure benches, #2280 vendor decision, toolchain bump
- `diffusion/requirements.txt`: security note — the 27 dependabot alerts are on the offline host-only export toolchain; pins are a version-coupled set, bump tracked with re-validation in Phase 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)