### PR TITLE
chore: bump package version to 1.0.1.0

### DIFF
--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -10,7 +10,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="1.0.0.0"
+    Version="1.0.1.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity


### PR DESCRIPTION
Same-identity/different-contents deploys are blocked by WDP (measured just now — the earlier "same-version reinstall works" gotcha only holds for identical contents). Phase 5 console deploys (in-proc experiment) need a version bump; LocalState survives version-bump reinstalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app package version to **1.0.1.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->