### PR TITLE
docs: full drift audit — current-state rewrite + user guides

### DIFF
--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -38,8 +38,8 @@ jobs:
 
       - name: Build UWP package
         shell: pwsh
-        # -NoBundledModel also belts-and-braces the nobundle variant: even if a
-        # cached model directory existed, the MSBuild property excludes it.
+        # No model is bundled: uwp/models/ carries only manifest.json, so the
+        # package is model-free by construction (~19 MB).
         run: >-
           ./scripts/build-uwp.ps1 -Configuration Release -Platform x64
           -Backend $('${{ matrix.variant }}' -eq 'llamacpp' ? 'llamacpp' : 'ort')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Docs — full drift audit + user guides (2026-07-09)
+
+Three-way audit (docs↔code, docs↔measured state, gaps) and fixes:
+
+- **Retired-narrative drift**: README, `phase1-runbook`, `device-portal`,
+  `windows-dev-vm`, `model-selection` still described the bundled-model MSIX,
+  the "~768 MB GPU pool", the build-time model merge, and pre-1.0 versions —
+  all rewritten to the current reality (19 MB no-model MSIX, first-launch
+  catalogue download from the `models-v1` Release, measured 3801 MB GPU
+  budget, per-workload verdict, image generation).
+- **Status drift**: ROADMAP Phase 3/3.5 headers and stale items (load_ms
+  baseline, 1.7B CPU bench, int4 variant location) flipped to their measured
+  state; three historical "On-console validation pending" CHANGELOG lines
+  flipped per the runbook convention; runbook section headers now carry
+  ✅ MEASURED / ⏳ PENDING markers and the v0.4.0.0 anchor is gone.
+- **New user docs**: `docs/using-the-app.md` (chat, settings, routing,
+  KV reuse, image generation) and `docs/install-release.md` (cert + VCLibs +
+  MSIX from a tagged release); `docs/README.md` index completed;
+  "Add your own model (manifest override)" how-to in `model-selection.md`;
+  `deploy.sh fetch-file` and the llamacpp CI variant documented.
+
 ### Added — in-process diffusion experiment (`diffuse-inproc.flag`)
 
 The 887A0036 device conflict (§7) was measured with ORT **GenAI**'s
@@ -258,10 +279,10 @@ This spike tests that hypothesis cheaply before building a full diffusion pipeli
 - `uwp/xllama.vcxproj`: added the ORT DirectML NuGet include dir + the new source.
   `onnxruntime.lib` was already linked.
 - Writes `imgspike-result.csv` (+ `.done`): DML vs CPU ms, GFLOP/s, GPU speedup.
-- On-console validation pending: upload `imgspike.onnx` to LocalState + drop
-  `image.flag`, fetch the CSV. **Hypothesis**: DML ≫ CPU here (compute-bound), the
-  inverse of text decode — if confirmed, a distilled SD-Turbo/LCM diffusion
-  pipeline becomes the flagship GPU workload (Phase 5).
+- On-console validation: ✅ measured 2026-07-08 — DML **11.1× faster** than CPU on
+  the compute-bound fp16 batch (2403 vs 216 GFLOP/s), the inverse of text
+  decode; hypothesis confirmed and the SD-Turbo diffusion pipeline shipped
+  in [1.0.0].
 
 ## [0.3.9.0] - 2026-07-08
 
@@ -312,8 +333,8 @@ per-turn prefill covers just the delta.
   the previous behaviour, never a wrong result.
 - Settings toggle `kv_reuse` (ToggleSwitch + `settings.json`, default on) so the
   win can be A/B'd on console.
-- On-console validation pending: measure turn-2 TTFT with reuse on vs off
-  (Stage 2b bench) and confirm multi-turn coherence before trusting it as default.
+- On-console validation: ✅ measured 2026-07-08 — turn-2 prefill **4.87× faster**
+  with reuse (103.7 ms vs 505.2 ms cold re-prefill); coherence confirmed.
 
 ### Added — multi-turn TTFT bench (Stage 2b)
 
@@ -336,8 +357,9 @@ per-turn prefill covers just the delta.
   is the prerequisite for continuous decoding / KV-cache reuse (`RewindTo`,
   generator reuse — Stage 2). No breaking C-API changes vs 0.13; existing model
   directories (built with model builder 0.14.1) load unchanged.
-- On-console validation pending: rerun the CPU + DML bench matrix and compare
-  decode tok/s to the v0.3.6 baselines to quantify the per-token overhead win.
+- On-console validation: ✅ measured 2026-07-08 — decode flat vs v0.3.6 (CPU int4
+  66.3 vs 68.0; DML fp16 46.8 = 46.8): the bump is a prereq/overhead win, not a
+  decode-rate win at this scale.
 
 ### Docs
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # xllama
 
-> Local LLM inference on Xbox Series S|X (UWP Dev Mode) — ONNX Runtime GenAI on Zen 2 CPU.
+> Local LLM chat + Stable-Diffusion image generation on Xbox Series S|X (UWP Dev Mode) — ONNX Runtime GenAI + DirectML.
 
 [![build-uwp](https://github.com/gianlucamazza/xllama/actions/workflows/build-uwp.yml/badge.svg)](https://github.com/gianlucamazza/xllama/actions/workflows/build-uwp.yml)
 [![build-linux](https://github.com/gianlucamazza/xllama/actions/workflows/build-linux.yml/badge.svg)](https://github.com/gianlucamazza/xllama/actions/workflows/build-linux.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-**Status:** experimental · early development  
+**Status:** v1.0 released · research-grade  
 **Maintainer:** [Venere Labs](https://github.com/gianlucamazza)
 
 ---
@@ -30,11 +30,11 @@
 
 ## What is this
 
-`xllama` is a UWP application for Xbox Series S|X in Dev Mode that runs LLM inference locally, with no cloud dependency and a gamepad-friendly UI.
+`xllama` is a UWP application for Xbox Series S|X in Dev Mode that runs LLM chat and Stable-Diffusion image generation locally, with no cloud dependency and a gamepad-friendly UI.
 
-The project started as a port of [`llama.cpp`](https://github.com/ggml-org/llama.cpp) (GGUF files, CPU-only), then migrated to **ONNX Runtime GenAI + DirectML** to target the Xbox GPU. After confirming that the UWP GPU memory pool on Series S is ~768 MB — too small for any usable LLM — the active backend is now **CPU EP** (Zen 2, 8 cores). The llama.cpp path is preserved for Linux development and CI.
+The project started as a port of [`llama.cpp`](https://github.com/ggml-org/llama.cpp) (GGUF files, CPU-only), then migrated to **ONNX Runtime GenAI + DirectML**. The measured verdict is **per-workload** (see [docs/technical-report.md](./docs/technical-report.md)): the Zen 2 **CPU wins autoregressive decode** at this model scale (~66 tok/s, SmolLM2-360M int4), the RDNA 2 **GPU wins batch compute** — prefill at ~1k prompt tokens (1.8× faster) and image generation (**11.1×** on the diffusion workload: SD-Turbo 512×512 in ~7 s). The app routes per conversation (CPU / GPU / auto). The llama.cpp path is preserved for Linux development, CI, and a bench-only UWP variant (measured: decode parity with ORT, so ORT stays the text backend).
 
-The bundled model is **SmolLM2-360M-Instruct INT4 CPU** (~403 MB), chosen to fit within the Xbox's available storage and RAM envelope.
+The default chat model is **SmolLM2-360M-Instruct INT4 CPU** (~403 MB), downloaded on first launch from the GitHub Release model catalogue — the MSIX itself is ~19 MB and ships no model.
 
 Goals:
 
@@ -62,9 +62,9 @@ source ~/.config/xllama/xbox-env           # sets XBOX_IP, XBOX_USER, XBOX_PASS
 ./scripts/deploy.sh path/to/xllama_*.msix
 ```
 
-The SmolLM2-360M-Instruct INT4 model is bundled inside the MSIX — no separate upload needed. On first launch the app copies the model to `LocalState` and starts the chat UI automatically.
+On first launch the app **downloads** the default model (SmolLM2-360M INT4, ~417 MB) from the [`models-v1` GitHub Release](https://github.com/gianlucamazza/xllama/releases/tag/models-v1) with a progress bar, then starts the chat UI. No model is bundled in the MSIX.
 
-See [docs/phase1-runbook.md](./docs/phase1-runbook.md) for the full step-by-step workflow.
+See [docs/install-release.md](./docs/install-release.md) to install a tagged release (cert + VCLibs + MSIX), [docs/using-the-app.md](./docs/using-the-app.md) for the app guide (chat, settings, image generation), and [docs/phase1-runbook.md](./docs/phase1-runbook.md) for the developer workflow.
 
 ---
 
@@ -73,7 +73,7 @@ See [docs/phase1-runbook.md](./docs/phase1-runbook.md) for the full step-by-step
 `xllama` predates the pivot to ONNX Runtime GenAI. The name is kept for continuity, not as a claim about the engine:
 
 - **`x`** — Xbox (UWP target) and cross-platform (Linux CLI build).
-- **`llama`** — local-LLM ecosystem at large. The Linux build still uses `llama.cpp`; the UWP build does not. Neither path ships LLaMA model weights — the bundled model is SmolLM2-360M-Instruct.
+- **`llama`** — local-LLM ecosystem at large. The Linux build still uses `llama.cpp`; the UWP build does not. Neither path ships LLaMA model weights — the default model is SmolLM2-360M-Instruct.
 
 ---
 
@@ -85,7 +85,7 @@ See [docs/phase1-runbook.md](./docs/phase1-runbook.md) for the full step-by-step
 - **Accessible Dev Mode**: one-time ~$19 activation via Partner Center unlocks unsigned UWP deployment.
 - **Underexplored**: no prior LLM port to the platform at time of writing.
 
-**Current performance (CPU EP, SmolLM2-360M INT4):** ~71 tok/s decode at 4 threads (bench v0.3.1; peak 771 MB RAM). Optimal: `intra_op_num_threads=4` — explicit 8-thread setting causes severe regression (~24 tok/s) due to memory bandwidth saturation on Zen 2. See `bench/results/phase1-cpu.csv` for full results.
+**Measured performance (Xbox Series S, 2026-07-08):** chat decode **66.3 tok/s** (CPU int4, SmolLM2-360M, ORT GenAI 0.14.1); prefill at ~1k prompt tokens **354 tok/s on GPU fp16** vs 198 CPU (the crossover that motivates routing); KV-cache reuse makes turn-2 prefill **4.87×** faster; SD-Turbo generates a 512×512 image in **~6.9 s** on DirectML. Full matrices: `bench/results/` and [docs/technical-report.md](./docs/technical-report.md).
 
 ---
 
@@ -102,18 +102,22 @@ See [docs/phase1-runbook.md](./docs/phase1-runbook.md) for the full step-by-step
                    ▼  CI build (GitHub Actions, windows-2022)
 ┌──────────────────────────────────────────┐
 │  Build: MSVC + Windows SDK + NuGet       │
-│  ├─ ORT GenAI 0.13.2 + ORT 1.24.4       │
+│  ├─ ORT GenAI 0.14.1 + ORT 1.24.4       │
 │  ├─ DirectML 1.15.4 (app-local DLLs)    │
-│  ├─ SmolLM2-360M INT4 merged into MSIX   │
-│  └─ Output: xllama_*.msix               │
+│  └─ Output: xllama_*.msix (~19 MB,      │
+│     no model bundled)                    │
 └──────────────────┬───────────────────────┘
                    │
                    ▼  sideload via Device Portal
 ┌──────────────────────────────────────────┐
 │  Target: Xbox Series S|X (Dev Mode)      │
-│  ├─ ORT GenAI → CPU EP (Zen 2)          │
-│  └─ DirectML EP: blocked by GPU OOM     │
-│     (UWP pool ~768 MB, LLM > 300 MB)    │
+│  ├─ first launch: model download from    │
+│  │  GitHub Release catalogue             │
+│  ├─ chat decode → CPU EP (Zen 2)        │
+│  ├─ long-prompt prefill → DML fp16      │
+│  │  (per-conversation routing)           │
+│  └─ image gen → SD-Turbo on DirectML    │
+│     (headless flag mode, 887A0036 — §7)  │
 └──────────────────────────────────────────┘
 ```
 
@@ -148,9 +152,12 @@ xllama/
 │   ├── App.cpp / App.h     # Application lifecycle, OnLaunched
 │   ├── MainPage.cpp / .h   # MainPageController — programmatic UI (XAML-free)
 │   ├── inference-bridge.cpp / .h  # UWP entry glue + bench mode main_loop()
+│   ├── diffuse.cpp         # SD-Turbo diffusion pipeline (plain ORT DirectML)
 │   ├── chat-history.cpp / .h      # ChatHistory: Save/Load/Delete/Clear
-│   ├── model-downloader.cpp / .h  # EnsureModelAsync — HF chunked download (Exp 2)
-│   ├── packages.config     # NuGet pins (ORT GenAI 0.13.2, ORT 1.24.4, DirectML 1.15.4)
+│   ├── model-downloader.cpp / .h  # EnsureModelAsync + LoadModelManifest (catalogue download)
+│   ├── models/manifest.json # model catalogue (LocalState override supported)
+│   ├── packages.config     # NuGet pins (ORT GenAI 0.14.1, ORT 1.24.4, DirectML 1.15.4)
+│   ├── ggml-uwp.vcxproj    # static ggml+llama lib (bench-only llamacpp backend)
 │   └── xllama.sln / .vcxproj
 ├── scripts/
 │   ├── deploy.sh                      # Device Portal: deploy, logs, bench trigger
@@ -161,11 +168,13 @@ xllama/
 │   ├── test-dml-config.sh             # upload DML provider_options without MSIX rebuild
 │   ├── check-uwp-host.sh              # Linux host preflight
 │   └── setup-windows-uwp-dev.ps1      # Windows VM setup
-├── tests/                  # unit tests (doctest)
+├── tests/                  # unit tests (doctest, incl. diffusion golden vectors)
 ├── bench/                  # benchmark configs + results
+├── diffusion/              # SD-Turbo export/convert/validate toolchain (host)
+├── patches/                # llama.cpp AppContainer guards (bench-only variant)
 ├── docs/                   # technical notes
 ├── cmake/                  # toolchain files
-└── .github/workflows/      # CI: build-linux + build-uwp
+└── .github/workflows/      # CI: build-linux + build-uwp (default + llamacpp)
 ```
 
 ---
@@ -193,12 +202,13 @@ ctest --test-dir build/linux-test --output-on-failure
 
 ### Build for Xbox (Windows / CI)
 
-The UWP package requires MSVC and the Windows SDK. Recommended path: push to `main` and download the `xllama-appx` artifact from the `build-uwp` GitHub Actions workflow.
+The UWP package requires MSVC and the Windows SDK. Recommended path: push to `main` and download the `xllama-appx` artifact from the `build-uwp` GitHub Actions workflow. CI also builds `xllama-appx-llamacpp` — a **bench-only** variant with the static ggml/llama.cpp CPU text backend (`-Backend llamacpp`, `patches/`), kept for A/B benchmarking; measured decode parity with ORT, so ORT GenAI remains the shipping backend.
 
 For local builds from a Windows VM, see [docs/windows-dev-vm.md](./docs/windows-dev-vm.md):
 
 ```powershell
-.\scripts\build-uwp.ps1 -Configuration Release -Platform x64
+.\scripts\build-uwp.ps1 -Configuration Release -Platform x64            # default (ORT GenAI)
+.\scripts\build-uwp.ps1 -Configuration Release -Platform x64 -Backend llamacpp  # bench-only
 ```
 
 ### Deploy to console
@@ -208,32 +218,34 @@ source ~/.config/xllama/xbox-env   # sets XBOX_IP, XBOX_USER, XBOX_PASS
 ./scripts/deploy.sh path/to/xllama_*.msix
 ```
 
-The model is bundled inside the MSIX — no separate upload required. See [docs/phase1-runbook.md](./docs/phase1-runbook.md) for the full workflow.
+No model upload is required: the app downloads the default model on first launch from the GitHub Release catalogue. See [docs/install-release.md](./docs/install-release.md) (release install) and [docs/phase1-runbook.md](./docs/phase1-runbook.md) (developer workflow).
 
 ---
 
 ## Models
 
-`xllama` on Xbox uses ONNX Runtime GenAI. Models are directories containing `genai_config.json`, `model.onnx`, `tokenizer.json`, and related files — not single `.gguf` files.
+`xllama` on Xbox uses ONNX Runtime GenAI for text (model directories with `genai_config.json`, `model.onnx`, `tokenizer.json`) and plain ORT DirectML for diffusion (`text_encoder`/`unet`/`vae_decoder` components).
 
-The MSIX bundles **SmolLM2-360M-Instruct INT4 CPU** (403 MB on-disk, merged into a self-contained `model.onnx` for AppContainer compatibility). The model is placed under `Package.InstalledPath\models\smollm2-360m-cpu-int4\` and is copied to `LocalState\models\` on first launch.
+Models come from the catalogue `uwp/models/manifest.json` (assets hosted on the [`models-v1` GitHub Release](https://github.com/gianlucamazza/xllama/releases/tag/models-v1)): the app downloads any catalogue entry on demand, with the default chat model fetched on first launch. A `LocalState\manifest.json` uploaded via Device Portal overrides the catalogue without a reinstall — see [docs/model-selection.md](./docs/model-selection.md) for adding your own model.
 
-| Model | Format | Size | Xbox UWP | Notes |
-|-------|--------|------|----------|-------|
-| SmolLM2-360M-Instruct INT4 CPU | ONNX GenAI | 403 MB | ✅ | Active; bundled in MSIX |
-| SmolLM2-1.7B-Instruct INT4 CPU | ONNX GenAI | 1.4 GB | ⚠ | Above disk budget |
-| Phi-3.5-mini CPU INT4 | ONNX GenAI | ~2.7 GB | ❌ | Disk full on Xbox Series S |
-| Phi-3.5-mini GPU INT4 | ONNX GenAI DirectML | ~2.2 GB | ❌ | GPU OOM (pool ~768 MB) |
+| Model                          | Format        | Size    | Xbox UWP | Notes                                                            |
+| ------------------------------ | ------------- | ------- | -------- | ---------------------------------------------------------------- |
+| SmolLM2-360M-Instruct INT4 CPU | ONNX GenAI    | 417 MB  | ✅       | Default; decode 66.3 tok/s                                       |
+| SmolLM2-360M-Instruct fp16 DML | ONNX GenAI    | ~700 MB | ✅       | Routing target (prefill 354 tok/s @1k)                           |
+| SD-Turbo fp16 (image)          | ONNX DirectML | 2.4 GB  | ✅       | 512×512 in ~6.9 s ([diffusion/README.md](./diffusion/README.md)) |
+| SmolLM2-1.7B-Instruct INT4 CPU | ONNX GenAI    | 1.4 GB  | ✅       | Measured 20.6 tok/s; tight on Dev Mode disk                      |
+| Phi-3.5-mini CPU INT4          | ONNX GenAI    | ~2.7 GB | ❌       | Above the Dev Mode disk budget                                   |
 
-Numbers are measured on Xbox Series S Dev Mode. See [docs/uwp-constraints.md](./docs/uwp-constraints.md) for the GPU pool limit and the `weakly_canonical` AppContainer workaround.
+Numbers are measured on Xbox Series S Dev Mode. See [docs/uwp-constraints.md](./docs/uwp-constraints.md) for the measured GPU budget (3801 MB), the disk budget, and the `weakly_canonical` AppContainer workaround.
 
 ---
 
 ## Limitations
 
-- **GPU pool ~768 MB**: UWP apps on Xbox Series S have ~768 MB of GPU-accessible memory. Any LLM larger than ~300 MB on-device triggers an OOM in `OgaCreateModel` (SEH `0xC0000005`). DirectML EP is not viable today.
-- **Sandboxed filesystem**: models must be pre-loaded into the MSIX or transferred via Device Portal. No arbitrary path access.
-- **AppContainer path traversal**: ORT 1.24.4 calls `std::filesystem::weakly_canonical()` for external ONNX data files, which traverses path segments the AppContainer cannot read. Workaround: merge `model.onnx.data` into `model.onnx` at MSIX build time (`scripts/merge_onnx_external_data.py`).
+- **Disk is the binding budget, not GPU memory**: the measured per-process GPU budget is **3801 MB** (package designated Game), but Dev Mode leaves only ~2.2–2.5 GB free on disk — that is what caps model size.
+- **DirectML vs XAML (`887A0036`)**: ORT GenAI's DML device conflicts with the XAML compositor's D3D12 device in the same process, so GPU workloads run in headless flag modes (`bench.flag`, `diffuse.flag`); fix contributed upstream ([onnxruntime-genai#2280](https://github.com/microsoft/onnxruntime-genai/pull/2280)). Whether plain ORT DML (diffusion) shares the constraint is under test (`diffuse-inproc.flag`).
+- **Sandboxed filesystem**: models are downloaded to `LocalState` or transferred via Device Portal / USB. No arbitrary path access.
+- **AppContainer path traversal**: ORT 1.24.4 calls `std::filesystem::weakly_canonical()` for external ONNX data files, which traverses path segments the AppContainer cannot read. Workaround: distribute models with `model.onnx.data` merged into a self-contained `model.onnx` (`scripts/merge_onnx_external_data.py`).
 - **No POSIX mmap / no `dlopen`**: NuGet-packaged ORT GenAI DLLs must be app-local (`DeploymentContent=true`); no system-wide DLL loading.
 - **Dev Mode only**: no path to retail-mode consoles.
 
@@ -245,10 +257,11 @@ For full details see [docs/uwp-constraints.md](./docs/uwp-constraints.md).
 
 See [ROADMAP.md](./ROADMAP.md). Headlines:
 
-1. **Phase 1 — CPU baseline** ✅ Working UWP, ORT GenAI, SmolLM2-360M bundled, CI green.
-2. **Phase 2 — GPU acceleration** 🚫 Blocked: UWP GPU pool too small for LLM inference.
-3. **Phase 3 — Benchmarks + model exploration** Populate results, tune n_threads, try sub-400 MB models.
-4. **Phase 4 — In-app model download + publication** ModelSpec multi-file ONNX, demo, technical report.
+1. **Phase 1 — CPU baseline** ✅ Working UWP, ORT GenAI, CI green.
+2. **Phase 2 — GPU acceleration** ✅ GPU proven; verdict per-workload (CPU decode, GPU prefill/images).
+3. **Phase 3 / 3.5 — Benchmarks + hardware ceiling** ✅ Measured matrices, routing, KV reuse, llama.cpp A/B (parity), diffusion on console.
+4. **Phase 4 — In-app model download + publication** ✅ Catalogue download, v1.0.0 release, technical report (demo video pending).
+5. **Phase 5 — Post-1.0 improvements** 🚧 In-proc diffusion experiment, interactive validations, upstream #2280.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,7 +78,7 @@ Milestones:
 - [x] Stage B (only if DML tok/s beats CPU) — ❌ dropped: DML is 8× slower than CPU at this scale; interactive app stays on CPU EP
 - [x] Measure GPU vs CPU tok/s for the same model — ✅ v0.3.6 utilization matrix (same SmolLM2-360M, 3 variants × 2 prompts): CPU int4 decode 68.0 vs GPU fp16 46.8 vs GPU int4 8.8 tok/s; prefill inverts at ~1k tok (GPU fp16 354 vs CPU 198)
 
-## Phase 3 — Benchmarks + Model Exploration 🔄 IN PROGRESS
+## Phase 3 — Benchmarks + Model Exploration ✅ DONE
 
 **Goal**: reproducible results, n_threads tuning, evaluate alternative compact models.
 
@@ -89,9 +89,9 @@ Milestones:
 - [x] `bench-xbox-ort.sh` + `bench_threads.txt` mechanism for automated multi-thread bench runs
 - [x] Evaluate Qwen2.5-0.5B INT4 ONNX — ❌ ~822 MB real (vocab embedding dominates); exceeds disk borderline and GPU pool
 - [x] Evaluate Llama-3.2-1B INT4 ONNX CPU — ❌ ~1.77 GB real; USB-only, same class as SmolLM2-1.7B
-- [x] `load_ms` in bench CSV: column existed but ORT path never measured it (always 0) — `run_inference` now times `OgaCreateModel`; baseline pending next bench run on console
+- [x] `load_ms` in bench CSV: column existed but ORT path never measured it (always 0) — `run_inference` now times `OgaCreateModel`; baseline measured 2026-07-08 (`phase35-014-*.csv`, `phase35-1b-cpu.csv`): CPU int4 360M **1593 ms**, DML fp16 2830, DML int4 837, 1.7B CPU 6179
 
-## Phase 3.5 — Hardware Ceiling 🔮 NEXT
+## Phase 3.5 — Hardware Ceiling ✅ CONSOLE-VALIDATED 2026-07-08 (residuals tracked in Phase 5)
 
 **Goal**: close the gap between measured utilization (CPU ~13 GB/s, GPU ~34 GB/s
 effective vs ~224 GB/s bus) and what the Series S can realistically deliver.
@@ -117,7 +117,8 @@ v0.4.0.0 on Xbox; CSVs `bench/results/phase35-*.csv`):
 - [x] **Image-generation spike** (v0.4.0, flagship hypothesis): **CONFIRMED on
       console 2026-07-08** — on a compute-bound fp16 batch (309 GFLOP), DirectML is
       **11.1× faster than CPU** (2403 vs 216 GFLOP/s). The inverse of text decode;
-      diffusion is the GPU's workload. → C++ pipeline built + host-validated (PR #5).
+      diffusion is the GPU's workload. → C++ pipeline console-validated 2026-07-08:
+      SD-Turbo fp16 512×512 in 6.9 s (`bench/results/phase5-diffuse.csv`).
 
 Milestones:
 
@@ -136,8 +137,9 @@ Milestones:
       big upload: community reports a ~2 GB per-file limit in Dev Mode
       (relevant for merged `model.onnx` > 2 GB). Exp 2 nobundle (Phase 4)
       remains useful for its own sake but is no longer a disk prerequisite.
-- [~] **1B+ scale bench**: SmolLM2-1.7B. **CPU int4 built OK** (1.4 GB, merged,
-  ready to upload). **fp16-DML blocked** (found 2026-07-08): a 1.7B fp16
+- [~] **1B+ scale bench**: SmolLM2-1.7B. **CPU int4 measured on console
+  2026-07-08: 20.6 tok/s decode, peak 2423 MB** (`phase35-1b-cpu.csv`).
+  **fp16-DML blocked** (found 2026-07-08): a 1.7B fp16
   `model.onnx` is ~3.4 GB and **exceeds the 2 GB protobuf serialization
   limit**, so it cannot be merged self-contained; keeping external data
   re-triggers the `weakly_canonical` AppContainer crash (§8). So the
@@ -157,7 +159,9 @@ Milestones:
       local lever.**
 - [~] **int4 DML config confirmation** (fast negative): SmolLM2-360M
   `int4_block_size=128` and `int4_accuracy_level=4` variants are **built**
-  (scratchpad); one console bench each to confirm they stay ≈ 8.8 tok/s (the
+  (rebuilt 2026-07-09, merged self-contained, in
+  `~/.cache/xllama-diffusion/int4-variants/`); one console bench each to
+  confirm they stay ≈ 8.8 tok/s (the
   kernel structure predicts no material gain). If either beats fp16-DML it
   would refute §12 — worth the ~5 min. Not a path forward, just closure.
 - [x] **llama.cpp CPU A/B** — ✅ **MEASURED 2026-07-08, hypothesis FALSIFIED.**

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,12 +2,16 @@
 
 Technical notes and design decisions for xllama.
 
-| Document | Description |
-|----------|-------------|
-| [uwp-constraints.md](./uwp-constraints.md) | UWP sandbox limitations, GPU pool limit, AppContainer filesystem quirks, and how xllama works around them |
-| [windows-dev-vm.md](./windows-dev-vm.md) | Windows VM setup for local UWP/MSIX builds |
-| [device-portal.md](./device-portal.md) | How to enable Dev Mode and deploy via Device Portal |
-| [phase1-runbook.md](./phase1-runbook.md) | End-to-end build, deploy, and benchmark instructions (ORT GenAI / SmolLM2-360M) |
-| [model-selection.md](./model-selection.md) | Checklist for choosing an ONNX GenAI model: disk/GPU hard limits, evaluation sequence, tested and candidate models |
+| Document                                                         | Description                                                                                                    |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [install-release.md](./install-release.md)                       | Install a tagged GitHub Release build on your Xbox (cert + VCLibs + MSIX)                                      |
+| [using-the-app.md](./using-the-app.md)                           | App guide: chat, settings (model picker, routing, KV reuse), image generation                                  |
+| [uwp-constraints.md](./uwp-constraints.md)                       | UWP sandbox limitations, measured GPU budget, AppContainer filesystem quirks, and how xllama works around them |
+| [technical-report.md](./technical-report.md)                     | The measured story: per-workload CPU/GPU verdict, falsified hypotheses, diffusion on console                   |
+| [console-validation-runbook.md](./console-validation-runbook.md) | Ordered on-console validation checklist with measured results per section                                      |
+| [windows-dev-vm.md](./windows-dev-vm.md)                         | Windows VM setup for local UWP/MSIX builds                                                                     |
+| [device-portal.md](./device-portal.md)                           | How to enable Dev Mode and deploy via Device Portal                                                            |
+| [phase1-runbook.md](./phase1-runbook.md)                         | End-to-end developer build, deploy, and benchmark instructions                                                 |
+| [model-selection.md](./model-selection.md)                       | Choosing/adding models: hard limits, evaluation sequence, tested models, manifest override how-to              |
 
-See also [../CHANGELOG.md](../CHANGELOG.md) for the full pivot history (llama.cpp → ORT GenAI → CPU EP).
+See also [../CHANGELOG.md](../CHANGELOG.md) for the full pivot history (llama.cpp → ORT GenAI → CPU EP → per-workload routing) and [../diffusion/README.md](../diffusion/README.md) for the SD-Turbo model toolchain.

--- a/docs/console-validation-runbook.md
+++ b/docs/console-validation-runbook.md
@@ -1,11 +1,9 @@
-# Console Validation Runbook — pending on-console checks (v0.4.0.0)
+# Console Validation Runbook
 
-Three PRs landed on `main` **CI-green but console-pending** (per the merge-on-CI-green
-policy, 2026-07-08): #2 (ORT GenAI 0.14.1 + KV-cache reuse + CPU/GPU routing), #3 (plain
-ORT DirectML image spike), #4 (diffusion toolchain, model-side only). Every code path is
-additive and flag-gated, so the default behaviour is unchanged until a flag/setting is
-used — but the perf wins and the image-spike hypothesis are **assumed, not measured** until
-run on the Xbox.
+On-console checks for merged, CI-green work (merge-on-CI-green policy). Most of the
+Phase 3.5 batch was **measured 2026-07-08** (§1, §3, §4, §6-CPU, §7 below carry their
+results); the sections still marked PENDING are §2 (routing A/B, interactive), §5b
+(int4 rebuild variants), and §7b (in-process diffusion experiment, 2026-07-09).
 
 This runbook batches all of them into **one Xbox session**. Each step writes a CSV/artifact
 fetched via Device Portal, with an explicit sanity gate. Mechanics (deploy, WDP quirks,
@@ -22,15 +20,17 @@ size` on any DML row (≈ 0 ⇒ silent CPU fallback — see `phase1-runbook.md �
 - Record each result CSV under `bench/results/`, commit with a one-line "Measured" note in
   `CHANGELOG.md` (flip the matching "On-console validation pending" line to the number).
 
-## 0. One-time — deploy main (v0.4.0.0)
+## 0. One-time — deploy main
 
-`AppxManifest.xml` is at `0.4.0.0` (> any previously deployed 0.3.x), so this is a
-**forward upgrade** and LocalState is preserved (existing uploaded models/settings survive).
+Deploy the current `xllama-appx` artifact (version per `uwp/AppxManifest.xml`).
+A **version-bump upgrade preserves LocalState** (uploaded models/settings survive);
+a same-version reinstall with different contents is **blocked by WDP** — bump the
+version for every console deploy.
 
 ```bash
 source ~/.config/xllama/xbox-env
 # Get the xllama-appx artifact from the latest green build-uwp run on main, then:
-./scripts/deploy.sh path/to/xllama_0.4.0.0_*.msix
+./scripts/deploy.sh path/to/xllama_*.msix
 PFN=$(./scripts/deploy.sh pfn)
 ./scripts/deploy.sh get-log        # confirm clean startup (App::App → Window activated)
 ```
@@ -38,7 +38,7 @@ PFN=$(./scripts/deploy.sh pfn)
 > Re-verify the **Game** designation in Dev Home after any reinstall (it can reset; all
 > measured figures assume Game-mode — `docs/uwp-constraints.md §5`).
 
-## 1. PR #2 — KV-cache reuse (Stage 2b bench) → `bench-kv-result.csv`
+## 1. PR #2 — KV-cache reuse (Stage 2b bench) — ✅ MEASURED 2026-07-08 (4.87×, `phase35-kv.csv`)
 
 **Validates**: turn-2 TTFT with KV reuse (append only the delta) vs the cold full
 re-prefill. Trigger is `bench_turns.txt` present (turn-2 prompt; `prompt.txt` = turn 1).
@@ -59,7 +59,7 @@ turn-2 cold re-prefills the full 2-turn context, reuse only the ~10-token delta.
 confirm multi-turn **coherence** (read the log's decoded turn-2 output) before trusting
 `kv_reuse` as the interactive default.
 
-## 2. PR #2 — CPU/GPU routing (Stage 3, interactive, ~10 min at the console)
+## 2. PR #2 — CPU/GPU routing (Stage 3, interactive, ~10 min at the console) — ⏳ PENDING
 
 **Validates**: the `routing=2` (auto) path picks GPU (DML fp16) for long prompts and CPU
 for decode, sticky per conversation.
@@ -94,7 +94,7 @@ and a short prompt. Fetch the log afterwards (`deploy.sh get-log`).
 the follow-up stays on the same EP (sticky); the new chat with a short prompt routes back
 to CPU. Flip `routing` back to `0` (Settings) afterwards if desired.
 
-## 3. PR #2 — 0.14.1 decode overhead → refresh the v0.3.6 matrix
+## 3. PR #2 — 0.14.1 decode overhead — ✅ MEASURED 2026-07-08 (flat vs v0.3.6, `phase35-014-*.csv`)
 
 **Validates**: the 0.13.2 → 0.14.1 bump reduced CPU-side per-token overhead.
 
@@ -106,7 +106,7 @@ to CPU. Flip `routing` back to `0` (Settings) afterwards if desired.
 **Looking for**: decode tok/s vs the v0.3.6 baselines (CPU int4 68.0 short / 50.9 long;
 DML fp16 46.8 / 36.5). Any uplift is the 0.14.x win; flat is also a valid (recorded) result.
 
-## 4. PR #3 — image spike → `imgspike-result.csv`
+## 4. PR #3 — image spike — ✅ MEASURED 2026-07-08 (DML 11.1× CPU, `phase35-imgspike.csv`)
 
 **Validates the flagship hypothesis**: on a compute-bound fp16 batch (one diffusion UNet
 step proxy), the RDNA 2 GPU **beats** the CPU — the inverse of text decode.
@@ -124,7 +124,7 @@ printf 'image' > /tmp/image.flag
 C++ diffusion pipeline (Fase 3) is greenlit as the flagship GPU workload. If DML ≈ CPU or
 worse, re-examine the hypothesis before building the pipeline.
 
-## 5. int4 DML — confirm/falsify the §12 desk-check
+## 5. int4 DML — confirm/falsify the §12 desk-check (5a ✅ done; 5b ⏳ PENDING — variants rebuilt 2026-07-09)
 
 Two distinct levers; keep them separate. The desk-check (§12) predicts **neither** moves
 the 8.8 tok/s decode floor, because the limit is the **non-fused** `MatMulNBits` kernel
@@ -151,7 +151,7 @@ block128/acc4, rebuild with the ORT GenAI model builder (`-p int4 -e dml` +
 limit, CPU int4 stays the decode default); a jump ⇒ the lever exists and §12 needs
 revising. Either outcome is a recorded verdict.
 
-## 6. 1.7B scale bench — does the GPU advantage grow with model size?
+## 6. 1.7B scale bench — ✅ CPU-int4 MEASURED 2026-07-08 (20.6 tok/s, `phase35-1b-cpu.csv`); fp16-DML blocked (>2 GB protobuf)
 
 **Validates**: GPU int4 1.7B decode vs CPU int4 1.7B, and prefill crossover at scale. The
 variants are already built in `~/.cache/xllama-1b-build/` (`smollm2-1.7b-cpu-int4`,

--- a/docs/device-portal.md
+++ b/docs/device-portal.md
@@ -41,6 +41,9 @@ curl -sS \
 ```
 
 Use `./scripts/deploy.sh` which wraps this call and polls installation status.
+Other wrapped operations: `upload-file` / `upload-dir` / `mkdir-localstate`
+(LocalState writes), `fetch-file` / `get-log` / `list-localstate` (reads),
+`start-app` / `stop-app` / `diagnose-startup`, `install-cert`, `pfn`.
 
 ## REST API: Listing installed packages
 
@@ -51,7 +54,7 @@ curl -sS --basic -u "$XBOX_USER:$XBOX_PASS" -k \
 
 ## REST API: Transferring model files
 
-The bundled SmolLM2-360M model is included in the MSIX — no upload is required for the standard flow. Use this only for swapping models in development.
+The standard flow needs no upload: the app downloads catalogue models on first use (`uwp/models/manifest.json` → `models-v1` GitHub Release). Use this only for provisioning models that have no download URL, or for development swaps.
 
 Models are ONNX GenAI **directories** (not single files). Upload each file in the directory:
 

--- a/docs/install-release.md
+++ b/docs/install-release.md
@@ -1,0 +1,72 @@
+# Install a release build on your Xbox
+
+How to install a tagged xllama release (e.g.
+[v1.0.0](https://github.com/gianlucamazza/xllama/releases/tag/v1.0.0)) on an
+Xbox Series S|X in Dev Mode, from a Linux/macOS host. For building from source
+see the [README](../README.md#build); for Dev Mode activation and Device
+Portal basics see [device-portal.md](./device-portal.md).
+
+## Prerequisites
+
+- Xbox in **Dev Mode** with the Device Portal enabled (note IP + credentials).
+- A credentials file, e.g. `~/.config/xllama/xbox-env`:
+
+  ```bash
+  export XBOX_IP=192.168.1.44
+  export XBOX_USER=...
+  export XBOX_PASS=...
+  ```
+
+- Internet access on the console (first launch downloads the default model).
+
+## 1. Download the release assets
+
+From the GitHub Release page (or `gh release download vX.Y.Z`):
+
+- `xllama_X.Y.Z.0_x64.msix` — the app (~19 MB, no model inside)
+- `xllama-test.cer` — the signing test certificate
+- `Microsoft.VCLibs.x64.14.00.appx` — runtime dependency
+
+## 2. Install the certificate, dependency, and app
+
+```bash
+source ~/.config/xllama/xbox-env
+
+# Trust cert (deploy.sh also auto-installs a .cer found next to the .msix)
+./scripts/deploy.sh install-cert xllama-test.cer
+
+# VCLibs dependency: install once via the Device Portal UI
+#   https://<XBOX_IP>:11443 → My games & apps → Install → Microsoft.VCLibs.x64.14.00.appx
+# (or add it as a dependency in the same WDP install dialog as the MSIX)
+
+# App
+./scripts/deploy.sh xllama_X.Y.Z.0_x64.msix
+```
+
+Notes:
+
+- **Upgrades**: a higher version installs over the old one and **preserves**
+  LocalState (models, settings, history). WDP refuses a same-version install
+  with different contents.
+- After (re)installs, check the **App type** in Dev Home (tile → View details):
+  the measured performance figures assume the **Game** designation
+  (`uwp-constraints.md §5`).
+
+## 3. First launch
+
+Launch xllama from Dev Home (or `./scripts/deploy.sh start-app`). The app
+downloads the default chat model (~417 MB) with a progress bar, then opens the
+chat. See [using-the-app.md](./using-the-app.md) from here.
+
+For image generation, the SD-Turbo model (2.4 GB, not in the download
+catalogue) is provisioned via Device Portal per
+[../diffusion/README.md](../diffusion/README.md) and the runbook §7.
+
+## Troubleshooting
+
+- `0x80070070` (disk full) while installing models: the Dev Mode partition has
+  ~2.2–2.5 GB free in total — remove unused models from LocalState first.
+- Startup issues: `./scripts/deploy.sh diagnose-startup` prints the process
+  state, the app log, and any crash dumps in one shot.
+- Log at any time: `./scripts/deploy.sh get-log`; individual files:
+  `./scripts/deploy.sh fetch-file "$(./scripts/deploy.sh pfn)" <name> <local-out>`.

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -7,10 +7,9 @@ xllama UWP build (Xbox Series S Dev Mode, CPU EP).
 
 | Constraint                              | Limit                                                                       | Source                       |
 | --------------------------------------- | --------------------------------------------------------------------------- | ---------------------------- |
-| Format                                  | ONNX GenAI directory (`genai_config.json` + `model.onnx` + tokenizer files) | ORT GenAI 0.13.2 requirement |
-| External data files                     | Must be merged before MSIX packaging                                        | `uwp-constraints.md §8`      |
-| On-disk size (merged ONNX)              | < 400 MB recommended, < 600 MB borderline                                   | `uwp-constraints.md §9`      |
-| MSIX size                               | < 600 MB recommended, < 800 MB borderline                                   | `uwp-constraints.md §9`      |
+| Format                                  | ONNX GenAI directory (`genai_config.json` + `model.onnx` + tokenizer files) | ORT GenAI 0.14.1 requirement |
+| External data files                     | Must be merged into a self-contained `model.onnx` before distribution       | `uwp-constraints.md §8`      |
+| On-disk size (merged ONNX)              | Dev Mode disk budget: ~2.2–2.5 GB free total across all models              | `uwp-constraints.md §9`      |
 | GPU EP weights (if attempting DirectML) | < ~300 MB                                                                   | `uwp-constraints.md §5`, §7  |
 
 ## Selection sequence
@@ -32,36 +31,25 @@ xllama UWP build (Xbox Series S Dev Mode, CPU EP).
 
    The script prints a `NOTE` or `WARNING` if the merged size exceeds budget thresholds.
 
-4. Check on-disk size. Reject if > 600 MB:
+4. Check on-disk size against the Dev Mode disk budget (~2.2–2.5 GB free total):
 
    ```bash
    du -sm models/<name>
    ```
 
-5. Update `uwp/xllama.vcxproj` to point to the new model directory. Build MSIX:
-
-   ```bash
-   # From Windows VM or via CI push:
-   .\scripts\build-uwp.ps1 -Configuration Release -Platform x64
-   ```
-
-6. Inspect MSIX size. Reject if > 800 MB:
-
-   ```bash
-   ls -lh uwp/AppPackages/xllama/*.msix
-   ```
-
-7. Deploy:
+5. Provision it on the console — either add a catalogue entry (see
+   "Add your own model" below) and let the app download it, or upload directly:
 
    ```bash
    source ~/.config/xllama/xbox-env
-   ./scripts/deploy.sh path/to/xllama_*.msix
+   PFN=$(./scripts/deploy.sh pfn)
+   ./scripts/deploy.sh upload-dir models/<name>/ "$PFN" "models\\<name>"
    ```
 
-   If install fails with `0x80070070` (ERROR_DISK_FULL), the model exceeds the
-   available Dev Mode partition space.
+   If the upload fails for space (`0x80070070` ERROR_DISK_FULL), the model
+   exceeds the available Dev Mode partition space.
 
-8. Launch and check the log:
+6. Launch and check the log:
 
    ```bash
    ./scripts/deploy.sh get-log
@@ -69,7 +57,7 @@ xllama UWP build (Xbox Series S Dev Mode, CPU EP).
 
    If `OgaCreateModel failed` appears, see `phase1-runbook.md §8` for diagnosis.
 
-9. Benchmark and compare against the current baseline:
+7. Benchmark and compare against the current baseline:
    ```bash
    ./scripts/bench-xbox.sh <model-name> bench/config/phase1-smollm2-360m.json
    ```
@@ -77,13 +65,13 @@ xllama UWP build (Xbox Series S Dev Mode, CPU EP).
 
 ## Reference: tested models
 
-| Model                          | On-disk (merged) | CPU EP                                | DirectML EP                                      | Notes                                                                                                     |
-| ------------------------------ | ---------------- | ------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
-| SmolLM2-360M-Instruct INT4 CPU | 403 MB           | ✅ Active baseline (70.9 tok/s)       | ❌ `80070057` (CPU-int4 graph in DML fused node) | Bundled in MSIX                                                                                           |
-| SmolLM2-360M-Instruct INT4 DML | 285 MB           | —                                     | ✅ **8.8 tok/s** (headless v0.3.4)               | Built with ORT GenAI model builder (`-p int4 -e dml`); CPU ~8× faster — DML not competitive at this scale |
-| SmolLM2-1.7B-Instruct INT4 CPU | 1.4 GB           | ❌ MSIX bundling / ✅ via USB (Exp 3) | —                                                | 23.6 tok/s, n=191, peak 2195 MB                                                                           |
-| Phi-3.5-mini INT4 CPU          | ~2.7 GB          | ❌ Disk budget                        | —                                                | Not attempted                                                                                             |
-| Phi-3.5-mini GPU INT4 AWQ      | ~2.2 GB          | —                                     | ❌ GPU OOM + disk                                | Not viable                                                                                                |
+| Model                          | On-disk (merged) | CPU EP                                  | DirectML EP                                      | Notes                                                                                                     |
+| ------------------------------ | ---------------- | --------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| SmolLM2-360M-Instruct INT4 CPU | 417 MB           | ✅ Active baseline (66.3 tok/s, 0.14.1) | ❌ `80070057` (CPU-int4 graph in DML fused node) | Default; downloaded from the `models-v1` Release catalogue                                                |
+| SmolLM2-360M-Instruct INT4 DML | 285 MB           | —                                       | ✅ **8.8 tok/s** (headless v0.3.4)               | Built with ORT GenAI model builder (`-p int4 -e dml`); CPU ~8× faster — DML not competitive at this scale |
+| SmolLM2-1.7B-Instruct INT4 CPU | 1.4 GB           | ✅ via USB / LocalState                 | —                                                | Console: 20.6 tok/s decode, peak 2423 MB (`phase35-1b-cpu.csv`)                                           |
+| Phi-3.5-mini INT4 CPU          | ~2.7 GB          | ❌ Disk budget                          | —                                                | Not attempted                                                                                             |
+| Phi-3.5-mini GPU INT4 AWQ      | ~2.2 GB          | —                                       | ❌ GPU OOM + disk                                | Not viable                                                                                                |
 
 ## Candidates evaluated (HF Hub file sizes, 2026-07-02)
 
@@ -105,7 +93,7 @@ Sizes below are the published `model.onnx.data` file sizes on Hugging Face
   (`onnx-community/Llama-3.2-1B-Instruct-GENAI-ONNX`
   `cpu-int4-rtn-block-32-acc-level-4`; `patdev/Llama-3.2-1B-Instruct-int4-cpu-onnx`
   identical; `aigdat` AWQ-uint4 ~1.66 GB). USB-only path, same class as
-  SmolLM2-1.7B (1.4 GB, 23.6 tok/s).
+  SmolLM2-1.7B (1.4 GB, 20.6 tok/s on console).
 - **Gemma-2-2B INT4 ONNX CPU**: estimated above 1 GB merged — unlikely to fit.
 
 Verify with `merge_onnx_external_data.py` output before committing to a build.
@@ -122,3 +110,41 @@ This document records only observed behavior at the application boundary. See
 `uwp-constraints.md §7` (GPU pool) and `uwp-constraints.md §9` (disk budget) for
 what we measure. Do not treat any claim about the internal Xbox OS partition layout
 as authoritative unless backed by a Microsoft source.
+
+## Add your own model (manifest override, no reinstall)
+
+The Settings ComboBox is populated from the model catalogue. A
+`LocalState\manifest.json` uploaded via Device Portal **overrides the bundled
+catalogue entirely** (`uwp/model-downloader.cpp`, `LoadModelManifest`), so you can
+add models without rebuilding the MSIX:
+
+1. Copy `uwp/models/manifest.json` and add an entry:
+
+   ```json
+   {
+     "name": "my-model-dir",
+     "display": "My Model (CPU int4)",
+     "kind": "ort-genai",
+     "hf_base_url": "https://example.com/base/url",
+     "files": [{ "filename": "model.onnx", "approx_bytes": 123456789 }]
+   }
+   ```
+
+   With `hf_base_url` set, the app downloads `<hf_base_url>/<filename>` for each
+   file on selection. Without it, the entry expects the directory at
+   `LocalState\models\<name>` (Device Portal upload) or USB `E:\xllama\models\<name>`.
+
+2. Upload the override and (if needed) the model files:
+
+   ```bash
+   source ~/.config/xllama/xbox-env
+   PFN=$(./scripts/deploy.sh pfn)
+   ./scripts/deploy.sh upload-file my-manifest.json "$PFN" ""   # rename to manifest.json first
+   ./scripts/deploy.sh upload-dir ./my-model-dir/ "$PFN" "models\\my-model-dir"
+   ```
+
+3. Restart the app: the ComboBox now shows the new entry.
+
+Constraints: `model.onnx` must be **self-contained** (< 2 GB, external data merged —
+`uwp-constraints.md §8`) and fit the Dev Mode disk budget. For diffusion models the
+contract is different (three components + CLIP assets): see `diffusion/README.md`.

--- a/docs/phase1-runbook.md
+++ b/docs/phase1-runbook.md
@@ -9,7 +9,7 @@ End-to-end instructions for building, deploying, and benchmarking xllama on Xbox
 - Linux dev machine with this repo cloned (`--recursive`)
 - Credentials file at `~/.config/xllama/xbox-env` (see `.env.example`)
 
-The bundled model (SmolLM2-360M-Instruct INT4 CPU, 403 MB) is included in the MSIX — no separate download or upload is required.
+The MSIX ships **no model** (~19 MB package): on first launch the app downloads the default model (SmolLM2-360M-Instruct INT4 CPU, 417 MB) from the `models-v1` GitHub Release catalogue (`uwp/models/manifest.json`). No manual upload is required — Device Portal/USB provisioning remains available for models without a download URL.
 
 For local UWP builds from an Arch workstation, use the Windows VM workflow in
 [windows-dev-vm.md](./windows-dev-vm.md). Linux cannot build the UWP/MSIX package because Windows SDK packaging tools require Windows.
@@ -32,7 +32,7 @@ Download the `xllama-appx` artifact from the Actions run. It contains:
 # Output: uwp\AppPackages\xllama\xllama_*.msix
 ```
 
-The CI and the local build both run `scripts/merge_onnx_external_data.py` to merge the model's external data into a self-contained `model.onnx` before packaging (required for AppContainer compatibility — see `docs/uwp-constraints.md §8`).
+The build packages no model. Model artifacts are prepared separately: external ONNX data must be merged into a self-contained `model.onnx` (`scripts/merge_onnx_external_data.py`) before distribution, required for AppContainer compatibility — see `docs/uwp-constraints.md §8`. The published `models-v1` Release assets are already merged.
 
 ## 2. Deploy to Xbox
 
@@ -77,14 +77,14 @@ Navigate to: LocalAppData → `VenereLabs.xllama_..._x64__<token>` → `LocalSta
 
 ## 4. Switching models
 
-The default bundled model is `smollm2-360m-cpu-int4`. Three alternatives are available, in order of preference:
+The default model is `smollm2-360m-cpu-int4` (downloaded on first launch). Alternatives, in order of preference:
 
-**Option A — Settings ComboBox (v0.3.0+, recommended):**
-Open the ⚙ Settings dialog inside the app. The Model ComboBox exposes:
-
-- SmolLM2-360M (bundled MSIX)
-- SmolLM2-1.7B (USB `E:\xllama\models\`)
-- SmolLM2-360M (HF download in LocalState)
+**Option A — Settings ComboBox (recommended):**
+Open the ⚙ Settings dialog inside the app. The Model ComboBox is populated from the
+catalogue (`uwp/models/manifest.json`, overridable via `LocalState\manifest.json`):
+any entry with a download URL is fetched on selection from the `models-v1` GitHub
+Release; entries without a URL expect USB (`E:\xllama\models\`) or Device Portal
+provisioning.
 
 The selection is persisted to `LocalState/settings.json` and takes effect on the next inference call (session rebuilt transparently).
 

--- a/docs/technical-report.md
+++ b/docs/technical-report.md
@@ -23,7 +23,7 @@ DirectML 1.24.4 for vision; llama.cpp (static ggml, CPU) as an A/B lane.
 
 ## 2. Text generation: the CPU wins decode, and nothing beats it
 
-SmolLM2-360M, identical prompts (285/~1050 tok), Game-mode, v0.4.x:
+SmolLM2-360M, identical prompts (285/~1050 tok), Game-mode, measured on the 0.4.x→1.0 line:
 
 | Backend                  | prefill 285 | prefill ~1k | decode   |
 | ------------------------ | ----------- | ----------- | -------- |
@@ -109,11 +109,12 @@ hardware, because console runtime errors are expensive to attribute:
 
 - Chat UI (ChatML, history, settings) with per-conversation CPU/GPU routing and
   KV-cache reuse; models described by a `manifest.json` catalogue (bundled +
-  Device-Portal-overridable) with in-app HF download.
+  Device-Portal-overridable) with in-app download from the `models-v1` GitHub
+  Release (the upstream HF path shipped a non-merged model and was retired).
 - Image generation UI over the headless SD-Turbo fp16 pipeline.
 - Headless bench/validation modes (`bench.flag`, `image.flag`, `diffuse.flag`)
-  with CSV artifacts; a console-validation runbook; CI producing bundled,
-  nobundle, and llamacpp MSIX variants.
+  with CSV artifacts; a console-validation runbook; CI producing the default
+  (no-model, ~19 MB) and llamacpp MSIX variants.
 
 **Bottom line.** On a 2020 console in a sandbox: a 360M-class chat model at
 66 tok/s, a 1.7B at 21 tok/s, ~5 s multi-turn latency turned interactive by KV

--- a/docs/using-the-app.md
+++ b/docs/using-the-app.md
@@ -1,0 +1,71 @@
+# Using xllama on the Xbox
+
+App guide for the gamepad UI. For installation see
+[install-release.md](./install-release.md); for the engineering background see
+[technical-report.md](./technical-report.md).
+
+## First launch — model download
+
+The MSIX ships no model (~19 MB). On first launch the app downloads the default
+chat model (SmolLM2-360M-Instruct INT4, ~417 MB) from the
+[`models-v1` GitHub Release](https://github.com/gianlucamazza/xllama/releases/tag/models-v1)
+with a progress bar, writes it to `LocalState\models\`, and opens the chat.
+The console needs internet access for this step; afterwards everything runs
+offline. If the download fails, provisioning via Device Portal or USB
+(`E:\xllama\models\<name>`) is described in
+[model-selection.md](./model-selection.md).
+
+## Chat
+
+Type with the on-screen keyboard (or a USB keyboard) and send. The toolbar:
+
+- **`[=] History`** — saved conversations: reopen, delete, or start a
+  **New conversation**. History persists in `LocalState`.
+- **`[S] Settings`** — see below.
+- **`[*] Image`** — image generation, see below.
+
+Generation shows live tok/s; **■ Cancel** stops a running reply.
+
+## Settings (`[S]`)
+
+- **Model** — ComboBox populated from the model catalogue
+  (`uwp/models/manifest.json`; overridable, see
+  [model-selection.md](./model-selection.md)). Selecting an entry with a
+  download URL fetches it on the spot; entries without one expect USB or
+  Device Portal provisioning.
+- **Sampling** — Temperature, Top-p, Top-k, Repetition penalty, Max new tokens.
+- **KV-cache reuse** (default on) — reuses the conversation's KV cache across
+  turns; measured **4.87×** faster turn-2 prefill on console. Leave it on
+  unless debugging.
+- **EP routing (per conversation)** — where inference runs:
+  - **CPU only (default)** — best decode throughput at 360M scale (~66 tok/s).
+  - **GPU only (DML)** — forces DirectML (needs the `gpu_model`, e.g.
+    `smollm2-360m-dml-fp16`, in LocalState).
+  - **Auto (long prompts → GPU)** — long first prompts route to GPU fp16
+    (prefill is 1.8× faster at ~1k tokens), short chats stay on CPU; the
+    choice is sticky per conversation.
+
+Settings persist to `LocalState\settings.json` and take effect on the next
+inference call.
+
+## Image generation (`[*]`)
+
+The dialog shows the last generated image (if any), a prompt box, and a
+**Steps** slider (1–4; SD-Turbo needs 1). Pressing **Generate (restarts app)**:
+
+1. writes the prompt/steps/seed and the `diffuse.flag`,
+2. **restarts the app** into a headless mode that runs SD-Turbo fp16 on the
+   GPU (~7 s for 512×512, plus ~7 s of model load) and exits,
+3. at the next launch, open `[*] Image` again to see the result.
+
+The restart is a workaround for a D3D12 device conflict between DirectML and
+the XAML compositor (`uwp-constraints.md §7`); removing it is in progress
+(in-process experiment + upstream fix
+[onnxruntime-genai#2280](https://github.com/microsoft/onnxruntime-genai/pull/2280)).
+
+Requires the `sd-turbo-fp16` model (2.4 GB, three components — not in the
+download catalogue) and the CLIP tokenizer assets in LocalState, provisioned
+via Device Portal — see [../diffusion/README.md](../diffusion/README.md) for
+how they are produced and uploaded. Each generation writes
+`diffuse-out.png`, `diffuse-result.csv` (per-stage timings) and a live
+`diffuse-progress.txt`; no cleanup is needed between runs.

--- a/docs/windows-dev-vm.md
+++ b/docs/windows-dev-vm.md
@@ -70,10 +70,12 @@ git submodule update --init --recursive
 ```
 
 The build script:
+
 1. Restores NuGet packages (`nuget restore`).
-2. Runs `merge_onnx_external_data.py` to merge the model's external data into a self-contained `model.onnx` (required for AppContainer `weakly_canonical` compatibility — see `docs/uwp-constraints.md §8`).
-3. Builds with MSBuild.
-4. Signs the package with the test certificate.
+2. Builds with MSBuild (`-Backend llamacpp` selects the bench-only ggml/llama.cpp text backend; the default is ORT GenAI).
+3. Signs the package with the test certificate.
+
+No model is packaged: distribution artifacts are prepared separately and must be self-contained (`scripts/merge_onnx_external_data.py`, `docs/uwp-constraints.md §8`).
 
 The package output is under:
 


### PR DESCRIPTION
## Summary
Audit in three passes (docs↔code, docs↔measured state, undocumented features), then fixes:

**Drift retired**
- Bundled-model narrative (README ×9, phase1-runbook, device-portal, windows-dev-vm, model-selection) → first-launch download from the `models-v1` Release catalogue, 19 MB no-model MSIX
- "GPU pool ~768 MB / DML not viable" → measured 3801 MB budget, per-workload verdict, image generation in the feature story
- Build docs claiming a build-time model merge → none exists (comment in build-uwp.yml fixed too)
- ROADMAP Phase 3/3.5 headers + stale items (load_ms baseline was already measured, 1.7B CPU = 20.6 tok/s, int4 variants location); 3 historical "pending" CHANGELOG lines flipped per the runbook's own convention; runbook sections stamped ✅/⏳ and de-anchored from v0.4.0.0
- model-selection: 0.14.1 baseline (66.3), 1.7B console numbers, selection sequence de-bundled

**Gaps filled**
- `docs/using-the-app.md` — end-user guide (first-launch download, chat, settings incl. routing/KV reuse, image generation)
- `docs/install-release.md` — install a tagged release (cert + VCLibs + WDP)
- `docs/model-selection.md` — "Add your own model" manifest-override how-to
- `docs/README.md` index completed; `deploy.sh fetch-file` + llamacpp CI variant documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation, usage, model selection, validation, and development guides to match the latest release flow.
  * Clarified first-launch model download behavior, model switching, and image-generation setup.
  * Expanded benchmark, routing, and performance notes with measured results.
  * Refreshed the changelog, roadmap, and README to reflect v1.0 release status and current app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->