### PR TITLE
feat(models): SD-Turbo in the download catalogue (image self-serve)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added — SD-Turbo in the download catalogue (image model self-serve)
+
+The image model no longer requires Device Portal provisioning: the catalogue
+gains a `kind: "diffusion"` entry for `sd-turbo-fp16` (validated artifact —
+`validate_pipeline.py` end-to-end pass; the `-ort-fp16` candidate is the
+CUDA-only NhwcConv trap and stays excluded), and the **Image dialog downloads
+it on the first Generate** (~2.4 GB, progress in the status bar).
+
+- Manifest schema: optional `kind` (`ort-genai` default / `diffusion`) and
+  per-file `remote` (flat release asset name; `filename` may now carry a
+  subpath like `unet/model.onnx` — the downloader creates subfolders).
+- Diffusion entries are hidden from the chat model picker.
+- `run_diffuse` reads the CLIP tokenizer from the model's own `tokenizer/`
+  dir first (what the download provides), falling back to the legacy
+  `LocalState\clip\` upload.
+- Requires the 5 `sd-turbo-fp16_*` assets on the `models-v1` GitHub Release.
+
 ### Docs — full drift audit + user guides (2026-07-09)
 
 Three-way audit (docs↔code, docs↔measured state, gaps) and fixes:

--- a/docs/install-release.md
+++ b/docs/install-release.md
@@ -58,9 +58,10 @@ Launch xllama from Dev Home (or `./scripts/deploy.sh start-app`). The app
 downloads the default chat model (~417 MB) with a progress bar, then opens the
 chat. See [using-the-app.md](./using-the-app.md) from here.
 
-For image generation, the SD-Turbo model (2.4 GB, not in the download
-catalogue) is provisioned via Device Portal per
-[../diffusion/README.md](../diffusion/README.md) and the runbook §7.
+For image generation, the SD-Turbo model (2.4 GB) is downloaded from the
+catalogue on the first **Generate** — mind the Dev Mode disk budget
+(~2.2–2.5 GB free total). Device Portal provisioning remains available
+([../diffusion/README.md](../diffusion/README.md), runbook §7).
 
 ## Troubleshooting
 

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -130,9 +130,13 @@ add models without rebuilding the MSIX:
    }
    ```
 
-   With `hf_base_url` set, the app downloads `<hf_base_url>/<filename>` for each
-   file on selection. Without it, the entry expects the directory at
+   With `hf_base_url` set, the app downloads `<hf_base_url>/<remote or filename>`
+   for each file on selection. Without it, the entry expects the directory at
    `LocalState\models\<name>` (Device Portal upload) or USB `E:\xllama\models\<name>`.
+   Optional fields: `kind` (`"ort-genai"` default; `"diffusion"` entries feed the
+   Image dialog and are hidden from the chat picker) and per-file `remote` (the
+   flat asset name in the release when `filename` carries a subpath, e.g.
+   `"filename": "unet/model.onnx"` + `"remote": "sd-turbo-fp16_unet_model.onnx"`).
 
 2. Upload the override and (if needed) the model files:
 

--- a/docs/using-the-app.md
+++ b/docs/using-the-app.md
@@ -63,9 +63,11 @@ the XAML compositor (`uwp-constraints.md §7`); removing it is in progress
 (in-process experiment + upstream fix
 [onnxruntime-genai#2280](https://github.com/microsoft/onnxruntime-genai/pull/2280)).
 
-Requires the `sd-turbo-fp16` model (2.4 GB, three components — not in the
-download catalogue) and the CLIP tokenizer assets in LocalState, provisioned
-via Device Portal — see [../diffusion/README.md](../diffusion/README.md) for
-how they are produced and uploaded. Each generation writes
+The `sd-turbo-fp16` model (2.4 GB: text encoder, UNet, VAE decoder + CLIP
+tokenizer) is **downloaded automatically on the first Generate** from the
+model catalogue, disk permitting (the Dev Mode budget is tight — free space
+first if needed); Device Portal provisioning remains available as an
+alternative ([../diffusion/README.md](../diffusion/README.md)). Each
+generation writes
 `diffuse-out.png`, `diffuse-result.csv` (per-stage timings) and a live
 `diffuse-progress.txt`; no cleanup is needed between runs.

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -952,6 +952,8 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
     std::vector<std::wstring> model_keys;
     int model_sel = 0;
     for (auto const& e : manifest) {
+        if (e.kind == L"diffusion")
+            continue; // image models belong to the Image dialog, not the chat picker
         modelBox.Items().Append(winrt::box_value(winrt::hstring(e.display)));
         if (m_model_filename == e.name)
             model_sel = (int)model_keys.size();
@@ -1141,6 +1143,59 @@ winrt::fire_and_forget MainPageController::ShowImageDialog() {
     auto result = co_await dlg.ShowAsync();
     if (result != winrt::Windows::UI::Xaml::Controls::ContentDialogResult::Primary)
         co_return;
+
+    // Ensure the diffusion model is present; download it from the catalogue if
+    // missing (kind "diffusion" entries never reach the chat picker).
+    constexpr const wchar_t* kDiffusionModel = L"sd-turbo-fp16";
+    {
+        auto local = ApplicationData::Current().LocalFolder();
+        std::wstring model_dir =
+            std::wstring(local.Path().c_str()) + L"\\models\\" + kDiffusionModel;
+        std::error_code ec;
+        const bool present = std::filesystem::exists(
+                                 std::filesystem::path(model_dir) / L"unet" / L"model.onnx", ec) ||
+                             ModelDownloader::IsComplete(model_dir);
+        if (!present) {
+            auto manifest = ::xllama::LoadModelManifest();
+            auto* entry = ::xllama::FindManifestEntry(manifest, kDiffusionModel);
+            if (!entry || entry->hf_base_url.empty() || entry->files.empty()) {
+                self->SetStatus(std::wstring(L"Model '") + kDiffusionModel +
+                                    L"' not found. Provision it via Device Portal "
+                                    L"(see diffusion/README.md).",
+                                StatusKind::Error);
+                co_return;
+            }
+            std::filesystem::create_directories(model_dir, ec);
+            if (ec) {
+                self->SetStatus(L"Cannot create the diffusion model dir", StatusKind::Error);
+                co_return;
+            }
+            self->SetStatus(L"Downloading image model (~2.4 GB)...", StatusKind::Working);
+            self->m_loadingBar.IsIndeterminate(false);
+            self->m_loadingBar.Value(0);
+            self->m_loadingBar.Visibility(winrt::Windows::UI::Xaml::Visibility::Visible);
+            auto dl_ok = std::make_shared<bool>(false);
+            auto dl_err = std::make_shared<std::wstring>();
+            co_await ModelDownloader::DownloadAsync(
+                entry->hf_base_url, model_dir, entry->files, m_root.Dispatcher(),
+                [self](uint64_t done, uint64_t total) {
+                    if (total > 0)
+                        self->m_loadingBar.Value((double)done / (double)total * 100.0);
+                    self->SetStatus(L"Downloading image model... " +
+                                        std::to_wstring(done / (1024 * 1024)) + L" MB",
+                                    StatusKind::Working);
+                },
+                [dl_ok, dl_err](bool ok2, std::wstring err) {
+                    *dl_ok = ok2;
+                    *dl_err = std::move(err);
+                });
+            self->m_loadingBar.Visibility(winrt::Windows::UI::Xaml::Visibility::Collapsed);
+            if (!*dl_ok) {
+                self->SetStatus(L"Image model download failed: " + *dl_err, StatusKind::Error);
+                co_return;
+            }
+        }
+    }
 
     // Stage the headless generation inputs. The flag is written LAST so a
     // partially staged run can never trigger.

--- a/uwp/diffuse.cpp
+++ b/uwp/diffuse.cpp
@@ -225,8 +225,19 @@ void run_diffuse() {
         Ort::MemoryInfo mem = cpu_mem();
 
         // ---- Tokenize (host-validated CLIP BPE) -----------------------------
-        auto tok = diffusion::ClipTokenizer::from_files(resolve_local_path("clip\\vocab.json"),
-                                                        resolve_local_path("clip\\merges.txt"));
+        // Tokenizer assets: prefer the model's own tokenizer/ dir (what the
+        // catalogue download provides), falling back to the legacy standalone
+        // LocalState\clip\ upload. Same CLIP BPE files either way.
+        auto exists = [](const std::string& p) {
+            return GetFileAttributesW(utf8_to_wstring(p).c_str()) != INVALID_FILE_ATTRIBUTES;
+        };
+        std::string vocab = resolve_local_path("models\\" + dir + "\\tokenizer\\vocab.json");
+        std::string merges = resolve_local_path("models\\" + dir + "\\tokenizer\\merges.txt");
+        if (!exists(vocab) || !exists(merges)) {
+            vocab = resolve_local_path("clip\\vocab.json");
+            merges = resolve_local_path("clip\\merges.txt");
+        }
+        auto tok = diffusion::ClipTokenizer::from_files(vocab, merges);
         const std::vector<int> ids = tok.encode(prompt); // length 77
 
         // Sessions are created and DESTROYED per stage: the 3801 MB GPU budget

--- a/uwp/model-downloader.cpp
+++ b/uwp/model-downloader.cpp
@@ -62,7 +62,7 @@ IAsyncAction ModelDownloader::DownloadAsync(std::wstring hf_repo_url, std::wstri
     constexpr uint32_t kBufSize = 256 * 1024; // 256 KB read buffer
 
     for (auto const& f : files) {
-        auto url_str = hf_repo_url + L"/" + f.filename;
+        auto url_str = hf_repo_url + L"/" + (f.remote.empty() ? f.filename : f.remote);
         Uri uri(url_str);
 
         // --- Send HTTP request ------------------------------------------------
@@ -89,12 +89,21 @@ IAsyncAction ModelDownloader::DownloadAsync(std::wstring hf_repo_url, std::wstri
         }
 
         // --- Open target file -------------------------------------------------
+        // filename may carry a relative subpath (e.g. "unet/model.onnx" for the
+        // diffusion components); create intermediate folders as needed.
         StorageFolder folder{nullptr};
         StorageFile out_file{nullptr};
         std::wstring open_err;
         try {
             folder = co_await StorageFolder::GetFolderFromPathAsync(local_dir);
-            out_file = co_await folder.CreateFileAsync(f.filename,
+            std::wstring leaf = f.filename;
+            size_t sep;
+            while ((sep = leaf.find_first_of(L"/\\")) != std::wstring::npos) {
+                folder = co_await folder.CreateFolderAsync(winrt::hstring(leaf.substr(0, sep)),
+                                                           CreationCollisionOption::OpenIfExists);
+                leaf = leaf.substr(sep + 1);
+            }
+            out_file = co_await folder.CreateFileAsync(winrt::hstring(leaf),
                                                        CreationCollisionOption::ReplaceExisting);
         } catch (...) {
             open_err = L"Cannot create file " + f.filename + L" in " + local_dir;
@@ -223,12 +232,14 @@ std::vector<ManifestEntry> parse_manifest(winrt::hstring const& text) {
         if (e.name.empty())
             continue;
         e.display = obj.GetNamedString(L"display", winrt::hstring(e.name));
+        e.kind = obj.GetNamedString(L"kind", L"ort-genai");
         e.hf_base_url = obj.GetNamedString(L"hf_base_url", L"");
         if (obj.HasKey(L"files")) {
             for (auto const& f : obj.GetNamedArray(L"files")) {
                 auto fo = f.GetObject();
                 ModelFile mf;
                 mf.filename = fo.GetNamedString(L"filename", L"");
+                mf.remote = fo.GetNamedString(L"remote", L"");
                 mf.approx_bytes = (uint64_t)fo.GetNamedNumber(L"approx_bytes", 0);
                 if (!mf.filename.empty())
                     e.files.push_back(std::move(mf));

--- a/uwp/model-downloader.cpp
+++ b/uwp/model-downloader.cpp
@@ -290,10 +290,10 @@ std::vector<ManifestEntry> LoadModelManifest() {
     // NOTE: no special_tokens_map.json — the HF repo does not have one (the old
     // hardcoded list requested it and got HTTP 404, breaking every download).
     e.files = {
-        {L"genai_config.json", 2'000},
-        {L"tokenizer.json", 3'600'000},
-        {L"tokenizer_config.json", 1'000},
-        {L"model.onnx", 417'404'408},
+        {L"genai_config.json", L"", 2'000},
+        {L"tokenizer.json", L"", 3'600'000},
+        {L"tokenizer_config.json", L"", 1'000},
+        {L"model.onnx", L"", 417'404'408},
     };
     return {e};
 }

--- a/uwp/model-downloader.h
+++ b/uwp/model-downloader.h
@@ -14,7 +14,10 @@
 namespace xllama {
 
 struct ModelFile {
-    std::wstring filename;
+    std::wstring
+        filename;        // local path under the model dir; may contain subdirs ("unet/model.onnx")
+    std::wstring remote; // asset name in the download source (release assets are flat);
+                         // empty = same as filename
     uint64_t approx_bytes; // 0 = unknown; used for progress display only
 };
 
@@ -42,9 +45,12 @@ class ModelDownloader {
 
 // One entry of the model catalogue (models/manifest.json). An empty hf_base_url
 // means the model cannot be auto-downloaded (USB/Device-Portal provisioning only).
+// kind selects the consumer: "ort-genai" (default, chat picker) or "diffusion"
+// (image dialog; hidden from the chat model ComboBox).
 struct ManifestEntry {
     std::wstring name;
     std::wstring display;
+    std::wstring kind{L"ort-genai"};
     std::wstring hf_base_url;
     std::vector<ModelFile> files;
 };

--- a/uwp/models/manifest.json
+++ b/uwp/models/manifest.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Model catalogue for xllama. Bundled at InstalledPath\\models\\manifest.json; a LocalState\\manifest.json (uploadable via Device Portal, no reinstall) overrides it entirely. Entries without hf_base_url are USB/Device-Portal-provisioned only. approx_bytes drives the download progress bar.",
+  "_comment": "Model catalogue for xllama. Bundled at InstalledPath\\models\\manifest.json; a LocalState\\manifest.json (uploadable via Device Portal, no reinstall) overrides it entirely. Entries without hf_base_url are USB/Device-Portal-provisioned only. approx_bytes drives the download progress bar. kind: 'ort-genai' (default, chat picker) or 'diffusion' (image dialog). files[].filename is the local path under models\\<name> (subdirs allowed); files[].remote is the flat asset name in the release (defaults to filename).",
   "models": [
     {
       "name": "smollm2-360m-cpu-int4",
@@ -31,6 +31,39 @@
     {
       "name": "smollm2-1.7b-cpu-int4",
       "display": "SmolLM2 1.7B (CPU int4)"
+    },
+    {
+      "name": "sd-turbo-fp16",
+      "display": "SD-Turbo (image, GPU fp16)",
+      "kind": "diffusion",
+      "hf_base_url": "https://github.com/gianlucamazza/xllama/releases/download/models-v1",
+      "files": [
+        {
+          "filename": "text_encoder/model.onnx",
+          "remote": "sd-turbo-fp16_text_encoder_model.onnx",
+          "approx_bytes": 681657392
+        },
+        {
+          "filename": "unet/model.onnx",
+          "remote": "sd-turbo-fp16_unet_model.onnx",
+          "approx_bytes": 1733278769
+        },
+        {
+          "filename": "vae_decoder/model.onnx",
+          "remote": "sd-turbo-fp16_vae_decoder_model.onnx",
+          "approx_bytes": 99125634
+        },
+        {
+          "filename": "tokenizer/vocab.json",
+          "remote": "sd-turbo-fp16_tokenizer_vocab.json",
+          "approx_bytes": 1059962
+        },
+        {
+          "filename": "tokenizer/merges.txt",
+          "remote": "sd-turbo-fp16_tokenizer_merges.txt",
+          "approx_bytes": 524619
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
(stacked on #24)

- Catalogue `kind: diffusion` entry for `sd-turbo-fp16` + Image dialog **downloads it on the first Generate** (~2.4 GB) — no more Device Portal provisioning for images
- Manifest schema: optional `kind` + per-file `remote` (flat release asset names); `filename` subpaths supported (downloader creates subfolders)
- Diffusion entries hidden from the chat model picker
- `run_diffuse` reads the CLIP tokenizer from `models\<dir>\tokenizer\` first, legacy `clip\` fallback (back-compat with the current console)

## Validated artifact
`validate_pipeline.py` end-to-end pass on `sd-turbo-fp16-fixed` (coherent image, std 51.9; ids int32, timestep int64); the `sd-turbo-ort-fp16` candidate fails with the CUDA-only `NhwcConv` kernel — confirmed trap, excluded.

## ⚠️ Before this is usable
The 5 `sd-turbo-fp16_*` assets must be uploaded to the `models-v1` Release (upload was classifier-blocked for me; staged symlinks ready):
```bash
gh release upload models-v1 <scratchpad>/release-assets/sd-turbo-fp16_*
```

## Test plan
- CI compile (default + llamacpp)
- Console: fresh Generate with no model present → download → restart flow produces the reference image

🤖 Generated with [Claude Code](https://claude.com/claude-code)