### PR TITLE
docs: in-proc PASS + runtime-backend + modern-model survey (v1.1.0 prep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+_(nothing yet)_
+
+## [1.1.0] - 2026-07-09
+
+**Image self-serve + faster in-app diffusion + dual-backend-ready build.** The
+image model now downloads itself from the catalogue; diffusion is proven to run
+in-process (no restart needed); and the binary can now compile both the ORT
+GenAI and llama.cpp backends into one MSIX, chosen per model at runtime — the
+groundwork for modern GGUF-only models (Qwen3.5, LFM2) the ORT builder can't
+produce. Full measured story: `docs/technical-report.md`.
+
+### Measured — plain ORT DML coexists with the XAML compositor (in-app diffusion)
+
+The `887A0036` device conflict that forced headless image generation was
+specific to ORT **GenAI**'s Agility device factory. `diffuse-inproc.flag` ran
+the full SD-Turbo pipeline **on a background thread inside the live XAML
+process** on console: coherent 512×512 PNG, compositor alive, no conflict, no
+OOM — **total 5.57 s, faster than the 6.9 s headless run** (warm GPU). Image
+generation no longer needs the restart flow (`docs/uwp-constraints.md` §7,
+runbook §7b). Wiring the in-app Generate is the follow-up; the restart flow
+stays as a fallback.
+
+### Added — runtime backend dispatch (ORT GenAI ⊕ llama.cpp in one binary)
+
+`src/bridge/session.cpp` + `inference.cpp` no longer select the backend with a
+mutually-exclusive `#ifdef XLLAMA_USE_ORT / #else`. Two independent capability
+macros (`XLLAMA_USE_ORT`, `XLLAMA_USE_LLAMA`) let both backends compile together;
+`Session::create` / `run_inference` become runtime dispatchers keyed on
+`SessionParams::backend` (`Auto` infers `.gguf` vs ORT-dir layout). A new
+`XllamaBackend=unified` UWP build links the static ggml lib alongside ORT and
+ships both — CI-validated (`build (unified)` green). Single-backend builds stay
+behaviorally identical. This unblocks modern GGUF-only models via llama.cpp
+while ORT remains the default; UI wiring (`kind:gguf`) is the next phase.
+
+### Evaluated — modern small models (host-validated; console benches pending)
+
+Surveyed the post-Qwen3/Gemma3 landscape (the ORT GenAI builder is frozen at
+those архitectures). Confirmed loading through our stack:
+
+- **Qwen3.5-0.8B** (Feb 2026, Apache-2.0) — current-gen, Q4_K_M 507 MB, runs via
+  our llama.cpp submodule (`qwen35` arch).
+- **LFM2.5-350M** (LiquidAI) — hybrid edge, Q4_K_M 218 MB, runs via llama.cpp.
+- **Qwen3-0.6B int4** — builds with the ORT GenAI builder (969 MB merged; the
+  151k-vocab embedding dominates — heavier than SmolLM2-360M's 417 MB).
+- **Gemma-3-270M** — gated on HF, build blocked pending a token.
+- **TAESD decoder** (madebyollin/taesd, MIT) — a 4.9 MB drop-in VAE that replaces
+  SD-Turbo's 94 MB decoder; `validate_pipeline.py --vae` confirms a coherent
+  image. On console the VAE stage is 2.6 s of 6.9 s → TAESD targets ~4.5 s.
+  Export recipe: `diffusion/export_taesd.py` (falsified the [0,1] output
+  assumption; the diffusers decoder already emits SD `[-1,1]`).
+
 ### Removed — purpose-served legacy (image spike, GGUF-era bench, dead switches)
 
 - **Image spike** (`uwp/image-spike.cpp`, the `image.flag` headless mode,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -212,15 +212,23 @@ Milestones:
 
 ## Phase 5 — Post-1.0 improvements 🚧 IN PROGRESS (2026-07-09)
 
-- [ ] **In-process diffusion experiment** (`diffuse-inproc.flag`, PR #20): does
-      plain ORT DML coexist with the XAML compositor? PASS → in-app image
-      generation, no restart flow (runbook §7b; `docs/uwp-constraints.md` §7
-      "Open experiment"). Console run pending.
+- [x] **In-process diffusion experiment** (`diffuse-inproc.flag`) — ✅ **PASS
+      2026-07-09**: plain ORT DML coexists with the XAML compositor (full
+      pipeline in-process, 5.57 s, coherent PNG, no 887A0036). Image generation
+      no longer needs the restart flow (runbook §7b, `docs/uwp-constraints.md`
+      §7). **Follow-up**: wire the in-app Generate (no restart).
 - [x] Diffusion progress/cancel plumbing (`diffuse-progress.txt`,
       `diffuse-cancel.flag`) — PR #20
+- [x] **Runtime backend dispatch** (PR #27) — ORT GenAI + llama.cpp compile
+      into one binary; `unified` MSIX variant CI-green. Unblocks modern
+      GGUF-only models (Qwen3.5, LFM2). Fase 2 (UI `kind:gguf`) next.
+- [x] **Modern-model survey** — Qwen3.5-0.8B / LFM2.5-350M load via llama.cpp;
+      Qwen3-0.6B builds via ORT (969 MB); TAESD decoder validated (`docs/model-selection.md`).
 - [ ] Interactive validations at the pad: §2 routing A/B + Image dialog flow
-- [ ] Closure benches: int4 `block_size=128` / `accuracy_level=4` (§12
-      confirm/refute) + first `load_ms` baseline
+- [~] Closure benches: int4 `block_size=128` / `accuracy_level=4` (§12
+  confirm/refute) — running on console 2026-07-09; `load_ms` baseline done
+- [ ] Fase 2: catalogue `kind:gguf` → `sp.backend`, gate KV-reuse/routing off
+      for GGUF; promote Qwen3.5/LFM2 to the catalogue if benches justify
 - [ ] If §2 shows `887A0036` on the GPU turn in XAML: vendor the patched GenAI
       DLL (PR microsoft/onnxruntime-genai#2280, console-validated) until the
       fix ships upstream

--- a/docs/console-validation-runbook.md
+++ b/docs/console-validation-runbook.md
@@ -209,23 +209,20 @@ done
 - If the image is noise, check the log for a tokenizer/model-shape mismatch (non-fp16
   model, `hidden_dim` ≠ 1024, wrong scheduler class).
 
-### 7b. In-process experiment (`diffuse-inproc.flag`) — PENDING
+### 7b. In-process experiment (`diffuse-inproc.flag`) — ✅ PASS 2026-07-09
 
-Falsification run for `docs/uwp-constraints.md` §7 "Open experiment": does plain ORT DML
-coexist with the XAML compositor device? Same inputs as §7, but write
-`diffuse-inproc.flag` **instead of** `diffuse.flag`, then `deploy.sh start-app` — the app
-starts the normal XAML UI and runs the pipeline on a background thread in the same
-process.
+Falsification run for `docs/uwp-constraints.md` §7: does plain ORT DML coexist with the
+XAML compositor device? **Result: YES.** With `diffuse-inproc.flag` (instead of
+`diffuse.flag`) the app started the normal XAML UI and ran the full SD-Turbo pipeline on
+a background thread **in the same process**: log `diffuse-inproc.flag detected -> in-process
+diffusion (compositor alive)` → te 1006 ms, UNet 2991 ms, VAE 1576 ms, **total 5.57 s** →
+`wrote diffuse-out.png` with the XAML window still up. No `887A0036`, no `8007000E`; the
+PNG is coherent and matches the headless output. In-process was even faster than headless
+(5.57 s vs 6.9 s, warm GPU).
 
-- Poll `diffuse-progress.txt` (`start` → `text_encoder` → `unet s/N` → `vae` → `done`);
-  `diffuse-cancel.flag` aborts between UNet steps (progress `cancelled`).
-- **PASS**: log shows `diffuse-inproc.flag detected` + per-stage ms + `wrote
-diffuse-out.png` with the XAML window still up; PNG matches the §7 headless output for
-  the same prompt/seed/steps.
-- **FAIL**: `diffuse: ORT error: ... 887A0036` (device conflict also affects plain ORT —
-  the headless flow stays) or `8007000E` during VAE (GPU budget with compositor:
-  headroom, not device, is the blocker).
-- Either outcome: record it in `docs/uwp-constraints.md` §7 and close the experiment.
+**Consequence**: image generation no longer needs the restart flow — it can run in-app on
+a background thread. The headless `diffuse.flag` path is kept only for bench parity. Wiring
+the in-app Generate (no restart) is the follow-up; the restart flow remains as a fallback.
 
 ## Closeout
 

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -152,3 +152,34 @@ add models without rebuilding the MSIX:
 Constraints: `model.onnx` must be **self-contained** (< 2 GB, external data merged —
 `uwp-constraints.md §8`) and fit the Dev Mode disk budget. For diffusion models the
 contract is different (three components + CLIP assets): see `diffusion/README.md`.
+
+## Modern models (2026 survey, runtime-backend era)
+
+The ORT GenAI model builder is frozen at the Qwen3 / Gemma3 architectures.
+Newer small models (Qwen3.5, LFM2, Gemma-4) ship as GGUF and run **only via
+llama.cpp** — reachable once the `unified` backend build (PR #27) is the default
+and the catalogue carries `kind: gguf` entries. Host-validated 2026-07-09;
+on-console decode/prefill benches pending.
+
+| Model               | Path       | Size (Q4_K_M / int4) | Status                                             |
+| ------------------- | ---------- | -------------------- | -------------------------------------------------- |
+| Qwen3.5-0.8B        | llama.cpp  | 507 MB               | ✅ loads+generates via submodule (`qwen35`); modern default candidate |
+| LFM2.5-350M         | llama.cpp  | 218 MB               | ✅ loads via submodule; hybrid edge arch           |
+| Qwen3-0.6B          | ORT GenAI  | 969 MB merged        | ✅ builds; heavy (151k-vocab embedding dominates)  |
+| Gemma-3-270M        | ORT GenAI  | ~300 MB (est.)       | ⛔ gated on HF — needs an access token to build    |
+| Gemma-4 (E2B/E4B)   | —          | ≥2B effective        | ⛔ too big + arch not in builder                   |
+
+Backend selection is by `SessionParams::backend` (`Auto` infers `.gguf` →
+llama.cpp, ORT-dir → ORT). Redistribution to the `models-v1` Release requires a
+permissive license: Qwen (Apache) ✅; LFM Open License / Gemma Terms — verify
+before hosting, else provision manually (entry without `hf_base_url`).
+
+### TAESD — a faster diffusion VAE decoder
+
+`madebyollin/taesd` (MIT) is a **4.9 MB** tiny autoencoder that drop-in replaces
+SD-Turbo's 94 MB VAE decoder (same `latent_sample [1,4,64,64] → sample
+[1,3,512,512]` contract). On console the VAE stage is 2.6 s of the 6.9 s total,
+so TAESD targets **~4.5 s/image** and frees ~90 MB of GPU. Export with
+`diffusion/export_taesd.py` (the diffusers `AutoencoderTiny` decoder already
+emits SD `[-1,1]` — the [0,1]→remap assumption was falsified); validate the swap
+with `validate_pipeline.py <sd_dir> out.png "<prompt>" 1 42 <taesd_dir>`.

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -179,17 +179,21 @@ GenAI release, the interactive (XAML) app can use DML without the headless
 path — practically relevant only if a larger model ever makes DML
 competitive (CPU is 8× faster at 360M scale).
 
-**Open experiment — plain ORT DML in the XAML process (`diffuse-inproc.flag`)**:
-the conflict above was measured with **ORT GenAI**, whose DML EP goes through the
-Agility device factory. The diffusion pipeline (`uwp/diffuse.cpp`) uses **plain
-ORT DirectML** (`OrtSessionOptionsAppendExecutionProvider_DML`, ORT 1.24.4) —
-potentially the same plain-`D3D12CreateDevice` path that coexisted with the
-compositor in Exp 1. The headless requirement for diffusion was inherited from
-the GenAI finding, never falsified for plain ORT. `diffuse-inproc.flag`
-(`App.cpp`) runs `run_diffuse()` on a background MTA thread inside the live XAML
-process to test exactly that. If it holds, image generation becomes in-app (no
-restart flow); watch GPU headroom — compositor + 2.4 GB of sequential-lifetime
-weights inside the 3801 MB budget. **Pending console run.**
+**Plain ORT DML coexists with the XAML compositor — ✅ MEASURED 2026-07-09.**
+The `887A0036` conflict was measured with **ORT GenAI**, whose DML EP goes
+through the Agility device factory. The diffusion pipeline (`uwp/diffuse.cpp`)
+uses **plain ORT DirectML** (`OrtSessionOptionsAppendExecutionProvider_DML`,
+ORT 1.24.4), and the headless requirement was _inherited_ from the GenAI finding,
+never falsified for plain ORT. `diffuse-inproc.flag` (`App.cpp`) runs
+`run_diffuse()` on a background MTA thread **inside the live XAML process**;
+on console it ran the full SD-Turbo pipeline to a coherent 512×512 PNG **with
+the compositor alive** — no `887A0036`, no OOM (te 1006 ms, UNet 2991 ms, VAE
+1576 ms, **total 5.57 s**, actually faster than the 6.9 s headless run, warm GPU).
+**Conclusion**: the device conflict is specific to GenAI's Agility factory;
+plain ORT DML shares the compositor's device fine. Image generation can run
+**in-app without the restart flow** — the headless `diffuse.flag` path is no
+longer required for diffusion (kept for bench parity). GPU headroom held:
+compositor + sequential-lifetime weights (~2.4 GB) inside the 3801 MB budget.
 
 **Diagnosis**: SEH `0xC0000005` in `OgaCreateModel`. WDP minidump (`type=2`) and the `xllama.log` entry `OgaCreateModel failed: ...` confirm the cause.
 

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -10,7 +10,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="1.0.1.0"
+    Version="1.1.0.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity


### PR DESCRIPTION
## Summary
Records the session's measured findings and preps the v1.1.0 release.

- **In-proc diffusion PASS** (§7/§7b): plain ORT DML coexists with the XAML compositor — full pipeline in-process, 5.57s, coherent PNG, no 887A0036. Image generation no longer needs the restart flow.
- **Runtime backend dispatch** landed (PR #27) — recorded in ROADMAP/CHANGELOG.
- **Modern-model survey** in model-selection.md: Qwen3.5-0.8B / LFM2.5-350M (llama.cpp), Qwen3-0.6B (ORT, 969MB), TAESD decoder (validated).
- Version → 1.1.0.0; CHANGELOG [1.1.0].

## Test plan
- CI (docs + build); then tag v1.1.0 + Release with the unified MSIX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)