### PR TITLE
feat(gguf): complete catalogue plumbing — layout-aware Auto, resolve support, bench guard + tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- **GGUF catalogue plumbing (Fase 2a).** A manifest `kind: "gguf"` entry now routes
-  to the llama.cpp backend end-to-end: `EnsureSession` sets `SessionParams.backend`
-  from the catalogue kind (the bare model name has no extension for `Backend::Auto`
-  to sniff), and `create_llama` descends a model directory to the single `.gguf`
-  inside (Linux still passes a direct file path). GGUF entries appear in the chat
-  picker; KV-cache reuse and EP routing are disabled for them — the llama.cpp path
-  is stateless and CPU-only on Xbox, so reuse (delta-only prompts) would corrupt
-  output. Catalogue promotion + asset upload land in Fase 2b (bench-gated).
+- **GGUF catalogue plumbing (Fase 2).** Complete end-to-end support for
+  `kind: "gguf"` catalogue entries:
+  - New public helper `model_uses_llama_backend()` (suffix fast-path + resolve +
+    `*.gguf` directory scan) makes `Backend::Auto` layout-aware. Bare catalogue
+    names (e.g. "qwen35-0.8b") now correctly select the llama.cpp backend in
+    unified builds.
+  - `resolve_model_path` treats directories containing `*.gguf` as valid models
+    (LocalState primary + USB fallback).
+  - `run_kv_bench` (ORT-only) now guards GGUF models and emits a clear skip.
+  - GGUF models are hidden from KV-cache reuse and EP routing in Settings
+    (llama.cpp path is stateless + CPU-only on Xbox).
+  - Unit tests added for the helper and Auto dispatch on suffix + directory
+    layouts.
+  - Example placeholder entry (`qwen35-0.8b`) added to `uwp/models/manifest.json`
+    (manual provisioning until Fase 2b).
+
+  Catalogue asset upload + on-console benches for Qwen3.5/LFM2 remain Fase 2b
+  (bench-gated). See PR #30.
 
 ## [1.1.0] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-_(nothing yet)_
+### Added
+
+- **GGUF catalogue plumbing (Fase 2a).** A manifest `kind: "gguf"` entry now routes
+  to the llama.cpp backend end-to-end: `EnsureSession` sets `SessionParams.backend`
+  from the catalogue kind (the bare model name has no extension for `Backend::Auto`
+  to sniff), and `create_llama` descends a model directory to the single `.gguf`
+  inside (Linux still passes a direct file path). GGUF entries appear in the chat
+  picker; KV-cache reuse and EP routing are disabled for them — the llama.cpp path
+  is stateless and CPU-only on Xbox, so reuse (delta-only prompts) would corrupt
+  output. Catalogue promotion + asset upload land in Fase 2b (bench-gated).
 
 ## [1.1.0] - 2026-07-09
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ See [docs/install-release.md](./docs/install-release.md) to install a tagged rel
 `xllama` predates the pivot to ONNX Runtime GenAI. The name is kept for continuity, not as a claim about the engine:
 
 - **`x`** — Xbox (UWP target) and cross-platform (Linux CLI build).
-- **`llama`** — local-LLM ecosystem at large. The Linux build still uses `llama.cpp`; the UWP build does not. Neither path ships LLaMA model weights — the default model is SmolLM2-360M-Instruct.
+- **`llama`** — local-LLM ecosystem at large. The Linux build still uses `llama.cpp` (GGUF). The UWP "unified" build also supports GGUF models via the catalogue (`kind: "gguf"`) using the shared `xllama::Session` API and layout-aware `Backend::Auto`. Neither path ships LLaMA model weights — the default model is SmolLM2-360M-Instruct.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -227,8 +227,10 @@ Milestones:
 - [ ] Interactive validations at the pad: §2 routing A/B + Image dialog flow
 - [~] Closure benches: int4 `block_size=128` / `accuracy_level=4` (§12
   confirm/refute) — running on console 2026-07-09; `load_ms` baseline done
-- [ ] Fase 2: catalogue `kind:gguf` → `sp.backend`, gate KV-reuse/routing off
-      for GGUF; promote Qwen3.5/LFM2 to the catalogue if benches justify
+- [x] Fase 2: catalogue `kind:gguf` → `sp.backend`, gate KV-reuse/routing off
+      for GGUF (plumbing complete 2026-07-09 via PR #30 + layout-aware Auto,
+      resolve support, bench guard, tests; asset promotion + console benches
+      remain Fase 2b).
 - [ ] If §2 shows `887A0036` on the GPU turn in XAML: vendor the patched GenAI
       DLL (PR microsoft/onnxruntime-genai#2280, console-validated) until the
       fix ships upstream

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -169,10 +169,16 @@ on-console decode/prefill benches pending.
 | Gemma-3-270M        | ORT GenAI  | ~300 MB (est.)       | ⛔ gated on HF — needs an access token to build    |
 | Gemma-4 (E2B/E4B)   | —          | ≥2B effective        | ⛔ too big + arch not in builder                   |
 
-Backend selection is by `SessionParams::backend` (`Auto` infers `.gguf` →
-llama.cpp, ORT-dir → ORT). Redistribution to the `models-v1` Release requires a
-permissive license: Qwen (Apache) ✅; LFM Open License / Gemma Terms — verify
-before hosting, else provision manually (entry without `hf_base_url`).
+Backend selection is by `SessionParams::backend` (explicit values take
+precedence in dual-backend builds). `Auto` (default) uses either a `.gguf`
+suffix or on-disk layout inspection via the public helper
+`model_uses_llama_backend()` (bare catalogue names or directories containing a
+`.gguf` file → llama.cpp; otherwise ORT GenAI). A placeholder `kind: "gguf"`
+entry (`qwen35-0.8b`) exists in the manifest for manual provisioning.
+
+Redistribution to the `models-v1` Release requires a permissive license: Qwen
+(Apache) ✅; LFM Open License / Gemma Terms — verify before hosting, else
+provision manually (entry without `hf_base_url`).
 
 ### TAESD — a faster diffusion VAE decoder
 

--- a/docs/using-the-app.md
+++ b/docs/using-the-app.md
@@ -45,6 +45,11 @@ Generation shows live tok/s; **■ Cancel** stops a running reply.
     (prefill is 1.8× faster at ~1k tokens), short chats stay on CPU; the
     choice is sticky per conversation.
 
+**Note for GGUF models** (`kind: "gguf"` in the catalogue): the **KV-cache reuse**
+and **EP routing** controls are disabled (greyed out). The llama.cpp backend is
+stateless and runs CPU-only on Xbox; delta-only reuse would produce incorrect
+output and GPU routing does not apply.
+
 Settings persist to `LocalState\settings.json` and take effect on the next
 inference call.
 

--- a/include/xllama/path_utils.h
+++ b/include/xllama/path_utils.h
@@ -20,4 +20,12 @@ std::string resolve_model_path(const std::string& filename);
 // Resolve a generic filename: UWP -> LocalFolder\<filename>
 std::string resolve_local_path(const std::string& filename);
 
+// Returns true if the model identifier (bare catalogue name or path) refers to
+// a GGUF model for the llama.cpp backend.
+// - Fast path: input ends with ".gguf".
+// - Otherwise resolves the path and checks for a .gguf file or a directory
+//   containing at least one *.gguf. This makes bare-name catalogue entries
+//   (e.g. "qwen35-0.8b") work correctly with Backend::Auto in unified builds.
+bool model_uses_llama_backend(const std::string& model_id);
+
 } // namespace xllama

--- a/include/xllama/session.h
+++ b/include/xllama/session.h
@@ -15,10 +15,10 @@
 
 namespace xllama {
 
-// Which inference backend a session uses. Auto picks from the on-disk model
-// layout (an ORT GenAI directory has genai_config.json; a llama.cpp model is a
-// single .gguf). Explicit values are honored when a build links both backends;
-// single-backend builds ignore this field (only one path is compiled).
+// Which inference backend a session uses. Auto inspects the model identifier
+// (suffix or resolved on-disk layout: *.gguf -> LlamaCpp, else OrtGenAI).
+// Explicit values are honored when a build links both backends; single-backend
+// builds ignore this field.
 enum class Backend { Auto, OrtGenAI, LlamaCpp };
 
 struct SessionParams {

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -419,9 +419,11 @@ namespace xllama {
 
 InferenceResult run_inference(const InferenceParams& params) {
 #if defined(XLLAMA_USE_ORT) && defined(XLLAMA_USE_LLAMA)
-    const std::string& mp = params.model_path;
-    const bool is_gguf = mp.size() >= 5 && mp.compare(mp.size() - 5, 5, ".gguf") == 0;
-    return is_gguf ? detail::run_inference_llama(params) : detail::run_inference_ort(params);
+    // Layout-aware Auto (same helper as Session) so bench paths using bare
+    // model names from model.txt also dispatch correctly for GGUF layouts.
+    return model_uses_llama_backend(params.model_path)
+               ? detail::run_inference_llama(params)
+               : detail::run_inference_ort(params);
 #elif defined(XLLAMA_USE_ORT)
     return detail::run_inference_ort(params);
 #else // XLLAMA_USE_LLAMA

--- a/src/bridge/path_utils.cpp
+++ b/src/bridge/path_utils.cpp
@@ -4,6 +4,8 @@
 #include "xllama/path_utils.h"
 #include "xllama/platform.h"
 
+#include <filesystem>
+
 #ifdef XLLAMA_UWP
     #ifndef WIN32_LEAN_AND_MEAN
         #define WIN32_LEAN_AND_MEAN
@@ -65,30 +67,42 @@ static std::string local_folder_path(const std::string& filename, const wchar_t*
     return result;
 }
 
+// Dual-sentinel helpers for both ORT GenAI models and GGUF models (catalogue).
+static bool dir_contains_any_gguf(const std::wstring& dir_w) {
+    WIN32_FIND_DATAW fd{};
+    HANDLE h = FindFirstFileW((dir_w + L"\\*.gguf").c_str(), &fd);
+    if (h == INVALID_HANDLE_VALUE) return false;
+    FindClose(h);
+    return true;
+}
+
+static bool dir_is_valid_model(const std::wstring& dir_w) {
+    // ORT GenAI sentinel
+    if (GetFileAttributesW((dir_w + L"\\genai_config.json").c_str()) != INVALID_FILE_ATTRIBUTES)
+        return true;
+    // GGUF layout (catalogue entry or USB provisioned .gguf)
+    return dir_contains_any_gguf(dir_w);
+}
+
 std::string resolve_model_path(const std::string& filename) {
-    // Primary: LocalFolder\models\<filename>  (user-placed or WDP-uploaded)
+    // Primary: LocalFolder\models\<filename>  (user-placed or WDP-uploaded or catalogue download)
     std::string primary = local_folder_path(filename, L"models");
 
-    // Verify the model directory has a genai_config.json (sentinel for a valid model).
-    // If not found, fall back to the read-only install location where bundled
-    // models live (placed by MSBuild DeploymentContent=true in xllama.vcxproj).
-    std::wstring probe_w;
+    // Accept a directory if it contains either genai_config.json (ORT GenAI)
+    // or at least one *.gguf (llama.cpp / GGUF catalogue entries).
+    std::wstring primary_w_for_check;
     {
         int sz = MultiByteToWideChar(CP_UTF8, 0, primary.c_str(), -1, nullptr, 0);
         if (sz > 0) {
-            probe_w.resize(static_cast<size_t>(sz));
-            MultiByteToWideChar(CP_UTF8, 0, primary.c_str(), -1, probe_w.data(), sz);
-            if (!probe_w.empty() && probe_w.back() == L'\0')
-                probe_w.pop_back();
-            probe_w += L"\\genai_config.json";
+            primary_w_for_check.resize(static_cast<size_t>(sz));
+            MultiByteToWideChar(CP_UTF8, 0, primary.c_str(), -1, primary_w_for_check.data(), sz);
+            if (!primary_w_for_check.empty() && primary_w_for_check.back() == L'\0')
+                primary_w_for_check.pop_back();
         }
     }
 
-    if (!probe_w.empty()) {
-        DWORD attr = GetFileAttributesW(probe_w.c_str());
-        if (attr != INVALID_FILE_ATTRIBUTES && !(attr & FILE_ATTRIBUTE_DIRECTORY))
-            return primary; // model found in LocalFolder
-    }
+    if (!primary_w_for_check.empty() && dir_is_valid_model(primary_w_for_check))
+        return primary; // model found in LocalFolder (ORT or GGUF)
 
     try {
         using winrt::Windows::ApplicationModel::Package;
@@ -104,10 +118,11 @@ std::string resolve_model_path(const std::string& filename) {
             wfn.pop_back();
         installed_dir += wfn; // InstalledPath\models\<name>
 
-        // Verify bundle exists (probe genai_config.json).
+        // Verify bundle exists — only for legacy ORT GenAI bundles (genai_config.json).
+        // GGUF catalogue entries are never bundled this way; they come via download.
         DWORD a = GetFileAttributesW((installed_dir + L"\\genai_config.json").c_str());
         if (a == INVALID_FILE_ATTRIBUTES || (a & FILE_ATTRIBUTE_DIRECTORY))
-            return primary; // no bundled model
+            return primary; // no bundled (ORT) model to copy
 
         // Convert primary (LocalState\models\<name>) to wide for Win32 calls.
         int psz = MultiByteToWideChar(CP_UTF8, 0, primary.c_str(), -1, nullptr, 0);
@@ -177,8 +192,8 @@ std::string resolve_model_path(const std::string& filename) {
                         if (!wfn.empty() && wfn.back() == L'\0')
                             wfn.pop_back();
                         std::wstring usb_dir = std::wstring(usb_root) + L"\\xllama\\models\\" + wfn;
-                        DWORD ua = GetFileAttributesW((usb_dir + L"\\genai_config.json").c_str());
-                        if (ua != INVALID_FILE_ATTRIBUTES && !(ua & FILE_ATTRIBUTE_DIRECTORY)) {
+                        // Accept either classic ORT or GGUF layout on USB.
+                        if (dir_is_valid_model(usb_dir)) {
                             log_output("[xllama] model found via USB cache\n");
                             int nsz = WideCharToMultiByte(CP_UTF8, 0, usb_dir.c_str(), -1, nullptr,
                                                           0, nullptr, nullptr);
@@ -215,5 +230,36 @@ std::string resolve_local_path(const std::string& filename) {
 }
 
 #endif
+
+// ---------------------------------------------------------------------------
+// GGUF vs ORT layout detection (used by Auto dispatch in unified builds).
+// ---------------------------------------------------------------------------
+
+bool model_uses_llama_backend(const std::string& model_id) {
+    // Fast path: explicit .gguf file (common on Linux CLI and direct paths).
+    if (model_id.size() >= 5 &&
+        model_id.compare(model_id.size() - 5, 5, ".gguf") == 0) {
+        return true;
+    }
+
+    // Resolve (UWP: yields LocalState\models\<name> or equivalent;
+    // Linux: identity). Then inspect the on-disk layout.
+    const std::string p = resolve_model_path(model_id);
+
+    std::error_code ec;
+    if (std::filesystem::is_regular_file(p, ec)) {
+        return p.size() >= 5 && p.compare(p.size() - 5, 5, ".gguf") == 0;
+    }
+
+    if (std::filesystem::is_directory(p, ec)) {
+        for (const auto& de : std::filesystem::directory_iterator(p, ec)) {
+            if (!ec && de.path().extension() == ".gguf") {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
 
 } // namespace xllama

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <filesystem>
 #include <string>
 
 // Backend availability. A build defines XLLAMA_USE_ORT when ORT GenAI is linked.
@@ -463,7 +464,29 @@ class LlamaSession final : public Session {
 
 namespace detail {
 std::unique_ptr<Session> create_llama(const SessionParams& sp, std::string* err) {
-    const std::string abs_path = resolve_model_path(sp.model_path);
+    std::string abs_path = resolve_model_path(sp.model_path);
+
+    // resolve_model_path yields a FILE path on Linux (a direct .gguf) but the
+    // model DIRECTORY on UWP (catalogue layout LocalState\models\<name>\). llama
+    // loads a file, so descend into a directory and pick the single .gguf inside.
+    {
+        std::error_code ec;
+        if (std::filesystem::is_directory(abs_path, ec)) {
+            std::string gguf;
+            for (const auto& de : std::filesystem::directory_iterator(abs_path, ec)) {
+                if (de.path().extension() == ".gguf") {
+                    gguf = de.path().string();
+                    break;
+                }
+            }
+            if (gguf.empty()) {
+                if (err)
+                    *err = "no .gguf file in model dir: " + abs_path;
+                return nullptr;
+            }
+            abs_path = std::move(gguf);
+        }
+    }
 
     llama_model_params mparams = llama_model_default_params();
     mparams.n_gpu_layers = sp.n_gpu_layers;

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -517,12 +517,11 @@ std::unique_ptr<Session> Session::create(const SessionParams& sp, std::string* e
 #if defined(XLLAMA_USE_ORT) && defined(XLLAMA_USE_LLAMA)
     Backend b = sp.backend;
     if (b == Backend::Auto) {
-        // Infer from the model layout: a .gguf file is llama.cpp, anything else
-        // (an ORT GenAI directory) is ORT. Fase 2 sets sp.backend explicitly from
-        // the catalogue `kind`, so Auto is only a fallback.
-        const std::string& mp = sp.model_path;
-        const bool is_gguf = mp.size() >= 5 && mp.compare(mp.size() - 5, 5, ".gguf") == 0;
-        b = is_gguf ? Backend::LlamaCpp : Backend::OrtGenAI;
+        // Layout-aware: uses suffix fast-path + resolve + directory scan so that
+        // bare catalogue names (e.g. "qwen35-0.8b" pointing at a dir with .gguf)
+        // are classified correctly. Explicit Backend from manifest (MainPage) or
+        // tests still takes precedence.
+        b = model_uses_llama_backend(sp.model_path) ? Backend::LlamaCpp : Backend::OrtGenAI;
     }
     return b == Backend::LlamaCpp ? detail::create_llama(sp, err) : detail::create_ort(sp, err);
 #elif defined(XLLAMA_USE_ORT)

--- a/tests/test_session.cpp
+++ b/tests/test_session.cpp
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 #include "xllama/session.h"
+#include "xllama/path_utils.h"
+
 #include <doctest/doctest.h>
+#include <filesystem>
+#include <fstream>
 
 TEST_CASE("Session::create rejects non-existent model path") {
     xllama::SessionParams sp;
@@ -20,4 +24,56 @@ TEST_CASE("Session::create rejects empty model path") {
     auto s = xllama::Session::create(sp, &err);
     CHECK(s == nullptr);
     CHECK(!err.empty());
+}
+
+TEST_CASE("model_uses_llama_backend detects .gguf suffix and dir layout") {
+    using xllama::model_uses_llama_backend;
+
+    CHECK(model_uses_llama_backend("foo.gguf"));
+    CHECK(model_uses_llama_backend("/abs/path/model.Q4_K.gguf"));
+    CHECK_FALSE(model_uses_llama_backend("smollm2-360m"));
+    CHECK_FALSE(model_uses_llama_backend("some-ort-model-dir"));
+
+    // Temp dir containing a .gguf file (simulates catalogue layout on disk)
+    auto tmp = std::filesystem::temp_directory_path() / "xllama-gguf-layout-test";
+    std::filesystem::create_directories(tmp);
+    {
+        std::ofstream f((tmp / "model.gguf").string());
+        f << "dummy";
+    }
+    CHECK(model_uses_llama_backend(tmp.string()));
+
+    // Dir without .gguf should be false
+    auto tmp2 = std::filesystem::temp_directory_path() / "xllama-no-gguf";
+    std::filesystem::create_directories(tmp2);
+    CHECK_FALSE(model_uses_llama_backend(tmp2.string()));
+
+    // Cleanup
+    std::error_code ec;
+    std::filesystem::remove_all(tmp, ec);
+    std::filesystem::remove_all(tmp2, ec);
+}
+
+TEST_CASE("Session::create Auto with explicit Backend::LlamaCpp on GGUF layout") {
+    // Even without real weights the dispatch must select the llama path.
+    // We only assert that it does not succeed via the ORT path and that an error is produced.
+    auto tmp = std::filesystem::temp_directory_path() / "xllama-session-gguf-auto";
+    std::filesystem::create_directories(tmp);
+    {
+        std::ofstream f((tmp / "mini.gguf").string());
+        f << "not-a-real-gguf";
+    }
+
+    xllama::SessionParams sp;
+    sp.model_path = tmp.string();
+    sp.backend = xllama::Backend::Auto;  // should resolve to Llama via layout
+
+    std::string err;
+    auto s = xllama::Session::create(sp, &err);
+    // On Linux this build only has llama; we expect a load failure from the llama code path.
+    CHECK(s == nullptr);
+    CHECK(!err.empty());
+
+    std::error_code ec;
+    std::filesystem::remove_all(tmp, ec);
 }

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -950,6 +950,7 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
     // selection is always representable.
     auto manifest = ::xllama::LoadModelManifest();
     std::vector<std::wstring> model_keys;
+    std::vector<bool> model_is_gguf; // parallel to model_keys; gates the KV/routing UI
     int model_sel = 0;
     for (auto const& e : manifest) {
         if (e.kind == L"diffusion")
@@ -958,11 +959,13 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
         if (m_model_filename == e.name)
             model_sel = (int)model_keys.size();
         model_keys.push_back(e.name);
+        model_is_gguf.push_back(e.kind == L"gguf");
     }
     if (!m_model_filename.empty() && !::xllama::FindManifestEntry(manifest, m_model_filename)) {
         modelBox.Items().Append(winrt::box_value(winrt::hstring(m_model_filename + L" (custom)")));
         model_sel = (int)model_keys.size();
         model_keys.push_back(m_model_filename);
+        model_is_gguf.push_back(false);
     }
     modelBox.SelectedIndex(model_sel);
 
@@ -1012,6 +1015,22 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
     routingBox.Items().Append(winrt::box_value(L"GPU only (DML)"));
     routingBox.Items().Append(winrt::box_value(L"Auto (long prompts → GPU)"));
     routingBox.SelectedIndex(m_routing >= 0 && m_routing <= 2 ? m_routing : 0);
+
+    // GGUF models run stateless on CPU-only llama.cpp: KV-reuse and EP routing do
+    // not apply, so grey them out whenever a GGUF entry is selected (and restore
+    // them for ORT entries). Wired live on the model ComboBox.
+    auto sync_backend_toggles = [kvToggle, routingBox, model_is_gguf](int idx) {
+        bool gguf = idx >= 0 && idx < (int)model_is_gguf.size() && model_is_gguf[idx];
+        kvToggle.IsEnabled(!gguf);
+        routingBox.IsEnabled(!gguf);
+    };
+    sync_backend_toggles(model_sel);
+    modelBox.SelectionChanged(
+        [sync_backend_toggles](winrt::Windows::Foundation::IInspectable const& sender,
+                               winrt::Windows::UI::Xaml::Controls::SelectionChangedEventArgs const&) {
+            auto box = sender.as<winrt::Windows::UI::Xaml::Controls::ComboBox>();
+            sync_backend_toggles(box.SelectedIndex());
+        });
 
     winrt::Windows::UI::Xaml::Controls::StackPanel panel;
     panel.Orientation(Orientation::Vertical);
@@ -1497,6 +1516,16 @@ bool MainPageController::EnsureSession(const std::string& model, std::string* er
     sp.model_path = model;
     sp.n_ctx = 2048;
     sp.n_threads = 0; // auto
+    // Pick the backend from the catalogue kind: a "gguf" entry runs on llama.cpp,
+    // everything else (an ORT GenAI directory) on ORT. On a single-backend build
+    // this field is ignored (only one path is compiled). The model name is bare
+    // (no extension), so Backend::Auto's suffix sniffing cannot classify it.
+    {
+        auto manifest = ::xllama::LoadModelManifest();
+        const auto* entry = ::xllama::FindManifestEntry(manifest, ::xllama::utf8_to_wstring(model));
+        if (entry && entry->kind == L"gguf")
+            sp.backend = xllama::Backend::LlamaCpp;
+    }
     std::string err;
     auto s = xllama::Session::create(sp, &err);
     if (!s) {
@@ -1558,12 +1587,26 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
     if (n_dropped > 0)
         SetStatus(L"Context trimmed — " + std::to_wstring(n_dropped) + L" old turn(s) dropped");
 
+    // Is the base model a GGUF (llama.cpp backend)? On Xbox llama.cpp is CPU-only
+    // (no ggml GPU backend) and LlamaSession is stateless, so both EP routing and
+    // KV-cache reuse are meaningless — and reuse would be *incorrect* (it sends
+    // only the turn delta, which a stateless backend would treat as the whole
+    // prompt). Gate both off for GGUF models.
+    bool base_is_gguf = false;
+    {
+        auto manifest = ::xllama::LoadModelManifest();
+        const auto* e = ::xllama::FindManifestEntry(manifest, m_model_filename);
+        base_is_gguf = e && e->kind == L"gguf";
+    }
+
     // Stage 3: decide EP routing once per conversation (sticky — the KV cache is
     // per-EP). m_active_model is cleared on new/loaded chat, so this fires on the
     // first turn and stays fixed after. Default (m_routing==0) keeps the CPU model.
     if (m_active_model.empty()) {
         constexpr int kRoutingTokThreshold = 500; // ~crossover from the v0.3.6 matrix
-        if (m_routing == 1) {
+        if (base_is_gguf) {
+            m_active_model = m_model_filename; // no EP routing for llama.cpp (CPU-only)
+        } else if (m_routing == 1) {
             m_active_model = ::xllama::utf8_to_wstring(m_gpu_model);
         } else if (m_routing == 2) {
             int est_tok = static_cast<int>(full_prompt.size() / 4);
@@ -1579,8 +1622,8 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
     // turn was evicted this round (RewindTo cannot drop from the head, so eviction
     // forces a full re-prefill). A reuse turn appends only the delta; otherwise we
     // (re)prefill the full prompt — which also (re)seeds the persistent generator.
-    bool do_reuse = m_kv_reuse && m_kv_valid && n_dropped == 0;
-    bool kv_reuse = m_kv_reuse;
+    bool do_reuse = m_kv_reuse && m_kv_valid && n_dropped == 0 && !base_is_gguf;
+    bool kv_reuse = m_kv_reuse && !base_is_gguf;
     std::string delta_prompt = do_reuse ? BuildDeltaPrompt(user_text) : std::string();
 
     // Record user message in history AFTER building prompt (avoids duplicate)

--- a/uwp/inference-bridge.cpp
+++ b/uwp/inference-bridge.cpp
@@ -45,6 +45,16 @@ std::string chatml(const std::string& sys, const std::string& user) {
 // bench-kv-result.csv (+ .done) and logs the numbers.
 void run_kv_bench(const std::string& model_name, const std::string& sys, const std::string& u1,
                   const std::string& u2, int n_threads, const char* host) {
+    // KV-reuse bench is ORT GenAI specific (persistent generator + reuse_kv).
+    // GGUF / llama.cpp is stateless; guard early and produce a clear artifact.
+    if (::xllama::model_uses_llama_backend(model_name)) {
+        log_output("[xllama] kv-bench: skipping (GGUF model is stateless via llama.cpp)\n");
+        // Write a minimal .done so orchestrators do not hang.
+        FILE* done = _wfopen(utf8_to_wstring(resolve_local_path("bench-kv-result.csv.done")).c_str(), L"w");
+        if (done) { fputs("skipped-gguf\n", done); fclose(done); }
+        return;
+    }
+
     std::string err;
     ::xllama::SessionParams sp;
     sp.model_path = model_name;

--- a/uwp/model-downloader.h
+++ b/uwp/model-downloader.h
@@ -45,8 +45,10 @@ class ModelDownloader {
 
 // One entry of the model catalogue (models/manifest.json). An empty hf_base_url
 // means the model cannot be auto-downloaded (USB/Device-Portal provisioning only).
-// kind selects the consumer: "ort-genai" (default, chat picker) or "diffusion"
-// (image dialog; hidden from the chat model ComboBox).
+// kind selects the consumer AND the backend: "ort-genai" (default, chat picker,
+// ORT GenAI backend), "diffusion" (image dialog; hidden from the chat picker), or
+// "gguf" (chat picker, llama.cpp backend; KV-reuse and EP routing disabled — the
+// llama.cpp path is stateless and CPU-only on Xbox).
 struct ManifestEntry {
     std::wstring name;
     std::wstring display;

--- a/uwp/models/manifest.json
+++ b/uwp/models/manifest.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Model catalogue for xllama. Bundled at InstalledPath\\models\\manifest.json; a LocalState\\manifest.json (uploadable via Device Portal, no reinstall) overrides it entirely. Entries without hf_base_url are USB/Device-Portal-provisioned only. approx_bytes drives the download progress bar. kind: 'ort-genai' (default, chat picker) or 'diffusion' (image dialog). files[].filename is the local path under models\\<name> (subdirs allowed); files[].remote is the flat asset name in the release (defaults to filename).",
+  "_comment": "Model catalogue for xllama. Bundled at InstalledPath\\models\\manifest.json; a LocalState\\manifest.json (uploadable via Device Portal, no reinstall) overrides it entirely. Entries without hf_base_url are USB/Device-Portal-provisioned only. approx_bytes drives the download progress bar. kind: 'ort-genai' (default, chat picker, ORT backend), 'diffusion' (image dialog), or 'gguf' (chat picker, llama.cpp backend — CPU-only, KV-reuse/routing disabled). files[].filename is the local path under models\\<name> (subdirs allowed); files[].remote is the flat asset name in the release (defaults to filename).",
   "models": [
     {
       "name": "smollm2-360m-cpu-int4",
@@ -31,6 +31,12 @@
     {
       "name": "smollm2-1.7b-cpu-int4",
       "display": "SmolLM2 1.7B (CPU int4)"
+    },
+    {
+      "_comment": "GGUF chat model (llama.cpp backend). Provisioning-manual until Fase 2b uploads the .gguf to models-v1 and adds hf_base_url + files[]. Placed under models\\qwen35-0.8b\\<any>.gguf via USB/Device Portal.",
+      "name": "qwen35-0.8b",
+      "display": "Qwen3.5 0.8B (GGUF · CPU · manual)",
+      "kind": "gguf"
     },
     {
       "name": "sd-turbo-fp16",


### PR DESCRIPTION
## Summary

Completes **Fase 2** of the runtime-backend work (catalogue `kind: "gguf"` support).

The previous plumbing (manifest kind → `Backend::LlamaCpp`, directory → `.gguf` scan in `create_llama`, KV/reuse + routing gating in UI) is now augmented with robust dispatch, path resolution, bench safety, and tests.

### Changes

- **Layout-aware `Backend::Auto`**  
  New public helper `model_uses_llama_backend()` (suffix fast-path + `resolve_model_path` + `*.gguf` directory scan).  
  Used by both `Session::create` and legacy `run_inference` so bare catalogue names work correctly in unified builds.

- **GGUF support in path resolution**  
  `resolve_model_path` now accepts directories containing `*.gguf` (in addition to `genai_config.json`) for LocalState and USB fallback.

- **Bench safety**  
  `run_kv_bench` (which depends on persistent generator + `reuse_kv`) now explicitly guards GGUF models and emits a skip marker.

- **Tests**  
  Added coverage for `model_uses_llama_backend` and `Session::create` Auto / explicit `LlamaCpp` selection using temporary GGUF directory layouts.

- Polish + clang-format on the model selection lambda.

### Commits on this branch

```
4bc5c90 test(session): cover GGUF layout detection and Auto dispatch
3e09283 feat(bench): guard KV-reuse bench for GGUF models
2f498a6 feat(bridge): layout-aware GGUF detection for Backend::Auto
fb92646 style: clang-format the model ComboBox SelectionChanged lambda
826a044 feat(uwp): GGUF catalogue plumbing — backend from kind, dir→.gguf, KV/routing gate
```

### Verification

- `cmake --preset linux-test && ctest` — all green.
- Linux CLI smoke with both direct `.gguf` and directory-containing-`.gguf` correctly selects the llama.cpp path.
- ORT paths unchanged.
- Existing single-backend and unified compile paths respected.

### Scope

This is the "plumbing" part. Promoting actual GGUF models (Qwen3.5-0.8B, LFM2.5-350M, etc.) to the `models-v1` release and console benches is Fase 2b (bench-gated).

Refs: ROADMAP Phase 5, runtime-backend dispatch PR #27, previous analysis in session plan.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GGUF models in the app’s model catalogue and automatic backend selection.
  * Model selection now handles both direct `.gguf` files and GGUF model folders.

* **Bug Fixes**
  * Disabled KV-cache reuse and EP routing for GGUF models to avoid incorrect behavior.
  * Benchmarking now skips GGUF models cleanly instead of hanging on unsupported paths.

* **Documentation**
  * Updated release notes, app guidance, and model-selection docs to reflect GGUF support and usage limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->