### PR TITLE
docs: fix documentation drift (AGENTS.md, README size, ROADMAP int4 marker)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,14 +37,13 @@ xllama/
 │   ├── MainPage.cpp / .h    # MainPageController (plain C++, not runtimeclass)
 │   ├── inference-bridge.cpp / .h   # UWP main_loop() + bench mode
 │   ├── chat-history.cpp / .h       # ChatHistory: Save/Load/Delete/Clear
-│   ├── model-downloader.cpp / .h   # EnsureModelAsync — HF chunked download (Exp 2)
-│   ├── packages.config      # NuGet pins (ORT GenAI 0.13.2, ORT 1.24.4, DirectML 1.15.4)
+│   ├── model-downloader.cpp / .h   # EnsureModelAsync — catalogue download (GitHub Release models-v1, models/manifest.json)
+│   ├── packages.config      # NuGet pins (ORT GenAI 0.14.1, ORT 1.24.4, DirectML 1.15.4)
 │   └── xllama.sln / .vcxproj
 ├── scripts/
 │   ├── deploy.sh                      # Device Portal: deploy, logs, bench trigger
 │   ├── build-uwp.ps1                  # Windows UWP packaging script
 │   ├── merge_onnx_external_data.py    # merge model.onnx.data → self-contained model.onnx
-│   ├── bench-xbox.sh                  # benchmark runner (llama.cpp / GGUF models)
 │   ├── bench-xbox-ort.sh              # benchmark runner (ORT GenAI; model already on device)
 │   ├── install-latest-build.sh        # fetch + deploy latest CI artifact
 │   ├── test-dml-config.sh             # upload DML provider_options without MSIX rebuild
@@ -101,7 +100,7 @@ Use `-ForceNewCert` only to regenerate the test signing certificate.
 
 - **ORT GenAI path**: UWP inference is entirely under `#ifdef XLLAMA_USE_ORT` in `src/bridge/inference.cpp`. ORT types are wrapped in `include/xllama/ort_raii.h`. Linux path (`#else`) uses llama.cpp unchanged.
 
-- **Model bundled in MSIX**: the default model (`smollm2-360m-cpu-int4`) is included as `DeploymentContent` in `uwp/xllama.vcxproj`. No manual upload is needed for the standard dev flow. The model directory must exist at `../models/smollm2-360m-cpu-int4/` relative to the project before building.
+- **No model in the MSIX**: the package is ~19 MB and ships no model. On first launch the app downloads the default model (`smollm2-360m-cpu-int4`) from the GitHub Release `models-v1` catalogue (`uwp/models/manifest.json`) into `LocalState\models\`. No manual upload is needed for the standard dev flow.
 
 - **ONNX external data merge**: ORT 1.24.4 calls `std::filesystem::weakly_canonical()` for models with a separate `.onnx.data` file, which traverses path segments inaccessible inside the Xbox AppContainer (`Q:\Users\UserMgr0\...`). Fix: merge external data into a single `model.onnx` using `scripts/merge_onnx_external_data.py` before MSIX packaging. CI does this automatically.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 The project started as a port of [`llama.cpp`](https://github.com/ggml-org/llama.cpp) (GGUF files, CPU-only), then migrated to **ONNX Runtime GenAI + DirectML**. The measured verdict is **per-workload** (see [docs/technical-report.md](./docs/technical-report.md)): the Zen 2 **CPU wins autoregressive decode** at this model scale (~66 tok/s, SmolLM2-360M int4), the RDNA 2 **GPU wins batch compute** — prefill at ~1k prompt tokens (1.8× faster) and image generation (**11.1×** on the diffusion workload: SD-Turbo 512×512 in ~7 s). The app routes per conversation (CPU / GPU / auto). The llama.cpp path is preserved for Linux development, CI, and a bench-only UWP variant (measured: decode parity with ORT, so ORT stays the text backend).
 
-The default chat model is **SmolLM2-360M-Instruct INT4 CPU** (~403 MB), downloaded on first launch from the GitHub Release model catalogue — the MSIX itself is ~19 MB and ships no model.
+The default chat model is **SmolLM2-360M-Instruct INT4 CPU** (~417 MB), downloaded on first launch from the GitHub Release model catalogue — the MSIX itself is ~19 MB and ships no model.
 
 Goals:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -225,8 +225,8 @@ Milestones:
 - [x] **Modern-model survey** — Qwen3.5-0.8B / LFM2.5-350M load via llama.cpp;
       Qwen3-0.6B builds via ORT (969 MB); TAESD decoder validated (`docs/model-selection.md`).
 - [ ] Interactive validations at the pad: §2 routing A/B + Image dialog flow
-- [~] Closure benches: int4 `block_size=128` / `accuracy_level=4` (§12
-  confirm/refute) — running on console 2026-07-09; `load_ms` baseline done
+- [x] Closure benches: int4 `block_size=128` / `accuracy_level=4` (§12
+      confirm/refute) — closed inconclusive (PR #29, §12 stands)
 - [x] Fase 2: catalogue `kind:gguf` → `sp.backend`, gate KV-reuse/routing off
       for GGUF (plumbing complete 2026-07-09 via PR #30 + layout-aware Auto,
       resolve support, bench guard, tests; asset promotion + console benches

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -100,7 +100,7 @@ Verify with `merge_onnx_external_data.py` output before committing to a build.
 
 **Future — BitNet / INT2 models**: Microsoft BitNet b1.58 (1-bit/1.58-bit quantization)
 could bring a 1.7B–3B model under 400 MB, fitting both the disk and GPU budgets.
-ORT GenAI does not natively support INT2 as of 0.13.2. Re-evaluate when
+ORT GenAI does not natively support INT2 as of 0.14.1. Re-evaluate when
 `microsoft/onnxruntime-genai` adds a stable INT2/BitNet execution path.
 
 ## Why these limits


### PR DESCRIPTION
Rebased continuation of #31 (auto-closed by branch deletion). Same doc-only drift fixes, plus the model-selection.md ORT GenAI version reference (same drift class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)