### PR TITLE
fix(diffuse): feed UNet timestep with the declared rank ([] or [1])

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **`diffuse.cpp` is timestep-shape-aware**: the UNet `timestep` tensor is fed
+  with the rank the model declares — `[1]` (optimum ≤ 1.23, the deployed
+  artifacts, unchanged path) or scalar `[]` (optimum-onnx 0.1.0+ exports) —
+  from the same 1-element buffer, mirroring `validate_pipeline.py`. Removes
+  the last code blocker for promoting new-generation diffusion artifacts;
+  the remaining gate is runbook §7 on console. The unet log line now reports
+  `ts rank 0|1`.
 - **Diffusion export toolchain bumped** (host-only, never shipped): torch
   2.4.1→2.9.1, optimum 1.23.3→optimum-onnx 0.1.0, transformers 4.46.3→4.57.6,
   diffusers 0.31.0→0.39.0. Clears the actionable dependabot alerts (torch

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -254,5 +254,6 @@ Milestones:
       visual, golden vectors byte-identical outside `reference`, ctest 100%,
       TAESD export + swap OK. Residual alerts documented in requirements.txt
       (kernels not installed; Trainer unused). New-generation exports declare
-      scalar UNet `timestep` — `diffuse.cpp` needs shape-awareness before any
-      artifact re-promotion (see `diffusion/README.md`).
+      scalar UNet `timestep` — `diffuse.cpp` is shape-aware since 2026-07-10;
+      the residual gate for artifact re-promotion is runbook §7 on console
+      (see `diffusion/README.md`).

--- a/diffusion/README.md
+++ b/diffusion/README.md
@@ -45,10 +45,10 @@ do not bump piecemeal. Use **Python 3.10** (torch 2.9's supported floor).
 
 Toolchain-generation note (bumped 2026-07-10 from torch 2.4.1 / optimum
 1.23.3): the new export declares the UNet `timestep` input as a **scalar**
-(shape `[]`) instead of `[1]`. `validate_pipeline.py` is shape-aware; the
-shipped `uwp/diffuse.cpp` feeds `[1]` and matches the **currently deployed**
-artifacts — if artifacts regenerated with this toolchain are ever promoted,
-make `diffuse.cpp` timestep-shape-aware first (and re-run runbook §7).
+(shape `[]`) instead of `[1]`. Both `validate_pipeline.py` and
+`uwp/diffuse.cpp` are shape-aware (they read the declared rank and feed `[]`
+or `[1]` from the same 1-element buffer) — if artifacts regenerated with
+this toolchain are ever promoted, the remaining gate is runbook §7 on console.
 
 ```bash
 python3.10 -m venv venv

--- a/uwp/diffuse.cpp
+++ b/uwp/diffuse.cpp
@@ -125,6 +125,19 @@ ONNXTensorElementDataType input_type_by_name(Ort::Session& s, const char* name) 
     return ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED;
 }
 
+// Declared rank of a session input (export-dependent: timestep is [1] on
+// optimum <= 1.23, [] scalar on optimum-onnx 0.1.0+). 1 if the name is absent.
+size_t input_rank_by_name(Ort::Session& s, const char* name) {
+    Ort::AllocatorWithDefaultOptions alloc;
+    const size_t n = s.GetInputCount();
+    for (size_t i = 0; i < n; ++i) {
+        auto nm = s.GetInputNameAllocated(i, alloc);
+        if (std::strcmp(nm.get(), name) == 0)
+            return s.GetInputTypeInfo(i).GetTensorTypeAndShapeInfo().GetShape().size();
+    }
+    return 1;
+}
+
 // A float tensor fed as fp16 or fp32 depending on what the session declares.
 // Owns the backing storage; keep alive until after Run. (Moving is safe: vector
 // moves preserve the heap buffer the Ort::Value points into.)
@@ -294,10 +307,14 @@ void run_diffuse() {
             // float16/float32 (the ORT-team fp16 export declares timestep:f16 — the
             // values used here, e.g. 999, are integers < 2048, exact in fp16).
             const auto ts_type = input_type_by_name(unet, "timestep");
+            // timestep shape is export-dependent as well: [1] (optimum <= 1.23) or
+            // [] scalar (optimum-onnx 0.1.0+). Same 1-element buffer either way;
+            // only the declared rank changes.
+            const size_t ts_rank = input_rank_by_name(unet, "timestep");
             log_output(std::string("[xllama] diffuse: unet input ") +
                        (unet_fp16 ? "fp16" : "fp32") + ", hidden_dim " +
-                       std::to_string(hidden_dim) + ", te+unet load " +
-                       std::to_string((int)ms_since(t_load0)) + " ms\n");
+                       std::to_string(hidden_dim) + ", ts rank " + std::to_string(ts_rank) +
+                       ", te+unet load " + std::to_string((int)ms_since(t_load0)) + " ms\n");
 
             for (size_t s = 0; s < sched.timesteps().size(); ++s) {
                 const std::string step_label =
@@ -322,14 +339,13 @@ void run_diffuse() {
                 Ort::Value u_ts{nullptr};
                 if (ts_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
                     u_ts = Ort::Value::CreateTensor(mem, &ts_f16, sizeof(ts_f16), t_shape.data(),
-                                                    t_shape.size(),
-                                                    ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16);
+                                                    ts_rank, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16);
                 } else if (ts_type == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
-                    u_ts = Ort::Value::CreateTensor<float>(mem, &ts_f32, 1, t_shape.data(),
-                                                           t_shape.size());
+                    u_ts =
+                        Ort::Value::CreateTensor<float>(mem, &ts_f32, 1, t_shape.data(), ts_rank);
                 } else {
-                    u_ts = Ort::Value::CreateTensor<int64_t>(mem, &ts_i64, 1, t_shape.data(),
-                                                             t_shape.size());
+                    u_ts =
+                        Ort::Value::CreateTensor<int64_t>(mem, &ts_i64, 1, t_shape.data(), ts_rank);
                 }
 
                 Ort::Value u_ins[] = {std::move(u_sample.value), std::move(u_ts),


### PR DESCRIPTION
## Summary

optimum-onnx 0.1.0+ exports (post PR #37 toolchain bump) declare the UNet `timestep` input as a **scalar** (shape `[]`) instead of `[1]`. `validate_pipeline.py` was already shape-aware; `uwp/diffuse.cpp` always fed `[1]`, which was the last code blocker for promoting new-generation diffusion artifacts (ROADMAP toolchain-bump item, `diffusion/README.md` note).

- Add `input_rank_by_name` (same lookup style as `input_type_by_name`) and pass the declared rank to the three timestep `CreateTensor` calls (f16/f32/i64) — same 1-element buffer either way, so the `[1]` path for the currently deployed artifacts is unchanged.
- Log `ts rank 0|1` in the `unet input` line for console diagnosis.
- Docs: README note + ROADMAP item updated (residual gate = runbook §7 on console), CHANGELOG `[Unreleased]` entry.

Artifact re-promotion stays gated on runbook §7 on console — out of scope here.

## Test plan

- [x] `cmake --preset linux-test` + ctest: 100% pass (sanity; file is UWP-only)
- [x] clang-format gate clean
- [ ] CI `build (default)` compiles `diffuse.cpp` against ORT DML
- [ ] Post-merge, at the pad: runbook §7 with deployed artifacts (rank 1 regression) and a new-generation export (rank 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)