### PR TITLE
ci: dispatch lane for -PatchedGenAI MSIX packages

### DIFF
--- a/.github/workflows/build-uwp-patched.yml
+++ b/.github/workflows/build-uwp-patched.yml
@@ -51,8 +51,11 @@ jobs:
         # vendor step fails; fail the lane instead of uploading a package
         # mislabeled as patched.
         run: |
+          $genai = ([xml](Get-Content uwp/packages.config)).packages.package |
+            Where-Object { $_.id -eq "Microsoft.ML.OnnxRuntimeGenAI.DirectML" } |
+            Select-Object -ExpandProperty version
           $vendor = "vendor/onnxruntime-genai-patched/win-x64/onnxruntime-genai.dll"
-          $nuget = "uwp/packages/Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.14.1/runtimes/win-x64/native/onnxruntime-genai.dll"
+          $nuget = "uwp/packages/Microsoft.ML.OnnxRuntimeGenAI.DirectML.$genai/runtimes/win-x64/native/onnxruntime-genai.dll"
           if (-not (Test-Path $vendor)) { Write-Error "patched DLL missing: $vendor"; exit 1 }
           if ((Get-FileHash $vendor).Hash -ne (Get-FileHash $nuget).Hash) {
             Write-Error "NuGet DLL is not the patched build"

--- a/.github/workflows/build-uwp-patched.yml
+++ b/.github/workflows/build-uwp-patched.yml
@@ -1,0 +1,88 @@
+name: build-uwp-patched
+
+# Manual lane: build the #2280-patched onnxruntime-genai.dll from source
+# (scripts/vendor-genai-dml-patch.ps1 -Build: tag v0.14.1 +
+# patches/onnxruntime-genai-2280-dml-fallback.patch) and package MSIX variants
+# with it. Produces the -PatchedGenAI packages the runbook §2 routing A/B
+# needs, without a local Windows machine. Dispatch-only: the DLL source build
+# is slow, and the default lane keeps shipping the vanilla DLL until §2 passes
+# (ROADMAP Phase 5 "Vendor patched GenAI DLL in shipping MSIX").
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    # Pin to windows-2022: has VS2022 (v143) + UWP workload pre-installed
+    # (same rationale as build-uwp.yml).
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        # default: the shipping ORT package with the patched DLL (§2 A/B vs
+        #   the vanilla xllama-appx artifact).
+        # unified: both backends + patched DLL — one package covering the whole
+        #   pad session (§2 A/B + GGUF benches).
+        variant: [default, unified]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+          fetch-depth: 1
+
+      - name: Checkout llama.cpp submodule + apply AppContainer guards
+        if: matrix.variant == 'unified'
+        shell: bash
+        run: |
+          git submodule update --init --depth 1 llama.cpp
+          bash scripts/apply-uwp-patches.sh
+
+      - name: Restore NuGet packages
+        shell: pwsh
+        working-directory: uwp
+        run: nuget restore packages.config -PackagesDirectory packages -NonInteractive
+
+      - name: Build patched onnxruntime-genai.dll (#2280) from source
+        shell: pwsh
+        run: ./scripts/vendor-genai-dml-patch.ps1 -Build
+
+      - name: Verify the patched DLL replaced the NuGet copy
+        shell: pwsh
+        # build-uwp.ps1 -PatchedGenAI degrades to the vanilla DLL when the
+        # vendor step fails; fail the lane instead of uploading a package
+        # mislabeled as patched.
+        run: |
+          $vendor = "vendor/onnxruntime-genai-patched/win-x64/onnxruntime-genai.dll"
+          $nuget = "uwp/packages/Microsoft.ML.OnnxRuntimeGenAI.DirectML.0.14.1/runtimes/win-x64/native/onnxruntime-genai.dll"
+          if (-not (Test-Path $vendor)) { Write-Error "patched DLL missing: $vendor"; exit 1 }
+          if ((Get-FileHash $vendor).Hash -ne (Get-FileHash $nuget).Hash) {
+            Write-Error "NuGet DLL is not the patched build"
+            exit 1
+          }
+
+      - name: Build UWP package (-PatchedGenAI)
+        shell: pwsh
+        run: >-
+          ./scripts/build-uwp.ps1 -Configuration Release -Platform x64
+          -Backend $('${{ matrix.variant }}' -eq 'default' ? 'ort' : '${{ matrix.variant }}')
+          -PatchedGenAI
+
+      - uses: actions/upload-artifact@v7
+        if: success()
+        with:
+          name: ${{ matrix.variant != 'default' && format('xllama-appx-patched-{0}', matrix.variant) || 'xllama-appx-patched' }}
+          path: |
+            uwp/AppPackages/**/*.msix
+            uwp/AppPackages/**/*.appx
+            uwp/xllama-test.cer
+          retention-days: 14
+
+      # The DLL itself, so a console-validated build can be dropped into
+      # vendor/onnxruntime-genai-patched/win-x64/ (gitignored) or attached to a
+      # release for the default lane later.
+      - name: Upload patched DLL
+        uses: actions/upload-artifact@v7
+        if: success() && matrix.variant == 'default'
+        with:
+          name: onnxruntime-genai-patched-dll
+          path: vendor/onnxruntime-genai-patched/win-x64/onnxruntime-genai.dll
+          retention-days: 90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `patches/onnxruntime-genai-2280-dml-fallback.patch`,
   `scripts/vendor-genai-dml-patch.ps1`, and `build-uwp.ps1 -PatchedGenAI` to
   overlay the NuGet `onnxruntime-genai.dll` for XAML + DML chat routing.
+- **CI lane for -PatchedGenAI packages** (`build-uwp-patched.yml`,
+  dispatch-only): builds the #2280 DLL from source and uploads
+  `xllama-appx-patched` (shipping ORT) and `xllama-appx-patched-unified`
+  (both backends) plus the DLL itself — the packages runbook §2 needs,
+  without a local Windows machine. The default lane keeps shipping vanilla
+  until §2 passes.
 - **Recommended configurations** — [`docs/recommended-config.md`](docs/recommended-config.md)
   and [`bench/configs/settings-modern.json`](bench/configs/settings-modern.json)
   for console validation.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -249,9 +249,11 @@ Milestones:
       the bench path, llama default-threads livelock (capped at 6 on UWP),
       unified CSV labels. **Promotion of `unified` to default is now
       bench-unblocked** — decision pending.
-- [~] Vendor patched GenAI DLL in shipping MSIX — pipeline done; default CI still
-  vanilla until `vendor/.../onnxruntime-genai.dll` is supplied or `-PatchedGenAI`
-  build is mandated post §2 PASS
+- [~] Vendor patched GenAI DLL in shipping MSIX — pipeline done; the
+  dispatch-only `build-uwp-patched.yml` lane builds the DLL from source and
+  uploads `-PatchedGenAI` packages (default + unified) for the §2 A/B; default
+  CI still vanilla until `vendor/.../onnxruntime-genai.dll` is supplied or
+  `-PatchedGenAI` build is mandated post §2 PASS
 - [x] `diffusion/requirements.txt` toolchain bump + re-validation (2026-07-10):
       torch 2.9.1 / optimum-onnx 0.1.0 / transformers 4.57.6 / diffusers 0.39.0.
       Full recipe re-run green: export (diff 0.0102, warning-level precedent),

--- a/patches/onnxruntime-genai-2280-dml-fallback.patch
+++ b/patches/onnxruntime-genai-2280-dml-fallback.patch
@@ -1,3 +1,5 @@
+diff --git a/src/dml/dml_helpers.cpp b/src/dml/dml_helpers.cpp
+index f3cfe32..c29e693 100644
 --- a/src/dml/dml_helpers.cpp
 +++ b/src/dml/dml_helpers.cpp
 @@ -135,12 +135,26 @@ DmlObjects CreateDmlObjects(const std::string& current_module_path, PLUID device
@@ -29,3 +31,4 @@
 +  if (!agility_device_created) {
      THROW_IF_FAILED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&dml_objects.d3d12_device)));
    }
+ 

--- a/scripts/vendor-genai-dml-patch.ps1
+++ b/scripts/vendor-genai-dml-patch.ps1
@@ -10,14 +10,17 @@
 
     Resolution order:
       1. vendor/onnxruntime-genai-patched/win-x64/onnxruntime-genai.dll (pre-built)
-      2. -Build: clone onnxruntime-genai @ v0.14.1, apply patch, cmake --build
-         (requires VS2022 + CMake; full GenAI build — slow)
+      2. -Build: clone onnxruntime-genai @ rel-0.14.1 (pinned commit), apply
+         patch, cmake --build against the restored NuGet ORT (ORT_HOME)
+         (requires VS2022 + CMake + prior 'nuget restore'; full GenAI build — slow)
 
 .PARAMETER Build
-    Build the DLL from source when no pre-built copy exists.
+    Build the DLL from source. Ignores (and overwrites) a cached vendor DLL —
+    the cache is only trusted on the install-only path.
 
 .PARAMETER GenAiVersion
-    onnxruntime-genai tag to match uwp/packages.config (default 0.14.1).
+    onnxruntime-genai version to match uwp/packages.config (default 0.14.1).
+    NB: upstream ships 0.14.1 as branch rel-0.14.1, not a tag.
 
 .EXAMPLE
     ./scripts/vendor-genai-dml-patch.ps1
@@ -52,7 +55,7 @@ function Install-Dll([string]$Source) {
     Write-Host "Installed patched onnxruntime-genai.dll -> $NuGetDll"
 }
 
-if (Test-Path $VendorDll) {
+if ((Test-Path $VendorDll) -and (-not $Build)) {
     Install-Dll $VendorDll
     exit 0
 }
@@ -74,34 +77,85 @@ Upstream: https://github.com/microsoft/onnxruntime-genai/pull/2280
 # --- Build from source -------------------------------------------------------
 $WorkDir = Join-Path $RepoRoot "build/vendor-onnxruntime-genai"
 $CloneDir = Join-Path $WorkDir "onnxruntime-genai"
-$Tag = "v$GenAiVersion"
+# 0.14.1 exists upstream only as branch rel-0.14.1 (no v0.14.1 tag); pin the
+# commit so a moving branch cannot change what we build.
+$Branch = "rel-$GenAiVersion"
+$PinnedCommit = "a30f479af016cb098688726831a9acbb8d19f0b2"
 
 if (-not (Test-Path $CloneDir)) {
     New-Item -ItemType Directory -Path $WorkDir -Force | Out-Null
-    git clone --depth 1 --branch $Tag https://github.com/microsoft/onnxruntime-genai.git $CloneDir
-} else {
-    Push-Location $CloneDir
-    git fetch --depth 1 origin tag $Tag 2>$null
-    git checkout $Tag
-    Pop-Location
+    git clone --depth 1 --branch $Branch https://github.com/microsoft/onnxruntime-genai.git $CloneDir
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "git clone of $Branch failed"
+        exit 1
+    }
 }
 
 Push-Location $CloneDir
+$Head = git rev-parse HEAD
+if ($Head -ne $PinnedCommit) {
+    git fetch --depth 1 origin $PinnedCommit
+    git checkout $PinnedCommit
+    if ($LASTEXITCODE -ne 0) {
+        Pop-Location
+        Write-Error "Could not check out pinned commit $PinnedCommit (branch $Branch drifted?)"
+        exit 1
+    }
+}
+
+# Apply the patch, or accept a tree where it is already applied (reverse-check).
 git apply --check $PatchFile 2>$null
-if ($LASTEXITCODE -ne 0) {
-    Write-Warning "Patch may already be applied; continuing."
-} else {
+if ($LASTEXITCODE -eq 0) {
     git apply $PatchFile
+    if ($LASTEXITCODE -ne 0) {
+        Pop-Location
+        Write-Error "git apply failed for $PatchFile"
+        exit 1
+    }
+} else {
+    git apply --reverse --check $PatchFile 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Pop-Location
+        Write-Error "Patch $PatchFile neither applies nor is already applied — refusing to build an unpatched DLL."
+        exit 1
+    }
+    Write-Host "Patch already applied; continuing."
 }
 Pop-Location
 
-Write-Host "Building onnxruntime-genai (DirectML, Release x64) — this may take several minutes ..."
+# ORT_HOME staged from the restored NuGet ORT (uwp/packages.config), so the DLL
+# links the exact onnxruntime the MSIX ships. Without ORT_HOME the GenAI build
+# downloads a nightly ORT (1.25-dev) — ABI mismatch with 1.24.4 at runtime.
+$OrtVersion = ([xml](Get-Content (Join-Path $RepoRoot "uwp/packages.config"))).packages.package |
+    Where-Object { $_.id -eq "Microsoft.ML.OnnxRuntime.DirectML" } | Select-Object -ExpandProperty version
+$OrtPkg = Join-Path $RepoRoot "uwp/packages/Microsoft.ML.OnnxRuntime.DirectML.$OrtVersion"
+if (-not (Test-Path $OrtPkg)) {
+    Write-Error "ORT NuGet package not restored: $OrtPkg — run 'nuget restore' in uwp/ first."
+    exit 1
+}
+$OrtHome = Join-Path $WorkDir "ort-home"
+New-Item -ItemType Directory -Path (Join-Path $OrtHome "include") -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $OrtHome "lib") -Force | Out-Null
+Copy-Item (Join-Path $OrtPkg "build/native/include/*") (Join-Path $OrtHome "include") -Recurse -Force
+Copy-Item (Join-Path $OrtPkg "runtimes/win-x64/native/*") (Join-Path $OrtHome "lib") -Force
+
+Write-Host "Building onnxruntime-genai (DirectML, Release x64, ORT $OrtVersion) — this may take several minutes ..."
 Push-Location $CloneDir
-cmake --preset dml_vs2022 2>$null
+cmake -B build -G "Visual Studio 17 2022" -A x64 `
+    -DUSE_DML=ON -DUSE_CUDA=OFF `
+    -DENABLE_PYTHON=OFF -DENABLE_TESTS=OFF -DENABLE_MODEL_BENCHMARK=OFF `
+    -DORT_HOME="$OrtHome"
 if ($LASTEXITCODE -ne 0) {
-    cmake -B build -G "Visual Studio 17 2022" -A x64 -DUSE_DML=ON -DCMAKE_BUILD_TYPE=Release
+    Pop-Location
+    Write-Error "cmake configure failed"
+    exit 1
 }
 cmake --build build --config Release --target onnxruntime-genai -j
+if ($LASTEXITCODE -ne 0) {
+    Pop-Location
+    Write-Error "cmake build failed"
+    exit 1
+}
 Pop-Location
 
 $Built = Get-ChildItem -Path (Join-Path $CloneDir "build") -Filter "onnxruntime-genai.dll" -Recurse |


### PR DESCRIPTION
## Summary

The runbook §2 routing A/B needs a `-PatchedGenAI` MSIX, but the #2280 pipeline (PR #38) only ran locally on Windows. This adds a **dispatch-only** lane, `build-uwp-patched.yml`:

- builds the patched `onnxruntime-genai.dll` from source (`vendor-genai-dml-patch.ps1 -Build`: GenAI `v0.14.1` + `patches/onnxruntime-genai-2280-dml-fallback.patch`)
- **verifies the DLL actually replaced the NuGet copy** (hash compare) — `build-uwp.ps1 -PatchedGenAI` silently continues with the vanilla DLL when the vendor step fails, so the lane fails loudly instead of uploading a mislabeled package
- packages two variants: `xllama-appx-patched` (shipping ORT, for the §2 A/B vs the vanilla `xllama-appx`) and `xllama-appx-patched-unified` (both backends — one package covering §2 + the GGUF benches in a single pad session)
- uploads the DLL itself (90 days) so a console-validated build can be dropped into `vendor/onnxruntime-genai-patched/win-x64/` or attached to a release later

Default CI is untouched and keeps shipping vanilla until §2 passes (ROADMAP Phase 5). Docs: CHANGELOG `[Unreleased]` + ROADMAP vendor bullet updated.

## Test plan

- [x] actionlint clean
- [ ] `gh workflow run build-uwp-patched.yml` after merge — both matrix jobs green, artifacts present
- [ ] Hash-verify step is exercised (it runs on every dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)