### PR TITLE
fix(llama): descend catalogue model dirs to the .gguf file in bench path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the first unified-build bench). The chat path (`create_llama`) already
   descended into the directory; that logic is now the shared
   `first_gguf_in_dir()` (`path_utils`) used by both, with host tests.
+- **llama.cpp default thread count livelocked on console**: with no explicit
+  `n_threads`, both llama paths used `detect_threads()` (= 8 on Series S),
+  hitting the known ggml spin-wait livelock at t7/t8 (phase35-llamacpp-scaling;
+  re-hit 2026-07-10 — bench runs loaded the model then hung past the 300 s
+  watchdog). New `detect_threads_llama()` caps the llama default at 6 on UWP
+  (t6 is the measured optimum); explicit `n_threads` still wins, ORT paths
+  unchanged.
+- **Bench CSV mislabelled GGUF runs in unified builds** as
+  `int4`/`ort-genai-cpu`: the label block keyed on compile-time
+  `XLLAMA_USE_ORT` only. It now keys on the backend that actually ran
+  (`model_uses_llama_backend`), keeping the llamacpp-lane labels
+  (`Q4_K_M`/`cpu`), and the CSV `n_threads` column reports the llama-capped
+  default.
+
+### Measured (2026-07-10, unified 1.1.1.0 on console)
+
+- **Fase 2b GGUF benches** (`bench/results/phase5-gguf.csv`, t6,
+  standard-512): **Qwen3.5-0.8B Q4_K_M decode 35.1 tok/s** (prefill 98.1,
+  peak 718 MB, load 4.1 s) — **LFM2.5-350M Q4_K_M decode 94.2 tok/s**
+  (prefill 241.4, peak 321 MB, load 1.4 s). LFM2.5-350M beats the ORT int4
+  360M baseline (66.3 @ t8) by ~42% at similar size; Qwen3.5-0.8B is in line
+  with size scaling (1.7B CPU int4: 20.6). Unified promotion is now
+  bench-unblocked.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Headless bench could not load catalogue GGUF models**: `run_inference_llama`
+  passed the resolved model _directory_ straight to
+  `llama_model_load_from_file`, which needs the `.gguf` _file_ — every bench
+  run of `qwen35-0.8b` / `lfm25-350m` failed on console (found 2026-07-10 on
+  the first unified-build bench). The chat path (`create_llama`) already
+  descended into the directory; that logic is now the shared
+  `first_gguf_in_dir()` (`path_utils`) used by both, with host tests.
+
 ### Changed
 
 - **`diffuse.cpp` is timestep-shape-aware**: the UNet `timestep` tensor is fed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -242,8 +242,13 @@ Milestones:
       resolve support, bench guard, tests).
 - [x] Fase 2b (assets): Qwen3.5-0.8B + LFM2.5-350M Q4_K_M published on
       `models-v1` with catalogue entries (LFM license redistributed per §4a);
-      host smoke test OK. **Console decode/prefill benches remain** (unified
-      MSIX, bench-gated promotion to default).
+      host smoke test OK. **Console benches measured 2026-07-10** (unified
+      1.1.1.0, t6, `phase5-gguf.csv`): Qwen3.5-0.8B decode **35.1** tok/s
+      (prefill 98.1), LFM2.5-350M decode **94.2** tok/s (prefill 241.4, ~42%
+      over the ORT 360M baseline). Found + fixed on the way: GGUF dir load in
+      the bench path, llama default-threads livelock (capped at 6 on UWP),
+      unified CSV labels. **Promotion of `unified` to default is now
+      bench-unblocked** — decision pending.
 - [~] Vendor patched GenAI DLL in shipping MSIX — pipeline done; default CI still
   vanilla until `vendor/.../onnxruntime-genai.dll` is supplied or `-PatchedGenAI`
   build is mandated post §2 PASS

--- a/bench/results/phase5-gguf.csv
+++ b/bench/results/phase5-gguf.csv
@@ -1,1 +1,0 @@
-model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,host,date

--- a/bench/results/phase5-gguf.csv
+++ b/bench/results/phase5-gguf.csv
@@ -1,0 +1,3 @@
+model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,host,date
+qwen35-0.8b,Q4_K_M,cpu,2048,6,98.08,35.08,718,4133,0,0,xbox-series-s-t6,2026-07-10T09:29:47Z
+lfm25-350m,Q4_K_M,cpu,2048,6,241.40,94.23,321,1430,0,0,xbox-series-s-t6,2026-07-10T09:31:07Z

--- a/bench/results/phase5-gguf.csv
+++ b/bench/results/phase5-gguf.csv
@@ -1,0 +1,1 @@
+model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,host,date

--- a/include/xllama/path_utils.h
+++ b/include/xllama/path_utils.h
@@ -28,4 +28,10 @@ std::string resolve_local_path(const std::string& filename);
 //   (e.g. "qwen35-0.8b") work correctly with Backend::Auto in unified builds.
 bool model_uses_llama_backend(const std::string& model_id);
 
+// llama_model_load_from_file needs a FILE path, but catalogue GGUF entries
+// resolve to a directory (LocalState\models\<name>\<file>.gguf). If path is a
+// directory, return the first *.gguf inside it; empty string if it contains
+// none. If path is not a directory, return it unchanged.
+std::string first_gguf_in_dir(const std::string& path);
+
 } // namespace xllama

--- a/include/xllama/platform.h
+++ b/include/xllama/platform.h
@@ -15,6 +15,13 @@ namespace xllama {
 // Number of hardware threads; falls back to 4 if detection fails.
 int detect_threads() noexcept;
 
+// Default thread count for the llama.cpp backend. On UWP this is capped at 6:
+// ggml's spin-wait threadpool livelocks at t7/t8 on the console (~6 cores left
+// to the app in Dev Mode, no thread affinity in AppContainer) — measured
+// 2026-07-08 (phase35-llamacpp-scaling, t6 optimal) and re-hit 2026-07-10 on
+// the first unified bench. An explicit n_threads always wins over this.
+int detect_threads_llama() noexcept;
+
 // Emit a log line. On UWP: OutputDebugStringA; otherwise: stderr.
 void log_output(const char* msg) noexcept;
 void log_output(const std::string& msg) noexcept;

--- a/src/bridge/bench.cpp
+++ b/src/bridge/bench.cpp
@@ -65,6 +65,15 @@ void write_bench_csv(const InferenceParams& params, const InferenceResult& res,
         }
     }
 
+    // Which backend actually ran this model (unified builds dispatch at runtime).
+#if defined(XLLAMA_USE_ORT) && defined(XLLAMA_USE_LLAMA)
+    const bool is_llama = model_uses_llama_backend(params.model_path);
+#elif defined(XLLAMA_USE_LLAMA)
+    const bool is_llama = true;
+#else
+    const bool is_llama = false;
+#endif
+
 #ifdef XLLAMA_USE_ORT
     // Derive the EP + quant labels from the model directory name (convention:
     // smollm2-<size>-<cpu|dml>-<int4|fp16>) instead of hardcoding — a DML fp16
@@ -78,10 +87,20 @@ void write_bench_csv(const InferenceParams& params, const InferenceResult& res,
     const char* backend = "cpu";
     const char* quant = "Q4_K_M";
 #endif
+    if (is_llama) {
+        // GGUF run: keep the llamacpp-lane labels (matches phase35-llamacpp-scaling.csv)
+        // even in unified builds, where the ORT labels above would win.
+        backend = "cpu";
+        quant = "Q4_K_M";
+    }
+
+    const int used_threads = params.n_threads > 0
+                                 ? params.n_threads
+                                 : (is_llama ? detect_threads_llama() : detect_threads());
     fprintf(fp, "%s,%s,%s,%d,%d,%.2f,%.2f,%zu,%.0f,%zu,%zu,%s,%s\n", model_name.c_str(), quant,
-            backend, params.n_ctx, params.n_threads > 0 ? params.n_threads : detect_threads(),
-            prompt_tok_s, decode_tok_s, res.peak_ws_mb, res.t_load_ms, res.gpu_mem_mb,
-            res.gpu_budget_mb, host_label ? host_label : "unknown", date_buf);
+            backend, params.n_ctx, used_threads, prompt_tok_s, decode_tok_s, res.peak_ws_mb,
+            res.t_load_ms, res.gpu_mem_mb, res.gpu_budget_mb, host_label ? host_label : "unknown",
+            date_buf);
     fclose(fp);
 
     // Write done marker

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -294,7 +294,7 @@ InferenceResult run_inference_llama(const InferenceParams& params) {
     if (params.on_status)
         params.on_status("decoding");
 
-    const int n_threads = params.n_threads > 0 ? params.n_threads : detect_threads();
+    const int n_threads = params.n_threads > 0 ? params.n_threads : detect_threads_llama();
 
     llama_context_params cparams = llama_context_default_params();
     cparams.n_ctx = static_cast<uint32_t>(params.n_ctx);

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -265,7 +265,15 @@ namespace detail {
 InferenceResult run_inference_llama(const InferenceParams& params) {
     InferenceResult res;
 
-    const std::string abs_model_path = resolve_model_path(params.model_path);
+    // Catalogue GGUF entries resolve to the model DIRECTORY; llama loads a file.
+    const std::string abs_model_path = first_gguf_in_dir(resolve_model_path(params.model_path));
+    if (abs_model_path.empty()) {
+        res.error_msg = "no .gguf file in model dir: " + resolve_model_path(params.model_path);
+        log_output("[xllama] " + res.error_msg + "\n");
+        if (params.on_status)
+            params.on_status("error: " + res.error_msg);
+        return res;
+    }
 
     llama_model_params mparams = llama_model_default_params();
     mparams.n_gpu_layers = 0; // CPU only on Linux path

--- a/src/bridge/path_utils.cpp
+++ b/src/bridge/path_utils.cpp
@@ -262,4 +262,15 @@ bool model_uses_llama_backend(const std::string& model_id) {
     return false;
 }
 
+std::string first_gguf_in_dir(const std::string& path) {
+    std::error_code ec;
+    if (!std::filesystem::is_directory(path, ec))
+        return path;
+    for (const auto& de : std::filesystem::directory_iterator(path, ec)) {
+        if (!ec && de.path().extension() == ".gguf")
+            return de.path().string();
+    }
+    return {};
+}
+
 } // namespace xllama

--- a/src/bridge/platform.cpp
+++ b/src/bridge/platform.cpp
@@ -3,6 +3,7 @@
 
 #include "xllama/platform.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <mutex>
 #include <thread>
@@ -29,6 +30,14 @@ namespace xllama {
 int detect_threads() noexcept {
     int n = static_cast<int>(std::thread::hardware_concurrency());
     return n > 0 ? n : 4;
+}
+
+int detect_threads_llama() noexcept {
+#ifdef XLLAMA_UWP
+    return std::min(detect_threads(), 6); // ggml livelock at t7/t8 (see platform.h)
+#else
+    return detect_threads();
+#endif
 }
 
 void log_output(const char* msg) noexcept {

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -501,7 +501,7 @@ std::unique_ptr<Session> create_llama(const SessionParams& sp, std::string* err)
         return nullptr;
     }
 
-    int n_threads = sp.n_threads > 0 ? sp.n_threads : detect_threads();
+    int n_threads = sp.n_threads > 0 ? sp.n_threads : detect_threads_llama();
     int n_ctx = sp.n_ctx > 0 ? sp.n_ctx : 2048;
     return std::make_unique<LlamaSession>(LlamaModelPtr(raw_model), n_ctx, n_threads);
 }

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -13,7 +13,6 @@
 #include <chrono>
 #include <cstdint>
 #include <cstring>
-#include <filesystem>
 #include <string>
 
 // Backend availability. A build defines XLLAMA_USE_ORT when ORT GenAI is linked.
@@ -482,28 +481,14 @@ class LlamaSession final : public Session {
 
 namespace detail {
 std::unique_ptr<Session> create_llama(const SessionParams& sp, std::string* err) {
-    std::string abs_path = resolve_model_path(sp.model_path);
-
     // resolve_model_path yields a FILE path on Linux (a direct .gguf) but the
     // model DIRECTORY on UWP (catalogue layout LocalState\models\<name>\). llama
     // loads a file, so descend into a directory and pick the single .gguf inside.
-    {
-        std::error_code ec;
-        if (std::filesystem::is_directory(abs_path, ec)) {
-            std::string gguf;
-            for (const auto& de : std::filesystem::directory_iterator(abs_path, ec)) {
-                if (de.path().extension() == ".gguf") {
-                    gguf = de.path().string();
-                    break;
-                }
-            }
-            if (gguf.empty()) {
-                if (err)
-                    *err = "no .gguf file in model dir: " + abs_path;
-                return nullptr;
-            }
-            abs_path = std::move(gguf);
-        }
+    std::string abs_path = first_gguf_in_dir(resolve_model_path(sp.model_path));
+    if (abs_path.empty()) {
+        if (err)
+            *err = "no .gguf file in model dir: " + resolve_model_path(sp.model_path);
+        return nullptr;
     }
 
     llama_model_params mparams = llama_model_default_params();

--- a/tests/test_path.cpp
+++ b/tests/test_path.cpp
@@ -5,8 +5,33 @@
 
 #include "xllama/path_utils.h"
 
+#include <filesystem>
+#include <fstream>
+
 TEST_CASE("Path utils: Linux returns input unchanged") {
     std::string path = "/home/user/model.gguf";
     CHECK(xllama::resolve_model_path(path) == path);
     CHECK(xllama::resolve_local_path("output.txt") == "output.txt");
+}
+
+TEST_CASE("first_gguf_in_dir: descends catalogue dirs, passes files through") {
+    namespace fs = std::filesystem;
+    const fs::path dir = fs::temp_directory_path() / "xllama-test-gguf-dir";
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+
+    SUBCASE("non-directory input is returned unchanged") {
+        CHECK(xllama::first_gguf_in_dir("/no/such/model.gguf") == "/no/such/model.gguf");
+    }
+    SUBCASE("directory without gguf yields empty") {
+        CHECK(xllama::first_gguf_in_dir(dir.string()).empty());
+    }
+    SUBCASE("directory with a gguf yields the file path") {
+        const fs::path gguf = dir / "model-Q4_K_M.gguf";
+        std::ofstream(gguf) << "stub";
+        std::ofstream(dir / "LICENSE.txt") << "license"; // ignored sibling
+        CHECK(xllama::first_gguf_in_dir(dir.string()) == gguf.string());
+    }
+
+    fs::remove_all(dir);
 }

--- a/tests/test_path.cpp
+++ b/tests/test_path.cpp
@@ -8,6 +8,8 @@
 #include <filesystem>
 #include <fstream>
 
+#include <unistd.h>
+
 TEST_CASE("Path utils: Linux returns input unchanged") {
     std::string path = "/home/user/model.gguf";
     CHECK(xllama::resolve_model_path(path) == path);
@@ -16,7 +18,9 @@ TEST_CASE("Path utils: Linux returns input unchanged") {
 
 TEST_CASE("first_gguf_in_dir: descends catalogue dirs, passes files through") {
     namespace fs = std::filesystem;
-    const fs::path dir = fs::temp_directory_path() / "xllama-test-gguf-dir";
+    // PID-suffixed so concurrent test invocations don't clobber each other.
+    const fs::path dir =
+        fs::temp_directory_path() / ("xllama-test-gguf-dir-" + std::to_string(::getpid()));
     fs::remove_all(dir);
     fs::create_directories(dir);
 

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -10,7 +10,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="1.1.0.0"
+    Version="1.1.1.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -1656,9 +1656,10 @@ bool MainPageController::EnsureSession(const std::string& model, std::string* er
     xllama::SessionParams sp;
     sp.model_path = model;
     sp.n_ctx = 2048;
-    // Series S: t=4 optimal for llama.cpp (t=7/8 livelock); ORT threads come from
+    // 0 = default: llama.cpp gets detect_threads_llama() (capped at 6 on UWP —
+    // t6 measured optimum, t7/t8 livelock); ORT threads come from
     // genai_config.json intra_op_num_threads on the model dir.
-    sp.n_threads = 4;
+    sp.n_threads = 0;
     // Pick the backend from the catalogue kind: a "gguf" entry runs on llama.cpp,
     // everything else (an ORT GenAI directory) on ORT. On a single-backend build
     // this field is ignored (only one path is compiled). The model name is bare


### PR DESCRIPTION
## Summary

First on-console bench of the unified build (today, post GGUF-asset upload) surfaced **three real bugs**, all fixed here:

1. **Catalogue GGUF dirs didn't load in the bench path**: `run_inference_llama` passed the resolved model **directory** to `llama_model_load_from_file`, which needs the **`.gguf` file**. The chat path already descended into the directory — extracted as shared `first_gguf_in_dir()` (`path_utils`), used by both, host-tested.
2. **llama default threads livelocked on console**: no explicit `n_threads` → `detect_threads()` = 8 → known ggml t7/t8 spin-wait livelock (runs loaded the model then hung). New `detect_threads_llama()` caps the llama default at 6 on UWP (measured optimum); explicit `n_threads` wins; ORT untouched.
3. **Unified bench CSV mislabelled GGUF runs** as `int4`/`ort-genai-cpu` (compile-time keying). Now keyed on the backend that actually ran; `n_threads` column reports the capped default.

Plus `build(uwp)`: package version 1.1.0.0 → **1.1.1.0** (WDP blocks same-identity redeploy with different contents; uninstalling would wipe LocalState models).

## Measured on console (unified 1.1.1.0, t6, `bench/results/phase5-gguf.csv`)

| model | decode tok/s | prefill tok/s | peak MB | load s |
|---|---|---|---|---|
| Qwen3.5-0.8B Q4_K_M | **35.1** | 98.1 | 718 | 4.1 |
| LFM2.5-350M Q4_K_M | **94.2** | 241.4 | 321 | 1.4 |

LFM2.5-350M beats the ORT int4 360M baseline (66.3 @ t8) by ~42%; Qwen3.5-0.8B in line with size scaling (1.7B: 20.6). **Fase 2b console benches: done — unified promotion is bench-unblocked.**

## Test plan

- [x] `ctest` 100% (new `first_gguf_in_dir` cases)
- [x] E2E host: `xllama-cli -m <dir-with-gguf>` loads and generates (failed before)
- [x] E2E console: both catalogue GGUFs bench headless end-to-end (failed before)
- [x] clang-format clean
- [ ] CI (default/llamacpp/unified) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GGUF model loading when a model path points to a directory by selecting the first `.gguf` found.
  * Prevented potential console hangs by capping default llama backend threads when thread count is unset.
  * Corrected unified GGUF benchmark CSV labeling and aligned reported thread counts to the capped default; session now uses backend defaults (via `n_threads=0`).

* **Documentation**
  * Updated changelog and roadmap with recent GGUF benchmark measurements and progress.

* **Tests**
  * Added coverage for `.gguf` discovery across directory/catalog layouts.

* **Chores**
  * Updated the app package version to `1.1.1.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->