### PR TITLE
build(uwp): bump package version to 1.1.2.0

### DIFF
--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -10,7 +10,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="1.1.1.0"
+    Version="1.1.2.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity


### PR DESCRIPTION
## Summary

The console currently runs the 1.1.1.0 unified build. The `-PatchedGenAI` packages from `build-uwp-patched.yml` must install as an **upgrade**: WDP blocks same-identity redeploys with different contents, and uninstalling would wipe LocalState (3+ GB of models). Version-only bump, no code changes.

## Test plan
- [ ] CI green (build-only change)
- [ ] Post-merge: re-dispatch `build-uwp-patched.yml` → deploy `xllama-appx-patched-unified` 1.1.2.0 on console as upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)