### PR TITLE
docs: drift pass after Fase-2b benches and the patched-lane repair

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,8 @@ xllama/
 │   ├── ort_raii.h           # RAII unique_ptr for OGA* types (UWP/ORT GenAI path)
 │   ├── llama_raii.h         # RAII unique_ptr for llama_* types (Linux path)
 │   ├── cli.h                # parse_cli_args (Linux)
-│   ├── platform.h           # log_output, detect_threads, peak_working_set_mb
-│   ├── path_utils.h         # resolve_model_path, resolve_local_path
+│   ├── platform.h           # log_output, detect_threads(_llama), peak_working_set_mb
+│   ├── path_utils.h         # resolve_model_path, first_gguf_in_dir, model_uses_llama_backend
 │   └── utf8_utils.h         # utf8 <-> wstring (Windows)
 ├── src/bridge/              # Shared implementation (Linux + UWP)
 │   ├── inference.cpp        # #ifdef XLLAMA_USE_ORT → ORT GenAI; #else → llama_decode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Docs
+
+- **Drift pass after the Fase-2b/patched-lane work**: README (GGUF rows with
+  measured decode, 90 GB disk supersession, in-process image gen in the
+  architecture diagram, helper listings), `docs/uwp-constraints.md` intro
+  aligned to the §9 supersession, `docs/recommended-config.md` (GGUF measured
+  - llama thread cap + sharper "do not use"), runbook §2 (CI-lane artifact
+    alternative; settings must upload as `settings.json`), vendor README +
+    script message (rel-0.14.1 branch pin, ORT_HOME build), AGENTS.md map.
+
 ### Fixed
 
 - **Headless bench could not load catalogue GGUF models**: `run_inference_llama`

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 `xllama` is a UWP application for Xbox Series S|X in Dev Mode that runs LLM chat and Stable-Diffusion image generation locally, with no cloud dependency and a gamepad-friendly UI.
 
-The project started as a port of [`llama.cpp`](https://github.com/ggml-org/llama.cpp) (GGUF files, CPU-only), then migrated to **ONNX Runtime GenAI + DirectML**. The measured verdict is **per-workload** (see [docs/technical-report.md](./docs/technical-report.md)): the Zen 2 **CPU wins autoregressive decode** at this model scale (~66 tok/s, SmolLM2-360M int4), the RDNA 2 **GPU wins batch compute** — prefill at ~1k prompt tokens (1.8× faster) and image generation (**11.1×** on the diffusion workload: SD-Turbo 512×512 in ~7 s). The app routes per conversation (CPU / GPU / auto). The llama.cpp path is preserved for Linux development, CI, and a bench-only UWP variant (measured: decode parity with ORT, so ORT stays the text backend).
+The project started as a port of [`llama.cpp`](https://github.com/ggml-org/llama.cpp) (GGUF files, CPU-only), then migrated to **ONNX Runtime GenAI + DirectML**. The measured verdict is **per-workload** (see [docs/technical-report.md](./docs/technical-report.md)): the Zen 2 **CPU wins autoregressive decode** at this model scale (~66 tok/s, SmolLM2-360M int4), the RDNA 2 **GPU wins batch compute** — prefill at ~1k prompt tokens (1.8× faster) and image generation (**11.1×** on the diffusion workload: SD-Turbo 512×512 in ~7 s). The app routes per conversation (CPU / GPU / auto). The llama.cpp path serves Linux development, CI, and — in the `unified` UWP build — modern GGUF-only models (Qwen3.5, LFM2.5); for the same model, ORT stays the text backend (measured decode parity, better prefill).
 
 The default chat model is **SmolLM2-360M-Instruct INT4 CPU** (~417 MB), downloaded on first launch from the GitHub Release model catalogue — the MSIX itself is ~19 MB and ships no model.
 
@@ -117,7 +117,7 @@ See [docs/install-release.md](./docs/install-release.md) to install a tagged rel
 │  ├─ long-prompt prefill → DML fp16      │
 │  │  (per-conversation routing)           │
 │  └─ image gen → SD-Turbo on DirectML    │
-│     (headless flag mode, 887A0036 — §7)  │
+│     (in-process; plain ORT DML — §7)     │
 └──────────────────────────────────────────┘
 ```
 
@@ -135,8 +135,8 @@ xllama/
 │   ├── ort_raii.h          # RAII wrappers for OGA* types (UWP)
 │   ├── llama_raii.h        # RAII wrappers for llama_* types (Linux)
 │   ├── cli.h               # parse_cli_args (Linux)
-│   ├── platform.h          # log_output, detect_threads, peak_working_set_mb
-│   ├── path_utils.h        # resolve_model_path, resolve_local_path
+│   ├── platform.h          # log_output, detect_threads(_llama), peak_working_set_mb
+│   ├── path_utils.h        # resolve_model_path, first_gguf_in_dir, backend sniffing
 │   └── utf8_utils.h        # utf8 <-> wstring (Windows)
 ├── src/
 │   ├── main.cpp            # Linux entry point
@@ -233,8 +233,10 @@ Models come from the catalogue `uwp/models/manifest.json` (assets hosted on the 
 | SmolLM2-360M-Instruct INT4 CPU | ONNX GenAI    | 417 MB  | ✅       | Default; decode 66.3 tok/s                                       |
 | SmolLM2-360M-Instruct fp16 DML | ONNX GenAI    | ~700 MB | ✅       | Routing target (prefill 354 tok/s @1k)                           |
 | SD-Turbo fp16 (image)          | ONNX DirectML | 2.4 GB  | ✅       | 512×512 in ~6.9 s ([diffusion/README.md](./diffusion/README.md)) |
-| SmolLM2-1.7B-Instruct INT4 CPU | ONNX GenAI    | 1.4 GB  | ✅       | Measured 20.6 tok/s; tight on Dev Mode disk                      |
-| Phi-3.5-mini CPU INT4          | ONNX GenAI    | ~2.7 GB | ❌       | Above the Dev Mode disk budget                                   |
+| SmolLM2-1.7B-Instruct INT4 CPU | ONNX GenAI    | 1.4 GB  | ✅       | Measured 20.6 tok/s                                              |
+| Qwen3.5-0.8B Q4_K_M            | GGUF          | 508 MB  | ✅       | `unified` builds (llama.cpp); decode 35.1 tok/s                  |
+| LFM2.5-350M Q4_K_M             | GGUF          | 219 MB  | ✅       | `unified` builds (llama.cpp); decode 94.2 tok/s                  |
+| Phi-3.5-mini CPU INT4          | ONNX GenAI    | ~2.7 GB | ❌       | GPU OOM history + >2 GB single-file ONNX (see constraints §8)    |
 
 Numbers are measured on Xbox Series S Dev Mode. See [docs/uwp-constraints.md](./docs/uwp-constraints.md) for the measured GPU budget (3801 MB), the disk budget, and the `weakly_canonical` AppContainer workaround.
 
@@ -242,7 +244,7 @@ Numbers are measured on Xbox Series S Dev Mode. See [docs/uwp-constraints.md](./
 
 ## Limitations
 
-- **Disk is the binding budget, not GPU memory**: the measured per-process GPU budget is **3801 MB** (package designated Game), but Dev Mode leaves only ~2.2–2.5 GB free on disk — that is what caps model size.
+- **File-size ceiling, not GPU memory**: the measured per-process GPU budget is **3801 MB** (package designated Game), and the Dev Mode disk allocation is raised to **90 GB** via Dev Home — what caps model choice now is the **2 GB ONNX protobuf / per-file limit** (self-contained `model.onnx` must stay under it; see [docs/uwp-constraints.md](./docs/uwp-constraints.md) §8–§9).
 - **DirectML vs XAML (`887A0036`)**: ORT **GenAI** DML conflicts with the XAML compositor's D3D12 device in the vanilla NuGet DLL. Image generation uses plain ORT DML and runs **in-process**; chat GPU routing needs the [#2280](https://github.com/microsoft/onnxruntime-genai/pull/2280) patched `onnxruntime-genai.dll` (`build-uwp.ps1 -PatchedGenAI`). Headless `bench.flag` remains for automation.
 - **Sandboxed filesystem**: models are downloaded to `LocalState` or transferred via Device Portal / USB. No arbitrary path access.
 - **AppContainer path traversal**: ORT 1.24.4 calls `std::filesystem::weakly_canonical()` for external ONNX data files, which traverses path segments the AppContainer cannot read. Workaround: distribute models with `model.onnx.data` merged into a self-contained `model.onnx` (`scripts/merge_onnx_external_data.py`).

--- a/docs/console-validation-runbook.md
+++ b/docs/console-validation-runbook.md
@@ -66,15 +66,19 @@ for decode, sticky per conversation.
 
 **Prereqs**:
 
-1. MSIX built with `./scripts/build-uwp.ps1 -PatchedGenAI` (ORT GenAI #2280 — vanilla NuGet
-   DLL hits `887A0036` in XAML).
+1. A `-PatchedGenAI` MSIX (ORT GenAI #2280 — vanilla NuGet DLL hits `887A0036`
+   in XAML): either `gh workflow run build-uwp-patched.yml` and download the
+   `xllama-appx-patched` / `xllama-appx-patched-unified` artifact (no Windows
+   machine needed), or build locally with `./scripts/build-uwp.ps1 -PatchedGenAI`.
 2. `smollm2-360m-dml-fp16` in `LocalState\models\`.
-3. Preload modern settings (tokenizer-accurate threshold **600 tok**):
+3. Preload modern settings (tokenizer-accurate threshold **600 tok**). NB: the
+   app reads `settings.json`, so upload under that name:
 
 ```bash
 source ~/.config/xllama/xbox-env
 PFN=$(./scripts/deploy.sh pfn)
-./scripts/deploy.sh upload-file bench/configs/settings-modern.json "$PFN" ""
+cp bench/configs/settings-modern.json /tmp/settings.json
+./scripts/deploy.sh upload-file /tmp/settings.json "$PFN" ""
 ```
 
 Then, at the console: launch xllama → paste a **long** prompt (>~600 tokens — use

--- a/docs/recommended-config.md
+++ b/docs/recommended-config.md
@@ -6,11 +6,11 @@ is **measured** unless marked "host-only" or "pending console". See
 
 ## Runtime pins (do not drift)
 
-| Package | Version | File |
-| ------- | ------- | ---- |
-| ORT GenAI DirectML | **0.14.1** | `uwp/packages.config` |
-| ONNX Runtime DirectML | **1.24.4** | same |
-| DirectML | **1.15.4** | same |
+| Package               | Version    | File                  |
+| --------------------- | ---------- | --------------------- |
+| ORT GenAI DirectML    | **0.14.1** | `uwp/packages.config` |
+| ONNX Runtime DirectML | **1.24.4** | same                  |
+| DirectML              | **1.15.4** | same                  |
 
 Chat GPU inside XAML requires the **#2280** patched `onnxruntime-genai.dll`:
 
@@ -23,27 +23,36 @@ Upstream: [microsoft/onnxruntime-genai#2280](https://github.com/microsoft/onnxru
 
 ## UWP build variants
 
-| Variant | Command | When to use |
-| ------- | ------- | ----------- |
-| **ort** (shipping) | `build-uwp.ps1` | Default chat via ORT GenAI |
-| **unified** | `-Backend unified` | GGUF models (`kind: gguf`) + ORT |
-| **llamacpp** | `-Backend llamacpp` | Bench A/B only — not for end users |
+| Variant            | Command             | When to use                        |
+| ------------------ | ------------------- | ---------------------------------- |
+| **ort** (shipping) | `build-uwp.ps1`     | Default chat via ORT GenAI         |
+| **unified**        | `-Backend unified`  | GGUF models (`kind: gguf`) + ORT   |
+| **llamacpp**       | `-Backend llamacpp` | Bench A/B only — not for end users |
 
 ## Chat models
 
-| Use case | Catalogue `name` | Backend | Measured decode |
-| -------- | ---------------- | ------- | --------------- |
-| **Default** | `smollm2-360m-cpu-int4` | ORT CPU int4 | ~66 tok/s |
-| **Routing GPU** | `smollm2-360m-dml-fp16` | ORT DML fp16 | ~47 tok/s decode; ~354 tok/s prefill @1k |
-| **Larger chat** | `smollm2-1.7b-cpu-int4` | ORT CPU int4 | ~21 tok/s (USB / 90 GB disk) |
-| **Modern GGUF** | `qwen35-0.8b` | llama.cpp (`unified`) | Host OK; console pending |
+| Use case             | Catalogue `name`        | Backend               | Measured decode                          |
+| -------------------- | ----------------------- | --------------------- | ---------------------------------------- |
+| **Default**          | `smollm2-360m-cpu-int4` | ORT CPU int4          | ~66 tok/s                                |
+| **Routing GPU**      | `smollm2-360m-dml-fp16` | ORT DML fp16          | ~47 tok/s decode; ~354 tok/s prefill @1k |
+| **Larger chat**      | `smollm2-1.7b-cpu-int4` | ORT CPU int4          | ~21 tok/s (USB / 90 GB disk)             |
+| **Modern GGUF**      | `qwen35-0.8b`           | llama.cpp (`unified`) | 35.1 tok/s (98.1 prefill, t6)            |
+| **Fast modern GGUF** | `lfm25-350m`            | llama.cpp (`unified`) | 94.2 tok/s (241.4 prefill, t6)           |
+
+GGUF thread default: llama.cpp auto-detect is capped at **6** on console
+(`detect_threads_llama` — t6 measured optimum, t7/t8 livelock); explicit
+`--threads` on `bench-xbox-ort.sh` still wins.
 
 ### Do not use
 
 - DML **int4** for decode (~8.8 tok/s — DirectML kernel limit)
 - CPU-int4 SmolLM graph with DML `genai_config` (`80070057`)
 - Qwen2.5-0.5B ONNX CPU (~822 MB vocab embedding)
-- llama.cpp as primary text backend (decode parity, worse prefill vs ORT)
+- llama.cpp for a model that also has an ORT build (same-model A/B: decode
+  parity, worse prefill vs ORT) — the `unified` lane is for GGUF-only models
+  (Qwen3.5, LFM2.5), where it earns its keep (LFM2.5 beats the ORT 360M
+  baseline by ~42%)
+- llama.cpp auto threads above 6 on console (ggml spin-wait livelock)
 
 ## `genai_config.json` (on-device model dir)
 
@@ -71,27 +80,27 @@ Models must be **self-contained** `model.onnx` (< 2 GB merged) — run
 
 Copy [`bench/configs/settings-modern.json`](../bench/configs/settings-modern.json) via Device Portal, or use the UI.
 
-| Key | Recommended | Notes |
-| --- | ----------- | ----- |
-| `model` | `smollm2-360m-cpu-int4` | Downloaded on first launch |
-| `kv_reuse` | `true` | 4.87× turn-2 prefill (measured) |
-| `routing` | `0` default; `2` for RAG | `2` = Auto; needs DML fp16 model + patched DLL |
-| `gpu_model` | `smollm2-360m-dml-fp16` | USB/LocalState provision |
-| `diffuse_taesd_vae` | `true` after asset on `models-v1` | ~4.5 s/image target |
-| `sampling.temperature` | `0.8` | UI default |
-| `sampling.n_predict` | `512` | UI default |
+| Key                    | Recommended                       | Notes                                          |
+| ---------------------- | --------------------------------- | ---------------------------------------------- |
+| `model`                | `smollm2-360m-cpu-int4`           | Downloaded on first launch                     |
+| `kv_reuse`             | `true`                            | 4.87× turn-2 prefill (measured)                |
+| `routing`              | `0` default; `2` for RAG          | `2` = Auto; needs DML fp16 model + patched DLL |
+| `gpu_model`            | `smollm2-360m-dml-fp16`           | USB/LocalState provision                       |
+| `diffuse_taesd_vae`    | `true` after asset on `models-v1` | ~4.5 s/image target                            |
+| `sampling.temperature` | `0.8`                             | UI default                                     |
+| `sampling.n_predict`   | `512`                             | UI default                                     |
 
 Routing Auto uses **600 tokens** (real tokenizer count), sticky per conversation.
 
 ## Image generation
 
-| Setting | Modern | Obsolete |
-| ------- | ------ | -------- |
-| Trigger | `[*] Image` → **Generate** (in-process) | App restart + `diffuse.flag` |
-| Model dir | `sd-turbo-fp16` | — |
-| VAE | TAESD toggle on | Full VAE only (~2.6 s stage) |
-| Steps | `1` (SD-Turbo) | — |
-| TAESD asset | `sd-turbo-fp16_taesd_vae_decoder_model.onnx` on `models-v1` | — |
+| Setting     | Modern                                                      | Obsolete                     |
+| ----------- | ----------------------------------------------------------- | ---------------------------- |
+| Trigger     | `[*] Image` → **Generate** (in-process)                     | App restart + `diffuse.flag` |
+| Model dir   | `sd-turbo-fp16`                                             | —                            |
+| VAE         | TAESD toggle on                                             | Full VAE only (~2.6 s stage) |
+| Steps       | `1` (SD-Turbo)                                              | —                            |
+| TAESD asset | `sd-turbo-fp16_taesd_vae_decoder_model.onnx` on `models-v1` | —                            |
 
 Export host-side: [`scripts/export-taesd-asset.sh`](../scripts/export-taesd-asset.sh).
 
@@ -113,13 +122,13 @@ ctest --test-dir build/linux-test --output-on-failure
 
 ## Obsolete assumptions (do not reuse)
 
-| Myth | Reality |
-| ---- | ------- |
-| GPU pool ~768 MB | **3801 MB** (Game designation) |
-| Dev Mode disk ~2.5 GB cap | Raised to **90 GB** (Dev Home) |
+| Myth                                | Reality                                                  |
+| ----------------------------------- | -------------------------------------------------------- |
+| GPU pool ~768 MB                    | **3801 MB** (Game designation)                           |
+| Dev Mode disk ~2.5 GB cap           | Raised to **90 GB** (Dev Home)                           |
 | Diffusion needs headless (887A0036) | Conflict is **ORT GenAI** only; plain ORT DML in-proc OK |
-| MSIX bundles model | **~19 MB** MSIX; catalogue download |
-| `intra_op_num_threads: 8` | Bandwidth saturation on Series S |
+| MSIX bundles model                  | **~19 MB** MSIX; catalogue download                      |
+| `intra_op_num_threads: 8`           | Bandwidth saturation on Series S                         |
 
 ## Validation checklist
 

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -31,9 +31,10 @@ Platform limitations relevant to running LLM inference on Xbox Dev Mode, and how
 **Background — pool estimate corrected (2026-07-07)**: the GPU budget measured
 in-app (`QueryVideoMemoryInfo(LOCAL).Budget`) is **3801 MB** (package designated Game — verified 2026-07-08, see §5) on
 Series S — the earlier "~768 MB pool" was a coarse inference from the
-Phi-3.5-mini OOM bracketing and is superseded. The operative constraint for
-model sizing is the **Dev Mode disk budget** (`Q:\` ~2.2–2.5 GB free), not GPU
-memory.
+Phi-3.5-mini OOM bracketing and is superseded. Disk was then the operative
+sizing constraint, but the Dev Mode allocation was raised to **90 GB** on
+2026-07-08 (§9, superseded note) — the binding limits now are the **2 GB ONNX
+protobuf / per-file ceiling** (§8; §9 caveat) and the RAM/GPU budget.
 
 **Effect on DirectML EP**: with a DML model variant and the headless path
 (§7), the EP loads and executes on the GPU. Very large models can still OOM

--- a/scripts/vendor-genai-dml-patch.ps1
+++ b/scripts/vendor-genai-dml-patch.ps1
@@ -66,7 +66,7 @@ No patched DLL at:
   $VendorDll
 
 Place a console-validated onnxruntime-genai.dll there (built from
-microsoft/onnxruntime-genai tag v$GenAiVersion + patches/onnxruntime-genai-2280-dml-fallback.patch),
+microsoft/onnxruntime-genai branch rel-$GenAiVersion + patches/onnxruntime-genai-2280-dml-fallback.patch),
 or re-run with -Build to compile from source.
 
 Upstream: https://github.com/microsoft/onnxruntime-genai/pull/2280

--- a/vendor/onnxruntime-genai-patched/README.md
+++ b/vendor/onnxruntime-genai-patched/README.md
@@ -9,12 +9,20 @@ vendor/onnxruntime-genai-patched/win-x64/onnxruntime-genai.dll
 Build or install:
 
 ```powershell
-# From repo root (Windows + VS2022)
-./scripts/vendor-genai-dml-patch.ps1 -Build
-./scripts/build-uwp.ps1 -PatchedGenAI
+# From repo root (Windows + VS2022 + prior 'nuget restore' in uwp/)
+./scripts/vendor-genai-dml-patch.ps1 -Build   # always rebuilds; ignores this cache
+./scripts/build-uwp.ps1 -PatchedGenAI          # installs the cached DLL over NuGet
 ```
 
-The binary is gitignored. Pin: ORT GenAI **0.14.1** + patch from
-[`patches/onnxruntime-genai-2280-dml-fallback.patch`](../../patches/onnxruntime-genai-2280-dml-fallback.patch).
+No Windows machine: dispatch the CI lane instead — `gh workflow run
+build-uwp-patched.yml` uploads `xllama-appx-patched`,
+`xllama-appx-patched-unified`, and the built DLL as artifacts.
+
+The binary is gitignored. Pin: ORT GenAI **0.14.1** — upstream ships it as
+branch `rel-0.14.1` (there is no `v0.14.1` tag), pinned to commit `a30f479`
+in `scripts/vendor-genai-dml-patch.ps1` — plus
+[`patches/onnxruntime-genai-2280-dml-fallback.patch`](../../patches/onnxruntime-genai-2280-dml-fallback.patch),
+built against the restored `Microsoft.ML.OnnxRuntime.DirectML` NuGet
+(`ORT_HOME`), so the DLL links the exact onnxruntime the MSIX ships.
 
 Remove this vendor step when the fix ships in the official NuGet package.


### PR DESCRIPTION
## Summary

Documentation-only alignment to today's merged state (#39–#42), keeping each fact in its owning doc and pointers elsewhere — no content duplicated from CHANGELOG/ROADMAP:

| Doc | Fix |
|---|---|
| README | GGUF rows w/ measured decode; disk limitation → 90 GB supersession (points at constraints §8–§9); in-process image gen in the diagram; unified-lane sentence; helper listings |
| docs/uwp-constraints.md | intro claim aligned to the §9 superseded note |
| docs/recommended-config.md | GGUF measured rows, llama thread cap (6), sharper "do not use" |
| docs/console-validation-runbook.md §2 | CI-lane artifact as the no-Windows path; settings upload must land as `settings.json` (as-written command left `settings-modern.json` unread) |
| vendor README + script message | rel-0.14.1 branch pin (no v0.14.1 tag), ORT_HOME build, `-Build` cache semantics |
| AGENTS.md | directory map: new helpers |

## Test plan
- [x] pwsh syntax check on the touched script string
- [ ] CI green (docs-only + one ps1 message string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)