### PR TITLE
feat(uwp): console autopilot + validate-console.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ xllama/
 ├── src/main.cpp             # Linux entry point (getopt_long)
 ├── uwp/                     # C++/WinRT UWP app
 │   ├── App.cpp / App.h      # Application::OnLaunched
-│   ├── MainPage.cpp / .h    # MainPageController (plain C++, not runtimeclass)
+│   ├── MainPage.cpp / .h    # MainPageController (plain C++, not runtimeclass); incl. autopilot driver
 │   ├── inference-bridge.cpp / .h   # UWP main_loop() + bench mode
 │   ├── chat-history.cpp / .h       # ChatHistory: Save/Load/Delete/Clear
 │   ├── model-downloader.cpp / .h   # EnsureModelAsync — catalogue download (GitHub Release models-v1, models/manifest.json)
@@ -45,6 +45,7 @@ xllama/
 │   ├── build-uwp.ps1                  # Windows UWP packaging script
 │   ├── merge_onnx_external_data.py    # merge model.onnx.data → self-contained model.onnx
 │   ├── bench-xbox-ort.sh              # benchmark runner (ORT GenAI; model already on device)
+│   ├── validate-console.sh           # autopilot orchestrator: §2 routing / GGUF / §7c TAESD verdicts
 │   ├── install-latest-build.sh        # fetch + deploy latest CI artifact
 │   ├── test-dml-config.sh             # upload DML provider_options without MSIX rebuild
 │   ├── vendor-genai-dml-patch.ps1     # overlay #2280 patched onnxruntime-genai.dll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Console autopilot + `validate-console.sh`.** Dev Mode gives the console no
+  working text-input path, so §2 routing / §7c TAESD / GGUF-chat validations
+  needed a person at the pad. A flag-driven in-app driver (`autopilot.flag` →
+  `App::OnLaunched`) now replays a JSON action list
+  (`load_chat|send|new_chat|set_model|generate_image|quit`) against the same
+  controller methods the buttons call — real XAML process, no UI code
+  duplicated — writing `autopilot-done.txt` (`ok`/`error:`). The host
+  orchestrator `scripts/validate-console.sh <routing|gguf|taesd|all>` uploads
+  the script, restarts, polls, and emits deterministic PASS/FAIL from the log
+  (no LLM judgment in the verdict). The §2 automated PASS is the official gate
+  for promoting `-PatchedGenAI` to default. Package bumped to **1.1.3.0** (also
+  carries the #44 manifest-merge fix on-device). `create_llama` now logs a
+  distinct GGUF-session load marker.
 - **GGUF assets in the catalogue (Fase 2b).** `Qwen3.5-0.8B-Q4_K_M.gguf`
   (508 MB, unsloth quant, Apache-2.0) and `LFM2.5-350M-Q4_K_M.gguf` (219 MB,
   LiquidAI official) published on `models-v1`; catalogue entries `qwen35-0.8b`

--- a/docs/console-validation-runbook.md
+++ b/docs/console-validation-runbook.md
@@ -64,7 +64,21 @@ confirm multi-turn **coherence** (read the log's decoded turn-2 output) before t
 **Validates**: the `routing=2` (auto) path picks GPU (DML fp16) for long prompts and CPU
 for decode, sticky per conversation.
 
-**Prereqs**:
+> **Automated gate (preferred).** Dev Mode gives the console no working text-input
+> path, so this A/B is driven by the in-app **autopilot** (build ≥ 1.1.3.0):
+>
+> ```bash
+> source ~/.config/xllama/xbox-env
+> ./scripts/validate-console.sh routing   # PASS/FAIL from the log, exit code
+> ```
+>
+> It seeds a >600-token decoy conversation, replays load_chat → send → new_chat →
+> send via `autopilot.flag`/`autopilot.json`, and greps `xllama.log` for
+> `auto → gpu (N>600 tok`, `auto → cpu` on the new chat, and the absence of
+> `887A0036`. **A PASS here is the official §2 gate** (same StartInference in the
+> live XAML process as a human run). The manual steps below remain for debugging.
+
+**Prereqs** (manual path):
 
 1. A `-PatchedGenAI` MSIX (ORT GenAI #2280 — vanilla NuGet DLL hits `887A0036`
    in XAML): either `gh workflow run build-uwp-patched.yml` and download the
@@ -231,13 +245,30 @@ PNG is coherent and matches the headless output. In-process was even faster than
 
 ### 7c. TAESD VAE (Image dialog toggle) — ⏳ PENDING
 
-**Prereqs**: `sd-turbo-fp16_taesd_vae_decoder_model.onnx` on the `models-v1` Release
-(host export: `./scripts/export-taesd-asset.sh` + `gh release upload`).
+> **Automated (preferred).** `./scripts/validate-console.sh taesd` swaps the tiny
+> TAESD VAE into `models\sd-turbo-fp16\vae_decoder\model.onnx`, autopilots a
+> `generate_image` (steps=1), checks `diffuse-result.csv` `vae_ms < 1000`, and
+> **restores the full VAE on exit** (trap). PASS/FAIL + exit code.
+
+**Prereqs** (manual path): `sd-turbo-fp16_taesd_vae_decoder_model.onnx` on the
+`models-v1` Release (host export: `./scripts/export-taesd-asset.sh` + `gh release upload`).
 
 At the console: `[*] Image` → enable **TAESD fast VAE** → **Generate** with steps=1.
 
 **Looking for**: total wall-clock ~4.5 s (vs ~5.6 s full VAE, VAE stage ~2.6 s → sub-second),
 coherent PNG. Record te/UNet/VAE stage times from the log in `bench/results/`.
+
+## Autopilot (`validate-console.sh`)
+
+The in-app autopilot (build ≥ 1.1.3.0) scripts the live XAML UI so §2/§7c/GGUF
+chat run without a person at the pad. Trigger `LocalState\autopilot.flag` (consumed
+at `App::OnLaunched`); actions from `LocalState\autopilot.json`
+(`load_chat|send|new_chat|set_model|generate_image|quit`); result in
+`LocalState\autopilot-done.txt` (`ok` | `error: <detail>`). Progress lines carry an
+`[autopilot]` prefix — on a hard crash (no done-marker, process dead) the last
+`[autopilot] action <i> <op> start` in `xllama.log` names the in-flight action.
+`./scripts/validate-console.sh <routing|gguf|taesd|all>` orchestrates upload →
+restart → poll → verdict.
 
 ## Closeout
 

--- a/scripts/validate-console.sh
+++ b/scripts/validate-console.sh
@@ -39,6 +39,7 @@ PFN=$("${DEPLOY}" pfn 2>/dev/null)
 }
 
 TMPDIR_LOCAL=$(mktemp -d)
+VAE_CACHE="" # set by validate_taesd; read by its EXIT trap (must be global)
 trap 'rm -rf "$TMPDIR_LOCAL"' EXIT
 
 # --- WDP helpers (same idioms as bench-xbox-ort.sh) ------------------------
@@ -124,6 +125,10 @@ run_autopilot() {
 	printf 'go' >"${TMPDIR_LOCAL}/autopilot.flag"
 	delete_file "autopilot-done.txt"
 	delete_file "diffuse-progress.txt"
+	# xllama.log is append-only across restarts; clear it so the verdict greps
+	# only this run (a stale 887A0036 or routing line would falsify the gate).
+	# The app reopens the log lazily on next launch.
+	delete_file "xllama.log"
 	upload_file "${TMPDIR_LOCAL}/autopilot.json"
 	upload_file "${TMPDIR_LOCAL}/autopilot.flag"
 	restart_app
@@ -139,11 +144,29 @@ fetch_log() {
 
 validate_routing() {
 	echo "=== §2 routing A/B ==="
+	# Routing=auto is emitted only when settings.json has "routing": 2; seed it
+	# (the whole point is that no human could set it via the dialog). Schema
+	# mirrors SaveSettings (MainPage.cpp).
+	cat >"${TMPDIR_LOCAL}/settings.json" <<'JSON'
+{
+  "system_prompt": "You are a helpful AI assistant.",
+  "model": "smollm2-360m-cpu-int4",
+  "kv_reuse": true,
+  "routing": 2,
+  "gpu_model": "smollm2-360m-dml-fp16",
+  "diffuse_taesd_vae": false,
+  "sampling": {"temperature": 0.8, "top_p": 0.9, "top_k": 40, "repetition_penalty": 1.1, "n_predict": 256}
+}
+JSON
+	upload_file "${TMPDIR_LOCAL}/settings.json"
+
 	# Build the long decoy conversation (>600 tok) from long-1k.txt, stripping
-	# the ChatML wrapper so the stored user content is plain prose.
+	# the ChatML wrapper so the stored user content is plain prose. Merge it into
+	# the device's existing chat index rather than clobbering it.
 	local esca_id="ap-routing-longctx"
+	fetch_file "index.json" "${TMPDIR_LOCAL}/existing-index.json" "chats"
 	python3 - "$REPO_ROOT" "$TMPDIR_LOCAL" "$esca_id" <<'PY'
-import json, re, sys, time
+import json, re, sys
 repo, tmp, cid = sys.argv[1], sys.argv[2], sys.argv[3]
 body = open(f"{repo}/bench/prompts/long-1k.txt").read()
 m = re.search(r'<\|im_start\|>user\n(.*?)(?:<\|im_end\|>|$)', body, re.S)
@@ -154,17 +177,25 @@ conv = {"id": cid, "title": "routing A/B (long context)", "messages": [
     {"role": "assistant", "content": "Understood; ready to continue.", "ts": ts+1, "partial": False},
 ]}
 open(f"{tmp}/{cid}.json", "w").write(json.dumps(conv, ensure_ascii=False))
-open(f"{tmp}/index.json", "w").write(json.dumps(
-    [{"id": cid, "title": conv["title"], "last_modified": ts+1, "n_messages": 2}],
-    ensure_ascii=False))
-print(f"  decoy user chars: {len(user)} (~{len(user)//4} tok)")
+entry = {"id": cid, "title": conv["title"], "last_modified": ts+1, "n_messages": 2}
+idx = []
+try:
+    idx = json.load(open(f"{tmp}/existing-index.json"))
+    if not isinstance(idx, list):
+        idx = []
+except Exception:
+    idx = []
+idx = [e for e in idx if e.get("id") != cid]
+idx.insert(0, entry)
+open(f"{tmp}/index.json", "w").write(json.dumps(idx, ensure_ascii=False))
+print(f"  decoy user chars: {len(user)} (~{len(user)//4} tok); index entries: {len(idx)}")
 PY
 	upload_file "${TMPDIR_LOCAL}/${esca_id}.json" "chats"
 	upload_file "${TMPDIR_LOCAL}/index.json" "chats"
 
 	local marker
 	marker=$(
-		run_autopilot 900 <<JSON
+		run_autopilot 1300 <<JSON
 {"total_timeout_s": 900, "actions": [
   {"op": "load_chat", "id": "${esca_id}"},
   {"op": "send", "text": "continue", "timeout_s": 300},
@@ -174,7 +205,7 @@ PY
   {"op": "quit"}
 ]}
 JSON
-	)
+	) || true
 	echo "  autopilot: ${marker}"
 	local log
 	log=$(fetch_log)
@@ -224,7 +255,7 @@ validate_gguf() {
 	echo "=== GGUF chat (unified) ==="
 	local marker
 	marker=$(
-		run_autopilot 300 <<'JSON'
+		run_autopilot 900 <<'JSON'
 {"total_timeout_s": 300, "actions": [
   {"op": "set_model", "name": "lfm25-350m"},
   {"op": "new_chat"},
@@ -232,7 +263,7 @@ validate_gguf() {
   {"op": "quit"}
 ]}
 JSON
-	)
+	) || true
 	echo "  autopilot: ${marker}"
 	local log verdict=0
 	log=$(fetch_log)
@@ -256,31 +287,30 @@ JSON
 validate_taesd() {
 	echo "=== §7c TAESD image ==="
 	local rel="https://github.com/gianlucamazza/xllama/releases/download/models-v1"
-	local cache="${REPO_ROOT}/.cache-validate"
-	mkdir -p "$cache"
+	# VAE_CACHE is a GLOBAL (set below) so the EXIT trap can still read it after
+	# this function returns — a `local` would be out of scope at trap time and
+	# abort the restore under `set -u`.
+	VAE_CACHE="${REPO_ROOT}/.cache-validate"
+	mkdir -p "$VAE_CACHE"
 	# Cache the tiny (TAESD) and full VAE decoders once.
-	[[ -f "${cache}/taesd_vae.onnx" ]] ||
-		curl -fsSL "${rel}/sd-turbo-fp16_taesd_vae_decoder_model.onnx" -o "${cache}/taesd_vae.onnx"
-	[[ -f "${cache}/full_vae.onnx" ]] ||
-		curl -fsSL "${rel}/sd-turbo-fp16_vae_decoder_model.onnx" -o "${cache}/full_vae.onnx"
+	[[ -f "${VAE_CACHE}/taesd_vae.onnx" ]] ||
+		curl -fsSL "${rel}/sd-turbo-fp16_taesd_vae_decoder_model.onnx" -o "${VAE_CACHE}/taesd_vae.onnx"
+	[[ -f "${VAE_CACHE}/full_vae.onnx" ]] ||
+		curl -fsSL "${rel}/sd-turbo-fp16_vae_decoder_model.onnx" -o "${VAE_CACHE}/full_vae.onnx"
 
 	# Swap TAESD in, restore the full VAE on exit no matter what.
-	restore_vae() {
-		echo "  restoring full VAE decoder ..." >&2
-		upload_file "${cache}/full_vae.onnx" "models\\sd-turbo-fp16\\vae_decoder" "model.onnx"
-	}
-	trap 'restore_vae; rm -rf "$TMPDIR_LOCAL"' EXIT
-	upload_file "${cache}/taesd_vae.onnx" "models\\sd-turbo-fp16\\vae_decoder" "model.onnx"
+	trap 'echo "  restoring full VAE decoder ..." >&2; upload_file "${VAE_CACHE}/full_vae.onnx" "models\\sd-turbo-fp16\\vae_decoder" "model.onnx"; rm -rf "$TMPDIR_LOCAL"' EXIT
+	upload_file "${VAE_CACHE}/taesd_vae.onnx" "models\\sd-turbo-fp16\\vae_decoder" "model.onnx"
 
 	local marker
 	marker=$(
-		run_autopilot 600 <<'JSON'
+		run_autopilot 1300 <<'JSON'
 {"total_timeout_s": 600, "actions": [
   {"op": "generate_image", "prompt": "a red sports car on a mountain road at sunset", "steps": 1, "seed": 42, "timeout_s": 600},
   {"op": "quit"}
 ]}
 JSON
-	)
+	) || true
 	echo "  autopilot: ${marker}"
 	local verdict=0
 	[[ "$marker" == "ok" ]] || {

--- a/scripts/validate-console.sh
+++ b/scripts/validate-console.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+# validate-console.sh — drive the xllama autopilot to validate the live XAML UI
+# on Xbox with deterministic PASS/FAIL verdicts, no human at the pad.
+#
+# Usage:
+#   source ~/.config/xllama/xbox-env
+#   ./scripts/validate-console.sh <routing|gguf|taesd|all>
+#
+# Requires: an installed xllama build with the autopilot (>= 1.1.3.0), the
+# relevant models already in LocalState (smollm2-360m-dml-fp16 for routing,
+# lfm25-350m for gguf, sd-turbo-fp16 for taesd), and XBOX_IP/USER/PASS env.
+#
+# Contract per subcommand: upload chats/autopilot.json + autopilot.flag,
+# restart the app, poll LocalState\autopilot-done.txt, fetch xllama.log, and
+# grep the log for the verdict. Exit 0 = PASS, non-zero = FAIL. The autopilot
+# ends every script with a `quit` action so the app exits itself.
+
+set -euo pipefail
+
+: "${XBOX_IP:?XBOX_IP not set — run: source ~/.config/xllama/xbox-env}"
+: "${XBOX_USER:?XBOX_USER not set}"
+: "${XBOX_PASS:?XBOX_PASS not set}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEPLOY="${SCRIPT_DIR}/deploy.sh"
+BASE_URL="https://${XBOX_IP}:11443"
+CURL_AUTH=(--basic -u "${XBOX_USER}:${XBOX_PASS}" -k -sS)
+
+CSRF_TOKEN=$(curl "${CURL_AUTH[@]}" "${BASE_URL}/" -o /dev/null -D - 2>/dev/null |
+	sed -n 's/.*[Cc][Ss][Rr][Ff]-[Tt]oken=\([^;[:space:]]*\).*/\1/p' |
+	tr -d '\r' | head -n1)
+[[ -z "$CSRF_TOKEN" ]] && echo "Warning: no CSRF token — POST/DELETE may fail" >&2
+
+PFN=$("${DEPLOY}" pfn 2>/dev/null)
+[[ -z "$PFN" ]] && {
+	echo "Error: xllama not found — deploy it first" >&2
+	exit 1
+}
+
+TMPDIR_LOCAL=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_LOCAL"' EXIT
+
+# --- WDP helpers (same idioms as bench-xbox-ort.sh) ------------------------
+
+_curl_post_file() {
+	local local_path="$1" path_param="$2" filename="${3:-}"
+	local form_entry
+	if [[ -n "$filename" ]]; then
+		form_entry="${local_path};filename=${filename};type=application/octet-stream"
+	else
+		form_entry="${local_path};type=application/octet-stream"
+	fi
+	curl "${CURL_AUTH[@]}" -H "X-CSRF-Token:${CSRF_TOKEN}" -X POST \
+		-F "file=@${form_entry}" \
+		"${BASE_URL}/api/filesystem/apps/file?knownfolderid=LocalAppData&packagefullname=${PFN}&path=${path_param}" \
+		>/dev/null
+}
+
+# upload_file <local> [remote_subdir] [remote_name]
+upload_file() {
+	local local_path="$1" remote_dir="${2:-}" remote_name="${3:-}"
+	local path_param="%5CLocalState"
+	[[ -n "$remote_dir" ]] && path_param="%5CLocalState%5C${remote_dir//\\/%5C}"
+	_curl_post_file "$local_path" "$path_param" "$remote_name"
+}
+
+# fetch_file <remote_name> <dest> [remote_subdir]
+fetch_file() {
+	local remote_name="$1" dest="$2" remote_dir="${3:-}"
+	local path_param="%5CLocalState"
+	[[ -n "$remote_dir" ]] && path_param="%5CLocalState%5C${remote_dir//\\/%5C}"
+	curl "${CURL_AUTH[@]}" -o "$dest" \
+		"${BASE_URL}/api/filesystem/apps/file?knownfolderid=LocalAppData&packagefullname=${PFN}&path=${path_param}&filename=${remote_name}" \
+		2>/dev/null || true
+}
+
+delete_file() {
+	local remote_name="$1" remote_dir="${2:-}"
+	local path_param="%5CLocalState"
+	[[ -n "$remote_dir" ]] && path_param="%5CLocalState%5C${remote_dir//\\/%5C}"
+	curl "${CURL_AUTH[@]}" -H "X-CSRF-Token:${CSRF_TOKEN}" -X DELETE \
+		"${BASE_URL}/api/filesystem/apps/file?knownfolderid=LocalAppData&packagefullname=${PFN}&path=${path_param}&filename=${remote_name}" \
+		>/dev/null 2>&1 || true
+}
+
+restart_app() {
+	curl "${CURL_AUTH[@]}" -H "X-CSRF-Token:${CSRF_TOKEN}" -X DELETE \
+		"${BASE_URL}/api/taskmanager/app?package=${PFN}" >/dev/null 2>&1 || true
+	sleep 2
+	local pfamily aumid
+	# shellcheck disable=SC2001
+	pfamily=$(echo "$PFN" | sed 's/_[0-9][0-9.]*_[^_]*__/_/')
+	aumid=$(printf '%s!xllama' "$pfamily" | base64 -w0)
+	curl "${CURL_AUTH[@]}" -H "X-CSRF-Token:${CSRF_TOKEN}" -X POST -d "" \
+		"${BASE_URL}/api/taskmanager/app?appid=${aumid}" >/dev/null 2>&1 || true
+}
+
+# Poll autopilot-done.txt; echoes its content, returns non-zero on timeout.
+wait_autopilot_done() {
+	local timeout_s="${1:-900}" elapsed=0 out="${TMPDIR_LOCAL}/done.txt"
+	echo "  Waiting for autopilot-done.txt (timeout ${timeout_s}s)..." >&2
+	while ((elapsed < timeout_s)); do
+		: >"$out"
+		fetch_file "autopilot-done.txt" "$out"
+		# A real marker is "ok" or "error: ..."; a 404 body contains neither.
+		if grep -qE '^(ok|error:)' "$out" 2>/dev/null; then
+			echo "  Done after ${elapsed}s." >&2
+			cat "$out"
+			return 0
+		fi
+		sleep 10
+		((elapsed += 10))
+	done
+	echo "  Timeout waiting for autopilot-done.txt" >&2
+	return 1
+}
+
+# Upload autopilot.json (from stdin) + a fresh autopilot.flag, clear stale
+# markers, restart, and wait. Echoes the done-marker content.
+run_autopilot() {
+	local timeout_s="${1:-900}"
+	cat >"${TMPDIR_LOCAL}/autopilot.json"
+	printf 'go' >"${TMPDIR_LOCAL}/autopilot.flag"
+	delete_file "autopilot-done.txt"
+	delete_file "diffuse-progress.txt"
+	upload_file "${TMPDIR_LOCAL}/autopilot.json"
+	upload_file "${TMPDIR_LOCAL}/autopilot.flag"
+	restart_app
+	wait_autopilot_done "$timeout_s"
+}
+
+fetch_log() {
+	fetch_file "xllama.log" "${TMPDIR_LOCAL}/xllama.log"
+	echo "${TMPDIR_LOCAL}/xllama.log"
+}
+
+# --- §2 routing A/B --------------------------------------------------------
+
+validate_routing() {
+	echo "=== §2 routing A/B ==="
+	# Build the long decoy conversation (>600 tok) from long-1k.txt, stripping
+	# the ChatML wrapper so the stored user content is plain prose.
+	local esca_id="ap-routing-longctx"
+	python3 - "$REPO_ROOT" "$TMPDIR_LOCAL" "$esca_id" <<'PY'
+import json, re, sys, time
+repo, tmp, cid = sys.argv[1], sys.argv[2], sys.argv[3]
+body = open(f"{repo}/bench/prompts/long-1k.txt").read()
+m = re.search(r'<\|im_start\|>user\n(.*?)(?:<\|im_end\|>|$)', body, re.S)
+user = (m.group(1) if m else body).strip()
+ts = 1
+conv = {"id": cid, "title": "routing A/B (long context)", "messages": [
+    {"role": "user", "content": user, "ts": ts, "partial": False},
+    {"role": "assistant", "content": "Understood; ready to continue.", "ts": ts+1, "partial": False},
+]}
+open(f"{tmp}/{cid}.json", "w").write(json.dumps(conv, ensure_ascii=False))
+open(f"{tmp}/index.json", "w").write(json.dumps(
+    [{"id": cid, "title": conv["title"], "last_modified": ts+1, "n_messages": 2}],
+    ensure_ascii=False))
+print(f"  decoy user chars: {len(user)} (~{len(user)//4} tok)")
+PY
+	upload_file "${TMPDIR_LOCAL}/${esca_id}.json" "chats"
+	upload_file "${TMPDIR_LOCAL}/index.json" "chats"
+
+	local marker
+	marker=$(
+		run_autopilot 900 <<JSON
+{"total_timeout_s": 900, "actions": [
+  {"op": "load_chat", "id": "${esca_id}"},
+  {"op": "send", "text": "continue", "timeout_s": 300},
+  {"op": "send", "text": "ok", "timeout_s": 120},
+  {"op": "new_chat"},
+  {"op": "send", "text": "hello", "timeout_s": 120},
+  {"op": "quit"}
+]}
+JSON
+	)
+	echo "  autopilot: ${marker}"
+	local log
+	log=$(fetch_log)
+
+	local verdict=0
+	if [[ "$marker" != "ok" ]]; then
+		echo "  FAIL: autopilot did not finish ok"
+		verdict=1
+	fi
+	# The routing log line uses "auto -> gpu"/"auto -> cpu" (ASCII arrow in the
+	# C++ is "→"; match on the tok field to be encoding-robust).
+	local gpu_line cpu_line
+	gpu_line=$(grep -aE 'routing: auto .* gpu \([0-9]+ tok' "$log" | head -1 || true)
+	cpu_line=$(grep -aE 'routing: auto .* cpu \([0-9]+ tok' "$log" | head -1 || true)
+	if [[ -z "$gpu_line" ]]; then
+		echo "  FAIL: no 'auto -> gpu' routing line for the long-context turn"
+		verdict=1
+	else
+		local ntok
+		ntok=$(sed -n 's/.*(\([0-9]\+\) tok.*/\1/p' <<<"$gpu_line")
+		if ((ntok <= 600)); then
+			echo "  FAIL: gpu-routed turn had only ${ntok} tok (<=600)"
+			verdict=1
+		else
+			echo "  ok: long turn routed to GPU (${ntok} tok)"
+		fi
+	fi
+	if [[ -z "$cpu_line" ]]; then
+		echo "  FAIL: no 'auto -> cpu' routing line for the new short chat"
+		verdict=1
+	else
+		echo "  ok: new short chat routed to CPU"
+	fi
+	if grep -aq '887A0036' "$log"; then
+		echo "  FAIL: 887A0036 present — patched GenAI DLL did not take"
+		verdict=1
+	else
+		echo "  ok: no 887A0036 (patched DLL works in XAML)"
+	fi
+	[[ $verdict -eq 0 ]] && echo "§2 routing: PASS" || echo "§2 routing: FAIL"
+	return $verdict
+}
+
+# --- GGUF chat -------------------------------------------------------------
+
+validate_gguf() {
+	echo "=== GGUF chat (unified) ==="
+	local marker
+	marker=$(
+		run_autopilot 300 <<'JSON'
+{"total_timeout_s": 300, "actions": [
+  {"op": "set_model", "name": "lfm25-350m"},
+  {"op": "new_chat"},
+  {"op": "send", "text": "Say hello in one short sentence.", "timeout_s": 180},
+  {"op": "quit"}
+]}
+JSON
+	)
+	echo "  autopilot: ${marker}"
+	local log verdict=0
+	log=$(fetch_log)
+	[[ "$marker" == "ok" ]] || {
+		echo "  FAIL: autopilot did not finish ok"
+		verdict=1
+	}
+	# The interactive llama.cpp session logs a distinct marker on load.
+	if grep -aq 'GGUF model loaded via llama.cpp' "$log"; then
+		echo "  ok: lfm25-350m loaded via llama.cpp (persistent session)"
+	else
+		echo "  FAIL: no llama.cpp GGUF session load in the log"
+		verdict=1
+	fi
+	[[ $verdict -eq 0 ]] && echo "GGUF chat: PASS" || echo "GGUF chat: FAIL"
+	return $verdict
+}
+
+# --- §7c TAESD -------------------------------------------------------------
+
+validate_taesd() {
+	echo "=== §7c TAESD image ==="
+	local rel="https://github.com/gianlucamazza/xllama/releases/download/models-v1"
+	local cache="${REPO_ROOT}/.cache-validate"
+	mkdir -p "$cache"
+	# Cache the tiny (TAESD) and full VAE decoders once.
+	[[ -f "${cache}/taesd_vae.onnx" ]] ||
+		curl -fsSL "${rel}/sd-turbo-fp16_taesd_vae_decoder_model.onnx" -o "${cache}/taesd_vae.onnx"
+	[[ -f "${cache}/full_vae.onnx" ]] ||
+		curl -fsSL "${rel}/sd-turbo-fp16_vae_decoder_model.onnx" -o "${cache}/full_vae.onnx"
+
+	# Swap TAESD in, restore the full VAE on exit no matter what.
+	restore_vae() {
+		echo "  restoring full VAE decoder ..." >&2
+		upload_file "${cache}/full_vae.onnx" "models\\sd-turbo-fp16\\vae_decoder" "model.onnx"
+	}
+	trap 'restore_vae; rm -rf "$TMPDIR_LOCAL"' EXIT
+	upload_file "${cache}/taesd_vae.onnx" "models\\sd-turbo-fp16\\vae_decoder" "model.onnx"
+
+	local marker
+	marker=$(
+		run_autopilot 600 <<'JSON'
+{"total_timeout_s": 600, "actions": [
+  {"op": "generate_image", "prompt": "a red sports car on a mountain road at sunset", "steps": 1, "seed": 42, "timeout_s": 600},
+  {"op": "quit"}
+]}
+JSON
+	)
+	echo "  autopilot: ${marker}"
+	local verdict=0
+	[[ "$marker" == "ok" ]] || {
+		echo "  FAIL: autopilot did not finish ok"
+		verdict=1
+	}
+	fetch_file "diffuse-result.csv" "${TMPDIR_LOCAL}/diffuse-result.csv"
+	# diffuse-result.csv columns include a vae_ms field; TAESD should be sub-second.
+	local vae_ms
+	vae_ms=$(
+		python3 - "${TMPDIR_LOCAL}/diffuse-result.csv" <<'PY'
+import csv, sys
+try:
+    rows = list(csv.DictReader(open(sys.argv[1])))
+    r = rows[-1] if rows else {}
+    key = next((k for k in r if k and 'vae' in k.lower() and 'ms' in k.lower()), None)
+    print(r.get(key, "") if key else "")
+except Exception:
+    print("")
+PY
+	)
+	if [[ -n "$vae_ms" ]] && awk "BEGIN{exit !($vae_ms < 1000)}"; then
+		echo "  ok: TAESD VAE stage ${vae_ms} ms (<1000)"
+	else
+		echo "  FAIL: VAE stage ms='${vae_ms}' not sub-second"
+		verdict=1
+	fi
+	[[ $verdict -eq 0 ]] && echo "§7c TAESD: PASS" || echo "§7c TAESD: FAIL"
+	return $verdict
+}
+
+# --- dispatch --------------------------------------------------------------
+
+CMD="${1:-}"
+case "$CMD" in
+routing) validate_routing ;;
+gguf) validate_gguf ;;
+taesd) validate_taesd ;;
+all)
+	rc=0
+	validate_routing || rc=1
+	validate_gguf || rc=1
+	validate_taesd || rc=1
+	echo
+	echo "=== summary ==="
+	[[ $rc -eq 0 ]] && echo "ALL PASS" || echo "SOME FAILED (exit ${rc})"
+	exit $rc
+	;;
+*)
+	echo "Usage: $0 <routing|gguf|taesd|all>" >&2
+	exit 1
+	;;
+esac

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -503,6 +503,7 @@ std::unique_ptr<Session> create_llama(const SessionParams& sp, std::string* err)
 
     int n_threads = sp.n_threads > 0 ? sp.n_threads : detect_threads_llama();
     int n_ctx = sp.n_ctx > 0 ? sp.n_ctx : 2048;
+    log_output("[xllama] Session: GGUF model loaded via llama.cpp (persistent)\n");
     return std::make_unique<LlamaSession>(LlamaModelPtr(raw_model), n_ctx, n_threads);
 }
 } // namespace detail

--- a/uwp/App.cpp
+++ b/uwp/App.cpp
@@ -128,6 +128,12 @@ void App::OnLaunched(LaunchActivatedEventArgs const&) {
                                      "XAML window still up)\n");
             }).detach();
         }
+
+        // Autopilot: scripted validation of the live XAML UI (no-op unless
+        // LocalState\autopilot.flag exists). Consumes the flag and drives the
+        // controller from a background thread — see MainPage.cpp.
+        if (m_controller)
+            m_controller->StartAutopilotIfRequested();
     } catch (winrt::hresult_error const& e) {
         char buf[512];
         snprintf(buf, sizeof(buf), "[xllama] OnLaunched hresult 0x%08X: %ls\n",

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -10,7 +10,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="1.1.2.0"
+    Version="1.1.3.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -2049,6 +2049,9 @@ void MainPageController::StartAutopilotIfRequested() {
             if (!ApParseScript(json, actions, total_cap, perr))
                 throw std::runtime_error("bad autopilot.json: " + perr);
             self->ApRun(std::move(actions), total_cap);
+        } catch (const winrt::hresult_error& e) {
+            result = "error: hresult 0x" + std::to_string((unsigned)e.code().value) + " " +
+                     ::xllama::wstring_to_utf8(std::wstring(e.message().c_str()));
         } catch (const std::exception& e) {
             result = std::string("error: ") + e.what();
         } catch (...) {

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -13,13 +13,16 @@
     #include "xllama/platform.h"
     #include "xllama/utf8_utils.h"
 
+    #include <winrt/Windows.Data.Json.h>
     #include <winrt/Windows.UI.Xaml.Media.Imaging.h>
 
+    #include <chrono>
     #include <cstdio>
     #include <ctime>
     #include <filesystem>
     #include <string>
     #include <thread>
+    #include <vector>
 
 using namespace winrt;
 using namespace winrt::Windows::Foundation;
@@ -1419,6 +1422,7 @@ fire_and_forget MainPageController::EnsureModelAsync() {
         self->LoadModelName();
         self->SetStatus(L"Ready", StatusKind::Success);
         self->m_runButton.IsEnabled(true);
+        self->m_model_ready.store(true);
         co_return;
     }
 
@@ -1435,6 +1439,7 @@ fire_and_forget MainPageController::EnsureModelAsync() {
             self->LoadModelName();
             self->SetStatus(L"Ready", StatusKind::Success);
             self->m_runButton.IsEnabled(true);
+            self->m_model_ready.store(true);
             co_return;
         }
     }
@@ -1560,6 +1565,7 @@ fire_and_forget MainPageController::EnsureModelAsync() {
             self->LoadModelName();
             self->SetStatus(L"Ready", StatusKind::Success);
             self->m_runButton.IsEnabled(true);
+            self->m_model_ready.store(true);
             co_return;
         }
     }
@@ -1630,6 +1636,7 @@ fire_and_forget MainPageController::EnsureModelAsync() {
             }
             self->SetStatus(L"Model ready", StatusKind::Success);
             self->LoadModelName();
+            self->m_model_ready.store(true);
         });
 }
 
@@ -1940,6 +1947,216 @@ void MainPageController::OnCancelClick(IInspectable const&, RoutedEventArgs cons
     m_abort.store(true);
     SetStatus(L"Cancelling...");
     m_cancelButton.IsEnabled(false);
+}
+
+// ---------------------------------------------------------------------------
+// Autopilot — scripted validation of the real XAML UI.
+//
+// Dev Mode gives the console no working text-input path (the Xbox companion
+// app's remote keyboard does not connect to a Dev-Mode console), so the §2
+// routing A/B, §7c TAESD and GGUF-chat validations could only be done by hand.
+// This driver replays a JSON action list against the same controller methods
+// the buttons call (StartInference / NewChat / LoadConversation / StartDiffusion),
+// on the UI thread, from a background MTA thread — no UI code is duplicated.
+//
+// Trigger: LocalState\autopilot.flag (consumed). Script: LocalState\autopilot.json.
+// Result: LocalState\autopilot-done.txt = "ok" | "error: <detail>". Progress is
+// logged with an [autopilot] prefix (flushed per line) so a hard crash still
+// leaves the in-flight action identifiable.
+// ---------------------------------------------------------------------------
+
+// Parse autopilot.json into an action list. Returns false + err on shape error.
+bool MainPageController::ApParseScript(const std::string& json_utf8, std::vector<ApAction>& out,
+                                       std::chrono::seconds& total_cap, std::string& err) {
+    using winrt::Windows::Data::Json::JsonObject;
+    JsonObject root{nullptr};
+    if (!JsonObject::TryParse(::xllama::utf8_to_wstring(json_utf8), root)) {
+        err = "not valid JSON";
+        return false;
+    }
+    total_cap = std::chrono::seconds((int64_t)root.GetNamedNumber(L"total_timeout_s", 1800));
+    if (!root.HasKey(L"actions")) {
+        err = "no 'actions' array";
+        return false;
+    }
+    for (auto const& item : root.GetNamedArray(L"actions")) {
+        auto obj = item.GetObject();
+        ApAction a;
+        a.op = ::xllama::wstring_to_utf8(std::wstring(obj.GetNamedString(L"op", L"").c_str()));
+        if (a.op.empty()) {
+            err = "action without 'op'";
+            return false;
+        }
+        // Single payload slot: text (send) / id (load_chat) / name (set_model) /
+        // prompt (generate_image).
+        for (auto key : {L"text", L"id", L"name", L"prompt"}) {
+            if (obj.HasKey(key)) {
+                a.arg = std::wstring(obj.GetNamedString(key, L"").c_str());
+                break;
+            }
+        }
+        a.steps = (int)obj.GetNamedNumber(L"steps", 1);
+        a.seed = (unsigned)obj.GetNamedNumber(L"seed", 42);
+        int t = (int)obj.GetNamedNumber(L"timeout_s", 0);
+        a.timeout = std::chrono::seconds(t);
+        out.push_back(std::move(a));
+    }
+    if (out.empty()) {
+        err = "empty 'actions'";
+        return false;
+    }
+    return true;
+}
+
+void MainPageController::ApDispatchSync(std::function<void()> fn) {
+    // RunAsync(...).get() blocks the calling MTA thread until the lambda has run
+    // on the UI thread. Legal from MTA (would deadlock/assert on an STA pump).
+    m_root.Dispatcher()
+        .RunAsync(winrt::Windows::UI::Core::CoreDispatcherPriority::Normal,
+                  [fn = std::move(fn)]() { fn(); })
+        .get();
+}
+
+bool MainPageController::ApWaitAtomic(std::atomic<bool>& flag, bool want,
+                                      std::chrono::seconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (flag.load() == want)
+            return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    }
+    return flag.load() == want;
+}
+
+void MainPageController::StartAutopilotIfRequested() {
+    std::wstring flag = local_wpath(L"autopilot.flag");
+    if (GetFileAttributesW(flag.c_str()) == INVALID_FILE_ATTRIBUTES)
+        return;
+    _wremove(flag.c_str()); // consume before run (same as bench/diffuse flags)
+    log_output("[autopilot] flag detected\n");
+
+    auto self = shared_from_this(); // strong: worker-thread pattern (see StartDiffusion)
+    std::thread([self]() {
+        winrt::init_apartment(); // MTA (same as the diffuse worker)
+        std::string result = "ok";
+        try {
+            std::string json = read_local_text_file(L"autopilot.json");
+            if (json.empty())
+                throw std::runtime_error("autopilot.json missing or empty");
+            std::vector<ApAction> actions;
+            std::chrono::seconds total_cap{1800};
+            std::string perr;
+            if (!ApParseScript(json, actions, total_cap, perr))
+                throw std::runtime_error("bad autopilot.json: " + perr);
+            self->ApRun(std::move(actions), total_cap);
+        } catch (const std::exception& e) {
+            result = std::string("error: ") + e.what();
+        } catch (...) {
+            result = "error: unknown exception";
+        }
+        // ApRun writes the marker itself on a normal finish (so 'quit' can exit
+        // before we get here); only write it if it didn't.
+        if (GetFileAttributesW(local_wpath(L"autopilot-done.txt").c_str()) ==
+            INVALID_FILE_ATTRIBUTES)
+            write_local_bytes(L"autopilot-done.txt", result);
+        log_output("[autopilot] driver exit: " + result + "\n");
+    }).detach();
+}
+
+void MainPageController::ApRun(std::vector<ApAction> actions, std::chrono::seconds total_cap) {
+    const auto total_deadline = std::chrono::steady_clock::now() + total_cap;
+    const std::chrono::seconds kGrace{30};
+
+    // Gate on the model being ready (first-launch download may be in flight).
+    if (!ApWaitAtomic(m_model_ready, true, std::chrono::seconds{600}))
+        throw std::runtime_error("model not ready after 600s");
+
+    auto not_running = [&]() {
+        return ApWaitAtomic(m_is_running, false, kGrace) &&
+               ApWaitAtomic(m_diffuse_running, false, kGrace);
+    };
+
+    for (size_t i = 0; i < actions.size(); ++i) {
+        const ApAction& a = actions[i];
+        if (std::chrono::steady_clock::now() > total_deadline)
+            throw std::runtime_error("total timeout");
+        log_output("[autopilot] action " + std::to_string(i) + " " + a.op + " start\n");
+
+        if (a.op == "send") {
+            if (!not_running())
+                throw std::runtime_error("action " + std::to_string(i) + " send: busy");
+            std::wstring text = a.arg;
+            ApDispatchSync([this, text]() { StartInference(text); });
+            auto t = a.timeout.count() > 0 ? a.timeout : std::chrono::seconds{300};
+            if (!ApWaitAtomic(m_is_running, false, t)) {
+                m_abort.store(true);
+                ApWaitAtomic(m_is_running, false, kGrace);
+                throw std::runtime_error("action " + std::to_string(i) + " send: timeout");
+            }
+            // Fence: a status probe dispatched now runs AFTER the completion
+            // lambda (which does SetRunning(false) then SaveCurrentConversation),
+            // so the chat JSON is on disk and the status text is final.
+            std::wstring status;
+            ApDispatchSync(
+                [this, &status]() { status = std::wstring(m_statusText.Text().c_str()); });
+            if (status.rfind(L"! ", 0) == 0)
+                throw std::runtime_error("action " + std::to_string(i) +
+                                         " send: " + ::xllama::wstring_to_utf8(status.substr(2)));
+        } else if (a.op == "new_chat") {
+            if (!not_running())
+                throw std::runtime_error("action " + std::to_string(i) + " new_chat: busy");
+            ApDispatchSync([this]() { NewChat(); });
+        } else if (a.op == "load_chat") {
+            if (!not_running())
+                throw std::runtime_error("action " + std::to_string(i) + " load_chat: busy");
+            std::string id = ::xllama::wstring_to_utf8(a.arg);
+            std::wstring path = local_wpath((L"chats\\" + a.arg + L".json").c_str());
+            if (GetFileAttributesW(path.c_str()) == INVALID_FILE_ATTRIBUTES)
+                throw std::runtime_error("action " + std::to_string(i) + " load_chat: chat '" + id +
+                                         "' not found");
+            ApDispatchSync([this, id]() { LoadConversation(id); });
+        } else if (a.op == "set_model") {
+            std::wstring name = a.arg;
+            // Same as ShowSettings' Save path, plus clear the sticky routed model
+            // so the next send re-decides the EP for the new model.
+            ApDispatchSync([this, name]() {
+                m_model_filename = name;
+                m_modelText.Text(name);
+                m_active_model.clear();
+            });
+        } else if (a.op == "generate_image") {
+            if (!not_running())
+                throw std::runtime_error("action " + std::to_string(i) + " generate_image: busy");
+            std::string prompt = a.arg.empty() ? "a red sports car on a mountain road at sunset"
+                                               : ::xllama::wstring_to_utf8(a.arg);
+            write_local_bytes(L"prompt.txt", prompt);
+            write_local_bytes(L"diffuse-steps.txt", std::to_string(a.steps));
+            write_local_bytes(L"diffuse-seed.txt", std::to_string(a.seed));
+            write_local_bytes(L"diffuse-model.txt", "sd-turbo-fp16");
+            ApDispatchSync([this]() { StartDiffusion(); });
+            auto t = a.timeout.count() > 0 ? a.timeout : std::chrono::seconds{600};
+            if (!ApWaitAtomic(m_diffuse_running, false, t)) {
+                write_local_bytes(L"diffuse-cancel.flag", "cancel");
+                ApWaitAtomic(m_diffuse_running, false, kGrace);
+                throw std::runtime_error("action " + std::to_string(i) +
+                                         " generate_image: timeout");
+            }
+            std::string stage = read_local_text_file(L"diffuse-progress.txt");
+            if (stage != "done")
+                throw std::runtime_error("action " + std::to_string(i) +
+                                         " generate_image: stage=" + stage);
+        } else if (a.op == "quit") {
+            log_output("[autopilot] action " + std::to_string(i) + " quit\n");
+            write_local_bytes(L"autopilot-done.txt", "ok");
+            ApDispatchSync([]() { winrt::Windows::UI::Xaml::Application::Current().Exit(); });
+            return;
+        } else {
+            throw std::runtime_error("unknown op '" + a.op + "'");
+        }
+        log_output("[autopilot] action " + std::to_string(i) + " " + a.op + " end\n");
+    }
+    // Fell off the end without an explicit quit: still a success.
+    write_local_bytes(L"autopilot-done.txt", "ok");
 }
 
 } // namespace xllama

--- a/uwp/MainPage.h
+++ b/uwp/MainPage.h
@@ -13,9 +13,11 @@
 
     #include <atomic>
     #include <chrono>
+    #include <functional>
     #include <memory>
     #include <mutex>
     #include <string>
+    #include <vector>
 
 namespace xllama {
 
@@ -33,7 +35,26 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
         return m_root;
     }
 
+    // Autopilot: scripted validation of the real XAML UI (console has no human
+    // input path in Dev Mode). No-op unless LocalState\autopilot.flag exists;
+    // the flag is consumed, actions come from LocalState\autopilot.json, the
+    // outcome lands in LocalState\autopilot-done.txt ("ok" | "error: ...").
+    void StartAutopilotIfRequested(); // called from App::OnLaunched
+
   private:
+    // One parsed autopilot action (see ApParseScript in MainPage.cpp).
+    struct ApAction {
+        std::string op;   // load_chat|send|new_chat|set_model|generate_image|quit
+        std::wstring arg; // id / text / model name / image prompt
+        int steps{1};     // generate_image
+        unsigned seed{42};
+        std::chrono::seconds timeout{0}; // 0 = per-op default
+    };
+    static bool ApParseScript(const std::string& json_utf8, std::vector<ApAction>& out,
+                              std::chrono::seconds& total_cap, std::string& err);
+    void ApRun(std::vector<ApAction> actions, std::chrono::seconds total_cap);
+    void ApDispatchSync(std::function<void()> fn); // sync hop to the UI thread (MTA-only)
+    bool ApWaitAtomic(std::atomic<bool>& flag, bool want, std::chrono::seconds timeout);
     void BuildUI();
     void LoadModelName();
     winrt::fire_and_forget EnsureModelAsync();
@@ -142,6 +163,9 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     std::atomic<bool> m_abort{false};
     std::atomic<bool> m_is_running{false};
     std::atomic<bool> m_diffuse_running{false};
+    // Set once EnsureModelAsync lands a usable chat model (any source); the
+    // autopilot driver gates its first action on this.
+    std::atomic<bool> m_model_ready{false};
     winrt::Windows::UI::Xaml::DispatcherTimer m_diffuse_timer{nullptr};
     winrt::event_token m_diffuse_tick_token{};
     std::wstring m_model_filename;


### PR DESCRIPTION
## Summary

Dev Mode gives the Xbox no working text-input path (the companion app's remote keyboard won't connect to a Dev-Mode console), so §2 routing A/B, §7c TAESD and GGUF-chat validations were stuck needing a human at the pad. This makes them headless.

**Autopilot** (`uwp/MainPage.cpp`/`.h`, +2 lines `App.cpp`): a flag-driven driver (`autopilot.flag` consumed at `OnLaunched`, same pattern as `diffuse-inproc.flag`) replays a JSON action list — `load_chat|send|new_chat|set_model|generate_image|quit` — against the **existing** `StartInference`/`NewChat`/`LoadConversation`/`StartDiffusion` on the UI thread from an MTA driver. No UI code duplicated; those methods are untouched. Sync dispatch (`RunAsync().get()`) kills the `m_is_running` true→false race; per-action + total timeouts; result in `autopilot-done.txt`; `[autopilot]` log lines pinpoint the in-flight action after a hard crash. A new `m_model_ready` atomic (4 one-line inserts in `EnsureModelAsync` success sites) gates the first action.

**`scripts/validate-console.sh`** `<routing|gguf|taesd|all>`: clones `bench-xbox-ort.sh`'s WDP helpers; seeds inputs → restart → poll `autopilot-done.txt` → grep `xllama.log` for **deterministic** PASS/FAIL (no LLM judgment):
- **routing**: `auto → gpu (N>600 tok)`, `auto → cpu` on a new short chat, zero `887A0036`.
- **gguf**: llama.cpp session-load marker for `lfm25-350m`.
- **taesd**: swaps the tiny VAE in, `generate_image`, `vae_ms < 1000`, **restores the full VAE on exit** (trap).

Package → **1.1.3.0** (new app code; also lands the #44 manifest-merge fix on-device). Runbook §2/§7c now document the automated path as the official gate; manual steps kept for debugging. Per prior agreement, the §2 automated PASS gates the `-PatchedGenAI`-to-default promotion.

## Test plan

- [x] host ctest green, clang-format clean, shellcheck clean (autopilot is UWP-only → compile-validated in CI)
- [ ] CI `build (default|llamacpp|unified)` green
- [ ] After deploy (with explicit OK): `./scripts/validate-console.sh all` → 3 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an automated console validation workflow for chat model routing, model loading, and image generation.
  - Added scripted UI actions for repeatable validation of common console operations.

- **Bug Fixes**
  - Improved model readiness handling across supported loading sources, helping prevent actions from starting before the model is available.

- **Documentation**
  - Updated the validation runbook with automated and troubleshooting procedures.

- **Chores**
  - Updated the app version to 1.1.3.0.
  - Added clearer model-loading diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->