### PR TITLE
Per-architecture chat template + Gemma family + benchmark report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.1.6.0] - 2026-07-14
+
+### Added
+
+- **Per-architecture chat template** (`ChatFormat`, `src/bridge/chat_prompt.cpp`):
+  `chat_format_for()` replaces the hard-coded ChatML with a data-driven template
+  selected by model id. ChatML kept byte-identical (Qwen no-think suffix
+  preserved); **Gemma** added (`<start_of_turn>…<end_of_turn>`, no system role,
+  stop `<end_of_turn>`). UWP UI + bench call one abstraction.
+- **Gemma family**: vendored `llama.cpp` carries `gemma3` + `gemma4` (both load
+  and generate). Catalogue entry `gemma3-270m` (253 MB, GGUF, from HF per Gemma
+  Terms). Gemma-4-E2B is a feasibility candidate.
+- **Benchmark report** — `docs/benchmarks.md` + self-contained
+  `docs/benchmarks-charts.html` consolidate every tested model across backends.
+
+### Changed
+
+- Package version **1.1.6.0**.
+- `docs/model-selection.md` Gemma verdict revised (disk no longer the binding
+  constraint after the 90 GB Dev Mode bump).
+
+---
+
 ## [1.1.5.0] - 2026-07-14
 
 ### Added
@@ -21,13 +44,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - **GPU/DML multi-turn**: KV reuse disabled on `*-dml-*` models — ORT GenAI rejects
-  `AppendTokenSequences` on a persistent DirectML generator (*"Continuous decoding is
-  not supported on the selected device type (DirectML)"*); avoids per-turn fallback
+  `AppendTokenSequences` on a persistent DirectML generator (_"Continuous decoding is
+  not supported on the selected device type (DirectML)"_); avoids per-turn fallback
   and spurious failures.
 - **Qwen3.5 GGUF**: append Qwen no-think prefill after `<|im_start|>assistant` and
   strip leading empty think blocks from saved/displayed assistant text.
 - **`validate-console.sh routing`**: remove `ap-routing-longctx` decoy chat after the
-  test so the seeded *"Understood; ready to continue."* assistant turn does not linger
+  test so the seeded _"Understood; ready to continue."_ assistant turn does not linger
   in History.
 
 ### Changed
@@ -51,7 +74,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Shipping CI default** (`build-uwp.yml`): `xllama-appx` is now **unified +
   PatchedGenAI #2280**; `llamacpp` remains a bench-only artifact. `build-uwp.ps1
-  -PatchedGenAI` fails closed if the vendor step fails.
+-PatchedGenAI` fails closed if the vendor step fails.
 - **Recommended modern settings** (`bench/configs/settings-modern.json`): default chat
   model **LFM2.5-350M** (GGUF) on unified builds; routing GPU unchanged.
 - Package version **1.1.4.0**.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -119,7 +119,7 @@ v0.4.0.0 on Xbox; CSVs `bench/results/phase35-*.csv`):
 - [x] **Per-conversation CPU/GPU routing** (Stage 3, v0.3.9, default off): route
       long-prompt conversations to DML fp16, chat to CPU int4; sticky per
       conversation. **Console-validated 2026-07-14** via `validate-console.sh
-      routing` on unified 1.1.3.0 + patched GenAI: long turn auto→GPU (959 tok),
+    routing` on unified 1.1.3.0 + patched GenAI: long turn auto→GPU (959 tok),
       new short chat auto→CPU, no `887A0036`.
 
 - [x] **Image-generation spike** (v0.4.0, flagship hypothesis): **CONFIRMED on
@@ -146,12 +146,12 @@ Milestones:
       (relevant for merged `model.onnx` > 2 GB). Exp 2 nobundle (Phase 4)
       remains useful for its own sake but is no longer a disk prerequisite.
 - [x] **1B+ scale bench (CPU int4)** — ✅ SmolLM2-1.7B **cpu-int4 measured
-  2026-07-08: 20.6 tok/s decode, peak 2423 MB** (`phase35-1b-cpu.csv`).
-  Catalogue entry + `package-catalogue-ort-model.sh` ready; **1.4 GB asset
-  upload to `models-v1` optional** (WDP works today). **fp16-DML 1.7B blocked**
-  (protobuf > 2 GB — cannot merge self-contained; external data hits §8).
-  int4-DML 1.7B is mergeable but hits the §12 dead kernel. The fp16-at-scale
-  bandwidth crossover stays blocked by serialization/AppContainer, not GPU.
+      2026-07-08: 20.6 tok/s decode, peak 2423 MB** (`phase35-1b-cpu.csv`).
+      Catalogue entry + `package-catalogue-ort-model.sh` ready; **1.4 GB asset
+      upload to `models-v1` optional** (WDP works today). **fp16-DML 1.7B blocked**
+      (protobuf > 2 GB — cannot merge self-contained; external data hits §8).
+      int4-DML 1.7B is mergeable but hits the §12 dead kernel. The fp16-at-scale
+      bandwidth crossover stays blocked by serialization/AppContainer, not GPU.
 - [x] **Desk check upstream int4 status** — ✅ done 2026-07-08
       (`docs/uwp-constraints.md §12`). Verdict: `MatMulNBits` is present and runs
       on the DML GPU (not missing, not CPU fallback); DirectML implements it
@@ -161,8 +161,8 @@ Milestones:
       not "weeks of HLSL" we could contribute. **This closes GPU int4 decode as a
       local lever.**
 - [x] **int4 DML config confirmation** — ✅ **closed inconclusive 2026-07-09**
-  (runbook §5b): block128 fails DML partition; acc4 not bench-promoted.
-  §12 desk-check stands — not a local lever.
+      (runbook §5b): block128 fails DML partition; acc4 not bench-promoted.
+      §12 desk-check stands — not a local lever.
 - [x] **llama.cpp CPU A/B** — ✅ **MEASURED 2026-07-08, hypothesis FALSIFIED.**
       The lane was built (uwp/ggml-uwp.vcxproj static ggml+llama, `patches/0001`
       AppContainer guards for 5 desktop-only APIs, CI `build (llamacpp)` variant,
@@ -281,6 +281,19 @@ validation gates, patched GenAI in XAML.
 
 Open items only — everything above is measured or shipped.
 
+- [x] **Per-architecture chat template** — hard-coded ChatML replaced by a
+      data-driven `ChatFormat` (`src/bridge/chat_prompt.cpp`, `chat_format_for()`);
+      byte-identical ChatML preserved, Gemma (`<start_of_turn>…<end_of_turn>`)
+      added, KV-reuse invariant unit-tested. UWP + bench call one abstraction.
+- [x] **Gemma family** — vendored `llama.cpp` carries `gemma3` + `gemma4`; both
+      load+generate via `xllama-cli`. Catalogue entry `gemma3-270m` (253 MB, fits)
+      added; Gemma-4-E2B is a feasibility candidate (2.29–3.1 GB, decode ~4 tok/s,
+      gated on the ~2 GB per-file Dev Mode limit + RAM). See `docs/benchmarks.md`.
+- [x] **Benchmark report + comparative charts** — `docs/benchmarks.md` +
+      self-contained `docs/benchmarks-charts.html` consolidate every tested model
+      (decode/prefill/RAM across 3 backends) from `bench/results/`.
+- [ ] **Gemma on-console benches** — `gemma3-270m` decode/prefill on Xbox; test
+      whether a >2 GB GGUF (Gemma-4-E2B) loads under the Dev Mode per-file limit.
 - [ ] **Demo video** — model loaded and running on Xbox hardware (Phase 4 carry-over)
 - [ ] **Publication venue** — GitHub Discussions vs arXiv for `docs/technical-report.md`
 - [ ] **`smollm2-1.7b-cpu-int4` on `models-v1`** — manifest ready; optional 1.4 GB

--- a/bench/results/phase6-gemma.csv
+++ b/bench/results/phase6-gemma.csv
@@ -1,0 +1,3 @@
+model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,host,date
+gemma3-270m,Q4_K_M,cpu,2048,6,394.98,76.78,368,1095,0,0,xbox-series-s-t6,2026-07-14T10:48:30Z
+gemma4-e2b,IQ2_M,cpu,2048,6,13.49,9.88,2534,6169,0,0,xbox-series-s-t6,2026-07-14T10:53:41Z

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,17 +2,18 @@
 
 Technical notes and design decisions for xllama.
 
-| Document                                                         | Description                                                                                                    |
-| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| [install-release.md](./install-release.md)                       | Install a tagged GitHub Release build on your Xbox (cert + VCLibs + MSIX)                                      |
-| [using-the-app.md](./using-the-app.md)                           | App guide: chat, settings (model picker, routing, KV reuse), image generation                                  |
-| [uwp-constraints.md](./uwp-constraints.md)                       | UWP sandbox limitations, measured GPU budget, AppContainer filesystem quirks, and how xllama works around them |
-| [technical-report.md](./technical-report.md)                     | The measured story: per-workload CPU/GPU verdict, falsified hypotheses, diffusion on console                   |
-| [console-validation-runbook.md](./console-validation-runbook.md) | Ordered on-console validation checklist with measured results per section                                      |
-| [windows-dev-vm.md](./windows-dev-vm.md)                         | Windows VM setup for local UWP/MSIX builds                                                                     |
-| [device-portal.md](./device-portal.md)                           | How to enable Dev Mode and deploy via Device Portal                                                            |
-| [phase1-runbook.md](./phase1-runbook.md)                         | End-to-end developer build, deploy, and benchmark instructions                                                 |
-| [model-selection.md](./model-selection.md)                       | Choosing/adding models: hard limits, evaluation sequence, tested models, manifest override how-to              |
-| [recommended-config.md](./recommended-config.md)               | Correct modern settings: models, genai_config, settings.json, build variants, obsolete myths                 |
+| Document                                                         | Description                                                                                                               |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| [install-release.md](./install-release.md)                       | Install a tagged GitHub Release build on your Xbox (cert + VCLibs + MSIX)                                                 |
+| [using-the-app.md](./using-the-app.md)                           | App guide: chat, settings (model picker, routing, KV reuse), image generation                                             |
+| [uwp-constraints.md](./uwp-constraints.md)                       | UWP sandbox limitations, measured GPU budget, AppContainer filesystem quirks, and how xllama works around them            |
+| [technical-report.md](./technical-report.md)                     | The measured story: per-workload CPU/GPU verdict, falsified hypotheses, diffusion on console                              |
+| [console-validation-runbook.md](./console-validation-runbook.md) | Ordered on-console validation checklist with measured results per section                                                 |
+| [windows-dev-vm.md](./windows-dev-vm.md)                         | Windows VM setup for local UWP/MSIX builds                                                                                |
+| [device-portal.md](./device-portal.md)                           | How to enable Dev Mode and deploy via Device Portal                                                                       |
+| [phase1-runbook.md](./phase1-runbook.md)                         | End-to-end developer build, deploy, and benchmark instructions                                                            |
+| [model-selection.md](./model-selection.md)                       | Choosing/adding models: hard limits, evaluation sequence, tested models, manifest override how-to                         |
+| [benchmarks.md](./benchmarks.md)                                 | Consolidated perf for every tested model (decode/prefill/RAM, 3 backends) + comparative charts (`benchmarks-charts.html`) |
+| [recommended-config.md](./recommended-config.md)                 | Correct modern settings: models, genai_config, settings.json, build variants, obsolete myths                              |
 
 See also [../CHANGELOG.md](../CHANGELOG.md) for the full pivot history (llama.cpp → ORT GenAI → CPU EP → per-workload routing) and [../diffusion/README.md](../diffusion/README.md) for the SD-Turbo model toolchain.

--- a/docs/benchmarks-charts.html
+++ b/docs/benchmarks-charts.html
@@ -205,8 +205,8 @@
     <section class="panel">
       <div class="panel-head">
         <div>
-          <h2>Gemma — arch-validated, console benches pending</h2>
-          <p class="cap">Host-dev sanity (Intel i7-1165G7, not Xbox). Both load on the pinned llama.cpp.</p>
+          <h2>Gemma on Xbox — measured, "too big" overturned</h2>
+          <p class="cap">Console-validated 2026-07-14 (MSIX 1.1.6.0). Both are in the chart above.</p>
         </div>
       </div>
       <div class="gemma" id="gemma"></div>
@@ -239,11 +239,13 @@
   // On-console (Xbox Series S), best decode config per model.
   const DATA = [
     { model: "LFM2.5-350M",  quant: "Q4_K_M", be: "llama", prefill: 241.4, decode: 94.2, ram: 321,  src: "phase5-gguf" },
+    { model: "Gemma-3-270M", quant: "Q4_K_M", be: "llama", prefill: 395.0, decode: 76.8, ram: 368,  src: "phase6-gemma" },
     { model: "SmolLM2-360M", quant: "int4",   be: "ort",   prefill: 219.8, decode: 70.9, ram: 722,  src: "phase1-cpu" },
     { model: "SmolLM2-360M", quant: "Q4_K_M", be: "llama", prefill: 141.5, decode: 62.9, ram: 402,  src: "phase35-scaling" },
     { model: "SmolLM2-360M", quant: "fp16",   be: "dml",   prefill: 353.5, decode: 46.8, ram: 1154, src: "phase2-dml", tag: "routing GPU" },
     { model: "Qwen3.5-0.8B", quant: "Q4_K_M", be: "llama", prefill: 98.1,  decode: 35.1, ram: 718,  src: "phase5-gguf" },
     { model: "SmolLM2-1.7B", quant: "int4",   be: "ort",   prefill: 54.9,  decode: 20.6, ram: 2423, src: "phase35-1b" },
+    { model: "Gemma-4-E2B",  quant: "IQ2_M",  be: "llama", prefill: 13.5,  decode: 9.9,  ram: 2534, src: "phase6-gemma", tag: "2.3 GB, 2-bit" },
     { model: "SmolLM2-360M", quant: "int4",   be: "dml",   prefill: 152.8, decode: 8.8,  ram: 999,  src: "phase2-dml", tag: "int4 GPU" },
   ];
   const METRICS = {
@@ -315,15 +317,15 @@
   document.getElementById("heroStats").innerHTML = `
     <div class="stat"><p class="k">Fastest decode</p><div class="v">94.2 <small>tok/s</small></div><p class="n">${fastest.model} · llama.cpp CPU</p></div>
     <div class="stat"><p class="k">Lightest</p><div class="v">321 <small>MB</small></div><p class="n">${lightest.model} · Q4_K_M</p></div>
-    <div class="stat"><p class="k">Models benched</p><div class="v">7 <small>configs</small></div><p class="n">3 backends · 4 model families</p></div>
+    <div class="stat"><p class="k">Models benched</p><div class="v">9 <small>configs</small></div><p class="n">3 backends · 5 model families</p></div>
     <div class="stat"><p class="k">KV-reuse win</p><div class="v">4.9<small>×</small></div><p class="n">turn-2 prefill · ORT CPU</p></div>`;
 
   // gemma cards
   const GEMMA = [
-    { model: "Gemma-3-270M-it", arch: "gemma3", quant: "Q4_K_M", size: "253 MB", decode: "~40 tok/s", ram: "~0.3 GB",
-      status: ["ok", "Fits console"], note: "Catalogue entry <b>gemma3-270m</b>. Loads clean; console bench pending." },
-    { model: "Gemma-4-E2B-it", arch: "gemma4", quant: "UD-IQ2_M", size: "2.29 GB", decode: "3.8 tok/s", ram: "2.35 GB",
-      status: ["warn", "Feasibility"], note: "Coherent output. Gated on the ~2 GB per-file Dev Mode limit + RAM." },
+    { model: "Gemma-3-270M-it", arch: "gemma3", quant: "Q4_K_M", size: "253 MB", decode: "76.8 tok/s", ram: "368 MB",
+      status: ["ok", "Console ✓"], note: "Catalogue entry <b>gemma3-270m</b>. Fast, tiny chat model; Gemma template applied on-device." },
+    { model: "Gemma-4-E2B-it", arch: "gemma4", quant: "IQ2_M", size: "2.29 GB", decode: "9.9 tok/s", ram: "2534 MB",
+      status: ["ok", "Console ✓"], note: "A 2.29 GB single GGUF loads — the ~2 GB Dev Mode per-file limit does not apply to GGUF. Slow load (6–24 s); 2-bit." },
   ];
   document.getElementById("gemma").innerHTML = GEMMA.map(g => `
     <div class="gcard">

--- a/docs/benchmarks-charts.html
+++ b/docs/benchmarks-charts.html
@@ -1,0 +1,355 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- Generated benchmark dashboard — self-contained, no external assets. Data source: bench/results/*.csv. See docs/benchmarks.md. -->
+</head><body>
+<title>xllama — Model Benchmarks (Xbox Series S)</title>
+<style>
+  :root {
+    color-scheme: light;
+    --plane:        #f7f8f7;
+    --surface:      #fdfdfc;
+    --ink:          #0c0f0e;
+    --ink-2:        #51554f;
+    --muted:        #8a8d86;
+    --grid:         #e6e7e1;
+    --baseline:     #c6c8bf;
+    --ring:         rgba(12,15,14,0.10);
+    /* backends (categorical, validated) */
+    --b-llama:      #2a78d6;  /* llama.cpp CPU */
+    --b-ort:        #1baf7a;  /* ORT-GenAI CPU */
+    --b-dml:        #eda100;  /* ORT DirectML */
+    --accent:       #2a78d6;
+    --shadow:       0 1px 2px rgba(12,15,14,.05), 0 8px 24px -12px rgba(12,15,14,.18);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:where(:not([data-theme="light"])) {
+      color-scheme: dark;
+      --plane:    #0c0d0c;
+      --surface:  #171917;
+      --ink:      #f4f5f0;
+      --ink-2:    #bcbfb4;
+      --muted:    #8a8d86;
+      --grid:     #2a2c28;
+      --baseline: #3a3d37;
+      --ring:     rgba(255,255,255,0.10);
+      --b-llama:  #3987e5;
+      --b-ort:    #199e70;
+      --b-dml:    #c98500;
+      --accent:   #3987e5;
+      --shadow:   0 1px 2px rgba(0,0,0,.4), 0 10px 30px -14px rgba(0,0,0,.6);
+    }
+  }
+  :root[data-theme="dark"] {
+    color-scheme: dark;
+    --plane:#0c0d0c; --surface:#171917; --ink:#f4f5f0; --ink-2:#bcbfb4; --muted:#8a8d86;
+    --grid:#2a2c28; --baseline:#3a3d37; --ring:rgba(255,255,255,0.10);
+    --b-llama:#3987e5; --b-ort:#199e70; --b-dml:#c98500; --accent:#3987e5;
+    --shadow:0 1px 2px rgba(0,0,0,.4), 0 10px 30px -14px rgba(0,0,0,.6);
+  }
+
+  * { box-sizing: border-box; }
+  body { margin: 0; }
+  .wrap {
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    background: var(--plane);
+    color: var(--ink);
+    min-height: 100vh;
+    padding: clamp(20px, 4vw, 56px) clamp(16px, 4vw, 40px) 64px;
+    line-height: 1.5;
+  }
+  .mono { font-family: ui-monospace, "Cascadia Code", "SF Mono", Menlo, Consolas, monospace; }
+  .shell { max-width: 940px; margin: 0 auto; }
+
+  header.head { margin-bottom: 28px; }
+  .eyebrow {
+    font-family: ui-monospace, "Cascadia Code", "SF Mono", Menlo, monospace;
+    font-size: 12px; letter-spacing: .14em; text-transform: uppercase;
+    color: var(--muted); margin: 0 0 10px;
+  }
+  h1 {
+    font-family: ui-monospace, "Cascadia Code", "SF Mono", Menlo, monospace;
+    font-weight: 650; font-size: clamp(24px, 4.4vw, 36px); letter-spacing: -0.01em;
+    margin: 0 0 8px; text-wrap: balance;
+  }
+  .sub { color: var(--ink-2); max-width: 62ch; margin: 0; font-size: 15px; }
+
+  .hero-stats { display: flex; flex-wrap: wrap; gap: 12px; margin: 24px 0 8px; }
+  .stat {
+    background: var(--surface); border: 1px solid var(--ring); border-radius: 12px;
+    padding: 14px 18px; box-shadow: var(--shadow); flex: 1 1 150px; min-width: 150px;
+  }
+  .stat .k { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: .08em; margin: 0 0 6px; }
+  .stat .v { font-family: ui-monospace, "Cascadia Code", Menlo, monospace; font-size: 26px; font-weight: 650; letter-spacing: -0.02em; }
+  .stat .v small { font-size: 13px; color: var(--ink-2); font-weight: 500; }
+  .stat .n { font-size: 12.5px; color: var(--ink-2); margin-top: 3px; }
+
+  .panel {
+    background: var(--surface); border: 1px solid var(--ring); border-radius: 16px;
+    box-shadow: var(--shadow); padding: clamp(16px, 3vw, 26px); margin-top: 22px;
+  }
+  .panel-head { display: flex; align-items: baseline; justify-content: space-between; flex-wrap: wrap; gap: 12px; margin-bottom: 6px; }
+  .panel-head h2 { font-size: 17px; margin: 0; font-weight: 620; letter-spacing: -0.01em; }
+  .panel-head .cap { font-size: 13px; color: var(--muted); margin: 0; }
+
+  .seg { display: inline-flex; background: var(--plane); border: 1px solid var(--ring); border-radius: 10px; padding: 3px; gap: 2px; }
+  .seg button {
+    font: inherit; font-size: 13px; font-weight: 550; border: 0; background: transparent; color: var(--ink-2);
+    padding: 6px 13px; border-radius: 7px; cursor: pointer; transition: background .15s, color .15s;
+  }
+  .seg button[aria-pressed="true"] { background: var(--surface); color: var(--ink); box-shadow: 0 1px 2px rgba(0,0,0,.12); }
+  .seg button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  .legend { display: flex; flex-wrap: wrap; gap: 16px; margin: 16px 0 20px; }
+  .legend span { display: inline-flex; align-items: center; gap: 7px; font-size: 13px; color: var(--ink-2); }
+  .legend i { width: 11px; height: 11px; border-radius: 3px; display: inline-block; }
+
+  /* chart */
+  .chart { display: flex; flex-direction: column; gap: 9px; }
+  .row { display: grid; grid-template-columns: 190px 1fr; align-items: center; gap: 14px; }
+  .row .lab { text-align: right; font-size: 13px; line-height: 1.25; }
+  .row .lab b { font-weight: 600; display: block; }
+  .row .lab .q { font-family: ui-monospace, Menlo, monospace; font-size: 11px; color: var(--muted); }
+  .track { position: relative; height: 30px; }
+  .bar {
+    position: absolute; left: 0; top: 0; height: 100%;
+    border-radius: 4px; min-width: 3px;
+    display: flex; align-items: center; justify-content: flex-end;
+    transition: width .5s cubic-bezier(.22,.61,.36,1);
+    cursor: default;
+  }
+  .bar::after { content: ""; position: absolute; inset: 0; border-radius: inherit; box-shadow: inset 0 0 0 1px var(--ring); pointer-events: none; }
+  .bar .val {
+    font-family: ui-monospace, Menlo, monospace; font-size: 12.5px; font-weight: 600;
+    color: #fff; padding-right: 8px; white-space: nowrap; font-variant-numeric: tabular-nums;
+  }
+  .bar.short .val { color: var(--ink); padding-right: 0; padding-left: 8px; position: absolute; left: 100%; }
+  .axis { grid-column: 2; display: flex; justify-content: space-between; font-family: ui-monospace, Menlo, monospace; font-size: 11px; color: var(--muted); margin-top: 4px; font-variant-numeric: tabular-nums; }
+  .unit { grid-column: 2; font-size: 12px; color: var(--muted); margin-top: 2px; }
+
+  /* tooltip */
+  .tip {
+    position: fixed; z-index: 20; pointer-events: none; opacity: 0; transform: translateY(4px);
+    transition: opacity .12s; background: var(--ink); color: var(--plane);
+    padding: 9px 11px; border-radius: 9px; font-size: 12.5px; box-shadow: var(--shadow); max-width: 260px;
+  }
+  .tip.on { opacity: 1; transform: translateY(0); }
+  .tip b { font-family: ui-monospace, Menlo, monospace; }
+  .tip .g { display: grid; grid-template-columns: auto auto; gap: 2px 12px; margin-top: 5px; }
+  .tip .g span:nth-child(even) { text-align: right; font-family: ui-monospace, Menlo, monospace; }
+
+  /* gemma card */
+  .gemma { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; margin-top: 14px; }
+  .gcard { border: 1px solid var(--ring); border-radius: 12px; padding: 16px; background: var(--plane); }
+  .gcard h3 { margin: 0 0 2px; font-size: 15px; font-family: ui-monospace, Menlo, monospace; font-weight: 620; }
+  .gcard .meta { font-size: 12.5px; color: var(--muted); margin: 0 0 12px; }
+  .gcard dl { margin: 0; display: grid; grid-template-columns: auto auto; gap: 6px 10px; font-size: 13px; }
+  .gcard dt { color: var(--ink-2); }
+  .gcard dd { margin: 0; text-align: right; font-family: ui-monospace, Menlo, monospace; font-variant-numeric: tabular-nums; }
+  .chip { display: inline-flex; align-items: center; gap: 5px; font-size: 11.5px; font-weight: 600; padding: 2px 9px; border-radius: 999px; }
+  .chip.ok  { background: color-mix(in srgb, #0ca30c 16%, transparent); color: #0a850a; }
+  .chip.warn{ background: color-mix(in srgb, #fab219 22%, transparent); color: #9a6b00; }
+  :root[data-theme="dark"] .chip.ok, .wrap .chip.ok { color: #37c437; }
+  :root[data-theme="dark"] .chip.warn { color: #e7b64a; }
+
+  details.table { margin-top: 22px; }
+  details.table summary { cursor: pointer; font-size: 13.5px; color: var(--ink-2); font-weight: 550; padding: 6px 0; }
+  .twrap { overflow-x: auto; margin-top: 10px; }
+  table { border-collapse: collapse; width: 100%; font-size: 13px; }
+  th, td { padding: 8px 12px; text-align: right; border-bottom: 1px solid var(--grid); white-space: nowrap; font-variant-numeric: tabular-nums; }
+  th:first-child, td:first-child { text-align: left; }
+  thead th { color: var(--muted); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; }
+  td .mid { font-family: ui-monospace, Menlo, monospace; }
+
+  footer.note { margin-top: 30px; font-size: 12.5px; color: var(--muted); max-width: 68ch; }
+  footer.note code { font-family: ui-monospace, Menlo, monospace; font-size: 11.5px; background: var(--surface); padding: 1px 5px; border-radius: 5px; border: 1px solid var(--ring); }
+  a { color: var(--accent); }
+  @media (max-width: 620px) {
+    .row { grid-template-columns: 128px 1fr; gap: 10px; }
+    .row .lab { font-size: 12px; }
+    .gemma { grid-template-columns: 1fr; }
+  }
+  @media (prefers-reduced-motion: reduce) { .bar { transition: none; } }
+</style>
+
+<div class="wrap">
+  <div class="shell">
+    <header class="head">
+      <p class="eyebrow">xllama · on-device inference · benchmarks</p>
+      <h1>Model performance on Xbox&nbsp;Series&nbsp;S</h1>
+      <p class="sub">Every text model xllama has run on the console (Dev Mode), across three backends — llama.cpp CPU, ONNX Runtime GenAI CPU, and ORT DirectML. Decode throughput is what a user feels; higher is better.</p>
+      <div class="hero-stats" id="heroStats"></div>
+    </header>
+
+    <section class="panel">
+      <div class="panel-head">
+        <div>
+          <h2>Backend comparison</h2>
+          <p class="cap" id="metricCap"></p>
+        </div>
+        <div class="seg" role="group" aria-label="Metric">
+          <button data-m="decode" aria-pressed="true">Decode</button>
+          <button data-m="prefill" aria-pressed="false">Prefill</button>
+          <button data-m="ram" aria-pressed="false">Peak RAM</button>
+        </div>
+      </div>
+
+      <div class="legend" aria-hidden="false">
+        <span><i style="background:var(--b-llama)"></i>llama.cpp&nbsp;CPU</span>
+        <span><i style="background:var(--b-ort)"></i>ORT-GenAI&nbsp;CPU</span>
+        <span><i style="background:var(--b-dml)"></i>ORT&nbsp;DirectML</span>
+      </div>
+
+      <div class="chart" id="chart"></div>
+    </section>
+
+    <section class="panel">
+      <div class="panel-head">
+        <div>
+          <h2>Gemma — arch-validated, console benches pending</h2>
+          <p class="cap">Host-dev sanity (Intel i7-1165G7, not Xbox). Both load on the pinned llama.cpp.</p>
+        </div>
+      </div>
+      <div class="gemma" id="gemma"></div>
+    </section>
+
+    <details class="table">
+      <summary>Data table &amp; sources</summary>
+      <div class="twrap">
+        <table id="dataTable">
+          <thead><tr><th>Model</th><th>Quant</th><th>Backend</th><th>Prefill&nbsp;tok/s</th><th>Decode&nbsp;tok/s</th><th>Peak&nbsp;RAM&nbsp;MB</th><th>Source</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </details>
+
+    <footer class="note">
+      On-console figures measured on Xbox Series S Dev Mode via <code>bench-xbox-ort.sh</code> — CSVs in <code>bench/results/</code>. Best decode config per model; llama.cpp rows at t6 (~6 usable Dev Mode cores). DirectML int4 is memory-bound (no fused low-bit GPU GEMM). Gemma figures are host-dev only. See <code>docs/benchmarks.md</code>.
+    </footer>
+  </div>
+</div>
+
+<div class="tip" id="tip" role="status" aria-live="polite"></div>
+
+<script>
+  const BACKENDS = {
+    llama: { name: "llama.cpp CPU", color: "var(--b-llama)" },
+    ort:   { name: "ORT-GenAI CPU", color: "var(--b-ort)" },
+    dml:   { name: "ORT DirectML",  color: "var(--b-dml)" },
+  };
+  // On-console (Xbox Series S), best decode config per model.
+  const DATA = [
+    { model: "LFM2.5-350M",  quant: "Q4_K_M", be: "llama", prefill: 241.4, decode: 94.2, ram: 321,  src: "phase5-gguf" },
+    { model: "SmolLM2-360M", quant: "int4",   be: "ort",   prefill: 219.8, decode: 70.9, ram: 722,  src: "phase1-cpu" },
+    { model: "SmolLM2-360M", quant: "Q4_K_M", be: "llama", prefill: 141.5, decode: 62.9, ram: 402,  src: "phase35-scaling" },
+    { model: "SmolLM2-360M", quant: "fp16",   be: "dml",   prefill: 353.5, decode: 46.8, ram: 1154, src: "phase2-dml", tag: "routing GPU" },
+    { model: "Qwen3.5-0.8B", quant: "Q4_K_M", be: "llama", prefill: 98.1,  decode: 35.1, ram: 718,  src: "phase5-gguf" },
+    { model: "SmolLM2-1.7B", quant: "int4",   be: "ort",   prefill: 54.9,  decode: 20.6, ram: 2423, src: "phase35-1b" },
+    { model: "SmolLM2-360M", quant: "int4",   be: "dml",   prefill: 152.8, decode: 8.8,  ram: 999,  src: "phase2-dml", tag: "int4 GPU" },
+  ];
+  const METRICS = {
+    decode:  { label: "Decode", unit: "tok/s", cap: "Generation throughput — the rate a user feels. Higher is better.", better: "high" },
+    prefill: { label: "Prefill", unit: "tok/s", cap: "Prompt-ingestion throughput. Higher is better; matters most for long prompts.", better: "high" },
+    ram:     { label: "Peak RAM", unit: "MB", cap: "Peak working set. Lower is better on the constrained Dev Mode budget.", better: "low" },
+  };
+
+  const chart = document.getElementById("chart");
+  const tip = document.getElementById("tip");
+  let current = "decode";
+
+  function fmt(n, m) { return m === "ram" ? Math.round(n).toLocaleString() : n.toFixed(1); }
+
+  function render(metric) {
+    current = metric;
+    const M = METRICS[metric];
+    document.getElementById("metricCap").textContent = M.cap;
+    const rows = [...DATA].sort((a,b) => M.better === "low" ? a[metric]-b[metric] : b[metric]-a[metric]);
+    const max = Math.max(...rows.map(r => r[metric]));
+    chart.innerHTML = "";
+    rows.forEach((r, i) => {
+      const row = document.createElement("div"); row.className = "row";
+      const lab = document.createElement("div"); lab.className = "lab";
+      lab.innerHTML = `<b>${r.model}</b><span class="q">${r.quant}${r.tag ? " · "+r.tag : ""}</span>`;
+      const track = document.createElement("div"); track.className = "track";
+      const bar = document.createElement("div"); bar.className = "bar";
+      const pct = Math.max((r[metric] / max) * 100, 1.5);
+      bar.style.background = BACKENDS[r.be].color;
+      const short = pct < 22;
+      if (short) bar.classList.add("short");
+      bar.innerHTML = `<span class="val">${fmt(r[metric], metric)}</span>`;
+      requestAnimationFrame(() => { bar.style.width = pct + "%"; });
+      const show = (e) => {
+        tip.classList.add("on");
+        tip.innerHTML = `<b>${r.model}</b> · ${r.quant}<div class="g">`+
+          `<span>Backend</span><span>${BACKENDS[r.be].name}</span>`+
+          `<span>Decode</span><span>${r.decode.toFixed(1)} tok/s</span>`+
+          `<span>Prefill</span><span>${r.prefill.toFixed(1)} tok/s</span>`+
+          `<span>Peak RAM</span><span>${r.ram.toLocaleString()} MB</span>`+
+          `<span>Source</span><span>${r.src}</span></div>`;
+        const x = (e.touches ? e.touches[0].clientX : e.clientX);
+        const y = (e.touches ? e.touches[0].clientY : e.clientY);
+        tip.style.left = Math.min(x + 14, window.innerWidth - tip.offsetWidth - 12) + "px";
+        tip.style.top  = Math.max(y - tip.offsetHeight - 10, 10) + "px";
+      };
+      track.addEventListener("mousemove", show);
+      track.addEventListener("mouseleave", () => tip.classList.remove("on"));
+      track.appendChild(bar);
+      row.appendChild(lab); row.appendChild(track);
+      chart.appendChild(row);
+    });
+    const axis = document.createElement("div"); axis.className = "axis";
+    axis.innerHTML = `<span>0</span><span>${fmt(max, metric)} ${M.unit}</span>`;
+    chart.appendChild(axis);
+  }
+
+  document.querySelectorAll(".seg button").forEach(b => {
+    b.addEventListener("click", () => {
+      document.querySelectorAll(".seg button").forEach(x => x.setAttribute("aria-pressed", "false"));
+      b.setAttribute("aria-pressed", "true");
+      render(b.dataset.m);
+    });
+  });
+
+  // hero stats
+  const fastest = DATA.reduce((a,b) => b.decode > a.decode ? b : a);
+  const lightest = DATA.reduce((a,b) => b.ram < a.ram ? b : a);
+  document.getElementById("heroStats").innerHTML = `
+    <div class="stat"><p class="k">Fastest decode</p><div class="v">94.2 <small>tok/s</small></div><p class="n">${fastest.model} · llama.cpp CPU</p></div>
+    <div class="stat"><p class="k">Lightest</p><div class="v">321 <small>MB</small></div><p class="n">${lightest.model} · Q4_K_M</p></div>
+    <div class="stat"><p class="k">Models benched</p><div class="v">7 <small>configs</small></div><p class="n">3 backends · 4 model families</p></div>
+    <div class="stat"><p class="k">KV-reuse win</p><div class="v">4.9<small>×</small></div><p class="n">turn-2 prefill · ORT CPU</p></div>`;
+
+  // gemma cards
+  const GEMMA = [
+    { model: "Gemma-3-270M-it", arch: "gemma3", quant: "Q4_K_M", size: "253 MB", decode: "~40 tok/s", ram: "~0.3 GB",
+      status: ["ok", "Fits console"], note: "Catalogue entry <b>gemma3-270m</b>. Loads clean; console bench pending." },
+    { model: "Gemma-4-E2B-it", arch: "gemma4", quant: "UD-IQ2_M", size: "2.29 GB", decode: "3.8 tok/s", ram: "2.35 GB",
+      status: ["warn", "Feasibility"], note: "Coherent output. Gated on the ~2 GB per-file Dev Mode limit + RAM." },
+  ];
+  document.getElementById("gemma").innerHTML = GEMMA.map(g => `
+    <div class="gcard">
+      <h3>${g.model}</h3>
+      <p class="meta mono">${g.arch} · ${g.quant} · ${g.size}</p>
+      <dl>
+        <dt>Arch loads</dt><dd><span class="chip ${g.status[0]}">${g.status[0]==="ok"?"✓":"◐"} ${g.status[1]}</span></dd>
+        <dt>Host decode</dt><dd>${g.decode}</dd>
+        <dt>Host peak RAM</dt><dd>${g.ram}</dd>
+      </dl>
+      <p class="meta" style="margin:12px 0 0">${g.note}</p>
+    </div>`).join("");
+
+  // data table
+  document.querySelector("#dataTable tbody").innerHTML = DATA
+    .slice().sort((a,b)=>b.decode-a.decode).map(r => `
+    <tr>
+      <td>${r.model}</td>
+      <td class="mid">${r.quant}</td>
+      <td>${BACKENDS[r.be].name}</td>
+      <td class="mid">${r.prefill.toFixed(1)}</td>
+      <td class="mid">${r.decode.toFixed(1)}</td>
+      <td class="mid">${r.ram.toLocaleString()}</td>
+      <td class="mid">${r.src}</td>
+    </tr>`).join("");
+
+  render("decode");
+</script>
+</body></html>

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,93 @@
+# Benchmarks
+
+Consolidated performance data for every model xllama has run. Unless noted, all
+figures are **measured on Xbox Series S in Dev Mode** (the target device) and
+come from the CSVs in `bench/results/`. Host-dev figures (Intel i7-1165G7,
+Linux) are called out separately and are **not** comparable to console numbers —
+they exist only to sanity-check a model loads and generates.
+
+Metrics: **prefill** = prompt tok/s (throughput ingesting the prompt), **decode**
+= generation tok/s (autoregressive, the number a user feels), **peak RAM** =
+`peak_working_set_mb`. `n_threads` matters on the ~6 usable Dev Mode cores
+(t7/t8 livelock the ggml threadpool — see `phase35-llamacpp-scaling.csv`).
+
+## Text chat models — on-console (Xbox Series S)
+
+Best measured decode configuration per model.
+
+| Model        | Params | Quant  | Backend               | Prefill tok/s | Decode tok/s | Peak RAM MB | Source CSV                  |
+| ------------ | ------ | ------ | --------------------- | ------------: | -----------: | ----------: | --------------------------- |
+| LFM2.5-350M  | 350M   | Q4_K_M | llama.cpp CPU · t6    |         241.4 |     **94.2** |         321 | `phase5-gguf`               |
+| SmolLM2-360M | 360M   | int4   | ORT-GenAI CPU         |         219.8 |         70.9 |         722 | `phase1-cpu` / `phase2-dml` |
+| SmolLM2-360M | 360M   | Q4_K_M | llama.cpp CPU · t6    |         141.5 |         62.9 |         402 | `phase35-llamacpp-scaling`  |
+| SmolLM2-360M | 360M   | fp16   | ORT DML (routing GPU) |         353.5 |         46.8 |        1154 | `phase2-dml`                |
+| Qwen3.5-0.8B | 0.8B   | Q4_K_M | llama.cpp CPU · t6    |          98.1 |         35.1 |         718 | `phase5-gguf`               |
+| SmolLM2-1.7B | 1.7B   | int4   | ORT-GenAI CPU         |          54.9 |         20.6 |        2423 | `phase35-1b-cpu`            |
+| SmolLM2-360M | 360M   | int4   | ORT DML int4          |       152–334 |          8.8 |    999–1525 | `phase2-dml`                |
+
+Notes:
+
+- **LFM2.5-350M** is the fastest chat model and the lightest (321 MB RAM) — the
+  default chat model on unified builds.
+- **DML int4** (8.8 tok/s) is ~8× slower than CPU at this scale: no fused low-bit
+  GPU GEMM, so decode is memory-bound reading fp16 weights round-tripped through
+  VRAM. DML fp16 is only worth it for long-prefill routing (353 tok/s prefill).
+- **Routing**: Auto switches SmolLM2-360M CPU → DML fp16 above a 600-token prompt
+  (`routing_policy.h`), trading decode (70.9 → 46.8) for prefill (219 → 353).
+
+## KV-cache reuse (ORT-GenAI, CPU)
+
+Turn-2 prefill with continuous decoding vs a cold full re-prefill
+(`phase35-kv.csv`, SmolLM2-360M):
+
+|                        | Prefill turn-2 (ms) | Tokens |   Speedup |
+| ---------------------- | ------------------: | -----: | --------: |
+| Reuse (delta only)     |               103.7 |     22 | **4.87×** |
+| Cold (full re-prefill) |               505.2 |    114 |         — |
+
+KV-reuse is ORT-GenAI-only and CPU-only (DirectML rejects continuous decoding;
+GGUF/llama.cpp is stateless on-console).
+
+## Diffusion — SD-Turbo fp16 (on-console, DirectML)
+
+`phase5-diffuse.csv`, 512×512, 1 step:
+
+| Stage         |  Time (ms) |
+| ------------- | ---------: |
+| Text encoder  |     1006.6 |
+| UNet (1 step) |     3328.9 |
+| VAE decode    |     2556.1 |
+| **Total**     | **6891.6** |
+
+TAESD (4.9 MB tiny VAE) targets the 2.6 s VAE stage → ~4.5 s/image (see
+`docs/model-selection.md`).
+
+## Gemma — arch-validated, on-console benches pending
+
+Added by the per-architecture chat-template work (`chat_format_for` selects the
+`<start_of_turn>…<end_of_turn>` template, stop `<end_of_turn>`). Both Gemma
+architectures **load and generate** on the pinned `llama.cpp` submodule
+(`9a532ae4b`): `general.architecture = gemma3` / `gemma4` confirmed via
+`xllama-cli`. Host-dev sanity numbers (Intel i7-1165G7 — **not** Xbox):
+
+| Model           | Params           | Quant    |    Size | Arch loads | Host decode tok/s | Host peak RAM | On-console                                              |
+| --------------- | ---------------- | -------- | ------: | ---------- | ----------------: | ------------: | ------------------------------------------------------- |
+| Gemma-3-270M-it | 270M             | Q4_K_M   |  253 MB | ✅ gemma3  |               ~40 |       ~0.3 GB | ✅ fits (catalogue entry `gemma3-270m`) — bench pending |
+| Gemma-4-E2B-it  | ~5B raw (2B eff) | UD-IQ2_M | 2.29 GB | ✅ gemma4  |               3.8 |       2.35 GB | ⚠️ feasibility candidate                                |
+
+**Gemma-4-E2B verdict**: loads and produces coherent output, but on the mobile
+i7 decode is 3.8 tok/s (a ~5B-raw MatFormer model at 2-bit). On-console the
+open questions are (a) the community-reported ~2 GB Dev Mode per-file limit —
+every E2B quant exceeds 2 GB (smallest 2.29 GB, never tested on this Xbox), and
+(b) RAM (~2.35 GB resident) under the Game memory budget. Disk is no longer a
+blocker (Dev Mode raised to 90 GB, 2026-07-08). E4B/12B+ are out of scope on
+size/speed. See `docs/model-selection.md` for the full survey.
+
+## Reproducing
+
+- **On-console**: `./scripts/bench-xbox-ort.sh <model> --runs 3 --out bench/results/<file>.csv`
+  (model already provisioned). KV bench: drop a `bench_turns.txt`; diffusion:
+  `phase5-diffuse`.
+- **Host (llama.cpp GGUF only)**: `./build/linux-release/bin/xllama-cli -m <model.gguf>
+-p '<prompt>' -n 128` prints `load / prompt tok/s / decode tok/s`.
+- Comparative charts: `docs/benchmarks-charts.html` (self-contained; open in a browser).

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -62,26 +62,33 @@ GGUF/llama.cpp is stateless on-console).
 TAESD (4.9 MB tiny VAE) targets the 2.6 s VAE stage → ~4.5 s/image (see
 `docs/model-selection.md`).
 
-## Gemma — arch-validated, on-console benches pending
+## Gemma — on-console (Xbox Series S, MSIX 1.1.6.0, `phase6-gemma.csv`)
 
 Added by the per-architecture chat-template work (`chat_format_for` selects the
 `<start_of_turn>…<end_of_turn>` template, stop `<end_of_turn>`). Both Gemma
-architectures **load and generate** on the pinned `llama.cpp` submodule
-(`9a532ae4b`): `general.architecture = gemma3` / `gemma4` confirmed via
-`xllama-cli`. Host-dev sanity numbers (Intel i7-1165G7 — **not** Xbox):
+architectures load and generate on the pinned `llama.cpp` (`9a532ae4b`);
+**measured on the console** 2026-07-14:
 
-| Model           | Params           | Quant    |    Size | Arch loads | Host decode tok/s | Host peak RAM | On-console                                              |
-| --------------- | ---------------- | -------- | ------: | ---------- | ----------------: | ------------: | ------------------------------------------------------- |
-| Gemma-3-270M-it | 270M             | Q4_K_M   |  253 MB | ✅ gemma3  |               ~40 |       ~0.3 GB | ✅ fits (catalogue entry `gemma3-270m`) — bench pending |
-| Gemma-4-E2B-it  | ~5B raw (2B eff) | UD-IQ2_M | 2.29 GB | ✅ gemma4  |               3.8 |       2.35 GB | ⚠️ feasibility candidate                                |
+| Model           | Params           | Quant  |    Size | Prefill tok/s | Decode tok/s | Peak RAM MB | Load ms |
+| --------------- | ---------------- | ------ | ------: | ------------: | -----------: | ----------: | ------: |
+| Gemma-3-270M-it | 270M             | Q4_K_M |  253 MB |         395.0 |     **76.8** |         368 |    1095 |
+| Gemma-4-E2B-it  | ~5B raw (2B eff) | IQ2_M  | 2.29 GB |          13.5 |          9.9 |        2534 |    6169 |
 
-**Gemma-4-E2B verdict**: loads and produces coherent output, but on the mobile
-i7 decode is 3.8 tok/s (a ~5B-raw MatFormer model at 2-bit). On-console the
-open questions are (a) the community-reported ~2 GB Dev Mode per-file limit —
-every E2B quant exceeds 2 GB (smallest 2.29 GB, never tested on this Xbox), and
-(b) RAM (~2.35 GB resident) under the Game memory budget. Disk is no longer a
-blocker (Dev Mode raised to 90 GB, 2026-07-08). E4B/12B+ are out of scope on
-size/speed. See `docs/model-selection.md` for the full survey.
+Both use the Gemma template on-device (log: `bench prompt: <start_of_turn>user
+…`). **Gemma-3-270M** is a fast, tiny chat model (76.8 tok/s, 368 MB).
+
+**Gemma-4-E2B verdict — the "too big" call is overturned:**
+
+- ✅ **The ~2 GB Dev Mode per-file limit does not apply to GGUF** — a 2.29 GB
+  single `.gguf` uploaded via Device Portal and loaded; **peak RAM 2534 MB**, no
+  OOM under the Game budget. (This was the project's main open unknown.)
+- ✅ Generates at **9.9 tok/s** @ t6 — faster than the i7-1165G7 host (3.8).
+- ⚠️ Load is slow (6–24 s, 2.3 GB heap read, `use_mmap=false`); a ~512-token
+  prompt at temp 0.8 can EOG immediately (2-bit) — short prompts generate fine.
+
+Disk was never the constraint (Dev Mode is 90 GB). E4B/12B+ stay out of scope on
+size/speed. Catalogue entry `gemma4-e2b` (downloads from HF; 2.29 GB exceeds the
+GitHub release 2 GB asset limit).
 
 ## Reproducing
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -90,6 +90,58 @@ Disk was never the constraint (Dev Mode is 90 GB). E4B/12B+ stay out of scope on
 size/speed. Catalogue entry `gemma4-e2b` (downloads from HF; 2.29 GB exceeds the
 GitHub release 2 GB asset limit).
 
+## Root-cause notes — the negative performers
+
+Investigated 2026-07-14 (reverse-engineered where noted). None is a loader or
+template bug; the causes are quantization behaviour, a UWP constraint, and known
+DirectML limits.
+
+### Gemma-4-E2B emits EOG immediately on the bench prompt (0 decode tokens)
+
+The first `phase6-gemma` E2B run scored **decode 0.0 tok/s** — the model hit an
+end-of-generation token on the first sample (`EOG after 0 tokens`). Isolated by
+reproduction:
+
+- Both `gemma3` and `gemma4` GGUFs set `eos_token_id = 106` (`<end_of_turn>`),
+  `add_bos_token = true` — so the template (which omits `<bos>`) is correct.
+- On the **identical** 272-token declarative prompt at temp 0.8: gemma3-270m (Q4)
+  generates 30+ tokens with **no** early EOG; gemma4-E2B (IQ2_M) stops early
+  (0 tokens on console, 7 on the host at a different RNG seed).
+
+**Root cause**: gemma4-E2B assigns a high probability to `<end_of_turn>` as the
+_first_ token after a **declarative** prompt (a technical overview, not a
+question) — the correct response is to end the turn. Two amplifiers: (1) the
+**IQ2_M 2-bit quant** degrades the logits and inflates specific tokens incl. EOG;
+(2) gemma4 is better turn-calibrated than the tiny under-trained gemma3-270m,
+which rambles instead. Stochastic under temp 0.8 → sometimes the very first
+sample. **Not a bug.** Mitigation: bench decode with a _question/generative_
+prompt (done → **9.9 tok/s**), use a higher-bit quant (Q3_K_S 2.45 GB), or lower
+temperature. `standard-512.txt` is a poor decode probe for a well-calibrated
+instruct model.
+
+### Gemma-4-E2B slow cold load (23.6 s cold → 6.2 s warm)
+
+llama.cpp uses `use_mmap = false` (UWP AppContainer has no POSIX mmap,
+`uwp-constraints.md §1`), so the full 2.29 GB is read into the heap — no lazy
+page-in. Cold = disk read + heap copy; warm = OS file cache (also 21.5 s on the
+host, confirming it's the no-mmap read, not a console quirk). Smaller quant is
+the only lever.
+
+### DirectML int4 decode 8.8 tok/s — 8× slower than CPU (already root-caused)
+
+`uwp-constraints.md §12`: DirectML has **no fused low-bit GPU GEMM**. It
+implements `MatMulNBits` as `DML_DEQUANTIZE`→fp16 + a full `DML_GEMM`,
+materialising fp16 weights — so int4 moves _more_ bandwidth than fp16 (hence
+8.8 < the fp16 path's 46.8). The builder also gives DML `accuracy_level=0` vs
+CPU's fused int8 MLAS (`=4`, → 70). A DirectML-team feature; not fixable in-app.
+
+### DirectML fp16 decode 46.8 < CPU 70.9 — expected, not a regression
+
+Autoregressive decode (M=1) is memory-bound and dominated by per-token DML
+dispatch overhead at this model scale; CPU `MatMulNBits` on AVX2 wins
+(ROADMAP Phase 2 / `uwp-constraints.md §7`). GPU's win is **prefill** (353 vs
+198 tok/s at ~1k tokens), which is exactly what routing uses it for.
+
 ## Reproducing
 
 - **On-console**: `./scripts/bench-xbox-ort.sh <model> --runs 3 --out bench/results/<file>.csv`

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -170,7 +170,7 @@ on-console decode/prefill benches pending.
 | LFM2.5-350M      | llama.cpp | 218 MB               | ✅ loads via submodule; hybrid edge arch                                 |
 | Qwen3-0.6B       | ORT GenAI | 969 MB merged        | ✅ builds; heavy (151k-vocab embedding dominates)                        |
 | Gemma-3-270M     | llama.cpp | 253 MB               | ✅ loads+generates via GGUF (`gemma3-270m`); catalogue entry added, fits |
-| Gemma-4-E2B      | llama.cpp | 2.29–3.1 GB          | ✅ `gemma4` arch loads; feasibility candidate (see below)                |
+| Gemma-4-E2B      | llama.cpp | 2.29 GB (IQ2_M)      | ✅ **console-validated** (`gemma4-e2b`): loads, ~9.9 tok/s (see below)   |
 | Gemma-4 E4B/12B+ | llama.cpp | ≥4.5 GB              | ⛔ too big / too slow for the console                                    |
 
 **Gemma chat template**: the ORT GenAI _builder_ is frozen at Gemma3, but the
@@ -182,15 +182,22 @@ now selects the Gemma template (`<start_of_turn>…<end_of_turn>`, no system rol
 stop `<end_of_turn>`, `<bos>` via `add_bos`) by model id, so any `gemma*` GGUF
 gets the right template with zero per-model code.
 
-**Gemma-4-E2B verdict** (revised): the "too big" call was based on the old
-~2.5 GB disk budget, superseded — Dev Mode disk is now 90 GB (`uwp-constraints.md §9`),
-so disk is no longer the constraint. E2B is ~5B raw params (2B effective, MatFormer);
-the smallest usable quant is UD-IQ2_M at 2.29 GB, Q3_K_S 2.45 GB, Q4_K_M 3.1 GB.
-Host-dev (i7-1165G7): loads, coherent output, decode 3.8 tok/s, 2.35 GB RAM. The
-open on-console questions are (a) the community-reported ~2 GB Dev Mode **per-file
-limit** — every E2B quant exceeds it and none has been tested on this Xbox — and
-(b) RAM under the Game budget + acceptable decode speed. Provision via USB /
-Device Portal (not MSIX). See `docs/benchmarks.md` for the full comparison.
+**Gemma-4-E2B verdict** (console-validated 2026-07-14, MSIX 1.1.6.0): the "too
+big" call is **overturned**. E2B is ~5B raw params (2B effective, MatFormer);
+UD-IQ2_M is 2.29 GB. Measured on Xbox Series S Dev Mode:
+
+- ✅ **The ~2 GB Dev Mode per-file limit does not apply to GGUF** — a 2.29 GB
+  single `.gguf` uploaded via Device Portal and loaded; **peak RAM 2534 MB**, no
+  OOM under the Game budget.
+- ✅ **Generates**: decode **9.9 tok/s** @ t6 (faster than the i7-1165G7 host's
+  3.8), coherent short answers ending on `<end_of_turn>`.
+- ⚠️ **Load is slow**: 6–24 s (2.3 GB heap read, `use_mmap=false`).
+- ⚠️ A ~512-token prompt at temp 0.8 can emit EOG immediately (2-bit quant);
+  short prompts generate normally. A Q3_K_S (2.45 GB) would trade size for quality.
+
+Disk was never the real constraint (Dev Mode is now 90 GB, `uwp-constraints.md §9`).
+Catalogue entry `gemma4-e2b` downloads from HF (2.29 GB > the GitHub release 2 GB
+asset limit). See `docs/benchmarks.md` for the full comparison.
 
 Backend selection is by `SessionParams::backend` (explicit values take
 precedence in dual-backend builds). `Auto` (default) uses either a `.gguf`

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -164,13 +164,33 @@ llama.cpp** — reachable once the `unified` backend build (PR #27) is the defau
 and the catalogue carries `kind: gguf` entries. Host-validated 2026-07-09;
 on-console decode/prefill benches pending.
 
-| Model             | Path      | Size (Q4_K_M / int4) | Status                                                                |
-| ----------------- | --------- | -------------------- | --------------------------------------------------------------------- |
-| Qwen3.5-0.8B      | llama.cpp | 507 MB               | ✅ loads+generates via submodule (`qwen35`); modern default candidate |
-| LFM2.5-350M       | llama.cpp | 218 MB               | ✅ loads via submodule; hybrid edge arch                              |
-| Qwen3-0.6B        | ORT GenAI | 969 MB merged        | ✅ builds; heavy (151k-vocab embedding dominates)                     |
-| Gemma-3-270M      | ORT GenAI | ~300 MB (est.)       | ⛔ gated on HF — needs an access token to build                       |
-| Gemma-4 (E2B/E4B) | —         | ≥2B effective        | ⛔ too big + arch not in builder                                      |
+| Model            | Path      | Size (Q4_K_M / int4) | Status                                                                   |
+| ---------------- | --------- | -------------------- | ------------------------------------------------------------------------ |
+| Qwen3.5-0.8B     | llama.cpp | 507 MB               | ✅ loads+generates via submodule (`qwen35`); modern default candidate    |
+| LFM2.5-350M      | llama.cpp | 218 MB               | ✅ loads via submodule; hybrid edge arch                                 |
+| Qwen3-0.6B       | ORT GenAI | 969 MB merged        | ✅ builds; heavy (151k-vocab embedding dominates)                        |
+| Gemma-3-270M     | llama.cpp | 253 MB               | ✅ loads+generates via GGUF (`gemma3-270m`); catalogue entry added, fits |
+| Gemma-4-E2B      | llama.cpp | 2.29–3.1 GB          | ✅ `gemma4` arch loads; feasibility candidate (see below)                |
+| Gemma-4 E4B/12B+ | llama.cpp | ≥4.5 GB              | ⛔ too big / too slow for the console                                    |
+
+**Gemma chat template**: the ORT GenAI _builder_ is frozen at Gemma3, but the
+vendored `llama.cpp` (`9a532ae4b`) already carries `LLM_ARCH_GEMMA3` **and**
+`LLM_ARCH_GEMMA4` — both load and generate (verified via `xllama-cli`,
+`general.architecture = gemma3`/`gemma4`). What was missing was the prompt
+format: the app hard-coded ChatML. `chat_format_for()` (`src/bridge/chat_prompt.cpp`)
+now selects the Gemma template (`<start_of_turn>…<end_of_turn>`, no system role,
+stop `<end_of_turn>`, `<bos>` via `add_bos`) by model id, so any `gemma*` GGUF
+gets the right template with zero per-model code.
+
+**Gemma-4-E2B verdict** (revised): the "too big" call was based on the old
+~2.5 GB disk budget, superseded — Dev Mode disk is now 90 GB (`uwp-constraints.md §9`),
+so disk is no longer the constraint. E2B is ~5B raw params (2B effective, MatFormer);
+the smallest usable quant is UD-IQ2_M at 2.29 GB, Q3_K_S 2.45 GB, Q4_K_M 3.1 GB.
+Host-dev (i7-1165G7): loads, coherent output, decode 3.8 tok/s, 2.35 GB RAM. The
+open on-console questions are (a) the community-reported ~2 GB Dev Mode **per-file
+limit** — every E2B quant exceeds it and none has been tested on this Xbox — and
+(b) RAM under the Game budget + acceptable decode speed. Provision via USB /
+Device Portal (not MSIX). See `docs/benchmarks.md` for the full comparison.
 
 Backend selection is by `SessionParams::backend` (explicit values take
 precedence in dual-backend builds). `Auto` (default) uses either a `.gguf`
@@ -185,7 +205,11 @@ permits redistribution provided recipients get a copy of the license —
 `LFM2.5-350M_LICENSE.txt` is published on the release and listed in the
 catalogue entry so it lands next to the model on-device. Note §5: commercial
 use is limited to entities under $10M revenue (xllama is non-commercial
-research). Gemma Terms — still verify before ever hosting.
+research). **Gemma** is under the Gemma Terms of Use (not Apache/MIT): the
+`gemma3-270m` catalogue entry therefore downloads straight from the original
+Hugging Face repo (`hf_base_url` → `unsloth/gemma-3-270m-it-GGUF/resolve/main`)
+rather than re-hosting the weights on `models-v1` — verify the Terms permit
+redistribution before ever mirroring them onto our release.
 
 ### TAESD — a faster diffusion VAE decoder
 

--- a/include/xllama/chat_prompt.h
+++ b/include/xllama/chat_prompt.h
@@ -62,8 +62,7 @@ struct ChatFormat {
     // gen_suffix. gen_suffix is appended ONLY to the final (trailing) assistant
     // header, never to completed history turns. History turns are complete
     // (user + assistant) exchanges.
-    std::string render_prompt(const std::string& system,
-                              const std::vector<ChatTurn>& history,
+    std::string render_prompt(const std::string& system, const std::vector<ChatTurn>& history,
                               const std::string& final_user) const;
 
     // Delta appended onto a reused KV cache. prev_ended_with_stop == the previous

--- a/include/xllama/chat_prompt.h
+++ b/include/xllama/chat_prompt.h
@@ -4,11 +4,16 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace xllama {
 
 // True for catalogue ids or filenames that refer to a Qwen GGUF chat model.
 bool model_is_qwen(const std::string& model_id);
+
+// True for catalogue ids or filenames that refer to a Gemma chat model
+// (substring "gemma", case-insensitive).
+bool model_is_gemma(const std::string& model_id);
 
 // Qwen3.x no-think generation prefill (matches Qwen3.5 Jinja with enable_thinking=false).
 // Empty when the model is not Qwen.
@@ -16,5 +21,62 @@ std::string qwen_no_think_gen_suffix(const std::string& model_id);
 
 // Remove leading empty </think> blocks (whitespace-only inside tags).
 std::string strip_empty_thinking_tags(std::string text);
+
+// ---------------------------------------------------------------------------
+// Per-architecture chat template
+//
+// Data-driven, backend-agnostic. The two supported formats differ only in
+// delimiters, the assistant role label, how the system prompt is placed, the
+// stop sequence and a per-model generation suffix. Built via chat_format_for().
+// ---------------------------------------------------------------------------
+
+enum class ChatFormatKind { ChatML, Gemma };
+
+// How the system prompt is emitted.
+// - DedicatedTurn: its own turn (ChatML: <|im_start|>system ... <|im_end|>).
+// - MergeIntoFirstUser: prepended to the first user turn (Gemma has no system role).
+enum class SystemStyle { DedicatedTurn, MergeIntoFirstUser };
+
+// One completed exchange used when rendering a full multi-turn prompt.
+struct ChatTurn {
+    std::string user;
+    std::string assistant;
+};
+
+struct ChatFormat {
+    ChatFormatKind kind = ChatFormatKind::ChatML;
+
+    // Delimiters / role labels.
+    std::string turn_open;     // "<|im_start|>"  | "<start_of_turn>"
+    std::string turn_close;    // "<|im_end|>\n"  | "<end_of_turn>\n"
+    std::string user_tag;      // "user"
+    std::string assistant_tag; // "assistant"     | "model"
+    std::string system_tag;    // "system"        | "" (Gemma: unused)
+    std::string system_sep;    // ""              | "\n\n" (merge separator)
+    SystemStyle system_style = SystemStyle::DedicatedTurn;
+
+    std::vector<std::string> stop_sequences; // {"<|im_end|>"} | {"<end_of_turn>"}
+    std::string gen_suffix;                  // Qwen no-think prefill; else ""
+
+    // Full multi-turn prompt ending with the assistant generation header +
+    // gen_suffix. gen_suffix is appended ONLY to the final (trailing) assistant
+    // header, never to completed history turns. History turns are complete
+    // (user + assistant) exchanges.
+    std::string render_prompt(const std::string& system,
+                              const std::vector<ChatTurn>& history,
+                              const std::string& final_user) const;
+
+    // Delta appended onto a reused KV cache. prev_ended_with_stop == the previous
+    // generation stopped on the stop token (turn already closed) vs cut short by
+    // the n_predict cap.
+    std::string render_delta(const std::string& user, bool prev_ended_with_stop) const;
+
+    // Output post-processing before display/persist (strips empty <think> blocks;
+    // no-op for Gemma).
+    std::string postprocess_output(std::string text) const;
+};
+
+// Select the chat format for a catalogue id / filename (as model_is_qwen does today).
+ChatFormat chat_format_for(const std::string& model_id);
 
 } // namespace xllama

--- a/include/xllama/inference_params.h
+++ b/include/xllama/inference_params.h
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <functional>
 #include <string>
+#include <vector>
 
 namespace xllama {
 
@@ -20,6 +21,14 @@ struct InferenceParams {
     int n_threads = 0; // 0 = auto-detect
     float temperature = 0.8f;
     uint32_t seed = 0xFFFFFFFF; // 0xFFFFFFFF = LLAMA_DEFAULT_SEED
+
+    // Stop strings: generation ends (and the match is trimmed from output_text)
+    // when the accumulated output ends with any of these. Empty = stop on EOG /
+    // n_predict only. Used by the CLI --chat mode and the GGUF bench.
+    std::vector<std::string> stop_sequences;
+
+    // CLI --chat: wrap `prompt` with the model's chat template before inference.
+    bool chat_template = false;
 
     // UI callbacks (optional). Called from the inference thread — must marshal
     // to the UI thread before touching XAML controls.

--- a/src/bridge/chat_prompt.cpp
+++ b/src/bridge/chat_prompt.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <utility>
 
 namespace xllama {
 namespace {
@@ -40,6 +41,10 @@ bool model_is_qwen(const std::string& model_id) {
     return to_lower(model_id).find("qwen") != std::string::npos;
 }
 
+bool model_is_gemma(const std::string& model_id) {
+    return to_lower(model_id).find("gemma") != std::string::npos;
+}
+
 std::string qwen_no_think_gen_suffix(const std::string& model_id) {
     if (!model_is_qwen(model_id))
         return {};
@@ -54,6 +59,82 @@ std::string strip_empty_thinking_tags(std::string text) {
         ltrim_inplace(text);
     }
     return text;
+}
+
+ChatFormat chat_format_for(const std::string& model_id) {
+    ChatFormat f;
+    // Gemma is checked before the ChatML default; the Qwen no-think suffix is
+    // resolved inside the ChatML branch. "gemma" does not collide with
+    // smollm2/lfm2/qwen ids.
+    if (model_is_gemma(model_id)) {
+        f.kind = ChatFormatKind::Gemma;
+        f.turn_open = "<start_of_turn>";
+        f.turn_close = "<end_of_turn>\n";
+        f.user_tag = "user";
+        f.assistant_tag = "model";
+        f.system_tag = "";
+        f.system_sep = "\n\n";
+        f.system_style = SystemStyle::MergeIntoFirstUser;
+        f.stop_sequences = {"<end_of_turn>"};
+        f.gen_suffix = {}; // Gemma has no think prefill; <bos> is added by add_bos.
+    } else {
+        f.kind = ChatFormatKind::ChatML;
+        f.turn_open = "<|im_start|>";
+        f.turn_close = "<|im_end|>\n";
+        f.user_tag = "user";
+        f.assistant_tag = "assistant";
+        f.system_tag = "system";
+        f.system_sep = "";
+        f.system_style = SystemStyle::DedicatedTurn;
+        f.stop_sequences = {"<|im_end|>"};
+        f.gen_suffix = qwen_no_think_gen_suffix(model_id);
+    }
+    return f;
+}
+
+std::string ChatFormat::render_prompt(const std::string& system,
+                                      const std::vector<ChatTurn>& history,
+                                      const std::string& final_user) const {
+    std::string p;
+
+    // System: dedicated turn (ChatML, emitted unconditionally) or merged into
+    // the first user turn (Gemma).
+    if (system_style == SystemStyle::DedicatedTurn)
+        p += turn_open + system_tag + "\n" + system + turn_close;
+
+    bool sys_pending = (system_style == SystemStyle::MergeIntoFirstUser) && !system.empty();
+    auto user_content = [&](const std::string& u) -> std::string {
+        if (sys_pending) {
+            sys_pending = false;
+            return system + system_sep + u;
+        }
+        return u;
+    };
+
+    for (const ChatTurn& t : history) {
+        p += turn_open + user_tag + "\n" + user_content(t.user) + turn_close;
+        // History assistant headers never carry gen_suffix (suffix only on the
+        // trailing header below), matching the legacy hand-built prompt.
+        p += turn_open + assistant_tag + "\n" + t.assistant + turn_close;
+    }
+
+    p += turn_open + user_tag + "\n" + user_content(final_user) + turn_close;
+    p += turn_open + assistant_tag + "\n" + gen_suffix;
+    return p;
+}
+
+std::string ChatFormat::render_delta(const std::string& user, bool prev_ended_with_stop) const {
+    // The reused KV already holds the previous assistant tokens. If generation
+    // stopped on the stop token the turn is already closed (only a newline is
+    // needed); otherwise close it with turn_close.
+    std::string d = prev_ended_with_stop ? std::string("\n") : turn_close;
+    d += turn_open + user_tag + "\n" + user + turn_close;
+    d += turn_open + assistant_tag + "\n" + gen_suffix;
+    return d;
+}
+
+std::string ChatFormat::postprocess_output(std::string text) const {
+    return strip_empty_thinking_tags(std::move(text));
 }
 
 } // namespace xllama

--- a/src/bridge/cli.cpp
+++ b/src/bridge/cli.cpp
@@ -22,6 +22,8 @@ static void print_help(const char* prog) {
                  "  -t, --threads <N>    Thread count; 0 = auto (default: 0)\n"
                  "      --temp <float>   Sampling temperature (default: 0.8)\n"
                  "      --seed <int>     RNG seed; 0 = random (default: 0)\n"
+                 "      --chat           Wrap the prompt with the model's chat template\n"
+                 "                       (ChatML/Gemma by model name) and stop on its stop token\n"
                  "  -h, --help           Show this message\n",
                  prog);
 }
@@ -42,6 +44,7 @@ bool parse_cli_args(int argc, char** argv, InferenceParams& out) {
                                               {"threads", required_argument, nullptr, 't'},
                                               {"temp", required_argument, nullptr, 1},
                                               {"seed", required_argument, nullptr, 2},
+                                              {"chat", no_argument, nullptr, 3},
                                               {"help", no_argument, nullptr, 'h'},
                                               {nullptr, 0, nullptr, 0}};
 
@@ -68,6 +71,9 @@ bool parse_cli_args(int argc, char** argv, InferenceParams& out) {
             break;
         case 2:
             out.seed = static_cast<uint32_t>(std::atoi(optarg));
+            break;
+        case 3:
+            out.chat_template = true;
             break;
         case 'h':
             print_help(argv[0]);

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -375,6 +375,28 @@ InferenceResult run_inference_llama(const InferenceParams& params) {
             std::fflush(stdout);
         }
 
+        // Stop strings (e.g. Gemma's <end_of_turn>, which is not an EOG token in
+        // every GGUF): if the accumulated output now ends with one, trim it and
+        // stop. Handles multi-piece stop tokens since we match on the full suffix.
+        bool hit_stop = false;
+        for (const std::string& stop : params.stop_sequences) {
+            if (!stop.empty() && res.output_text.size() >= stop.size() &&
+                res.output_text.compare(res.output_text.size() - stop.size(), stop.size(), stop) ==
+                    0) {
+                res.output_text.erase(res.output_text.size() - stop.size());
+                hit_stop = true;
+                break;
+            }
+        }
+        if (hit_stop) {
+            res.ended_with_stop = true;
+            log_output(
+                ("[xllama] stop sequence after " + std::to_string(n_generated + 1) + " tokens\n")
+                    .c_str());
+            ++n_generated;
+            break;
+        }
+
         llama_batch next = llama_batch_get_one(&token, 1);
         if (llama_decode(ctx.get(), next) != 0) {
             log_output("[xllama] decode failed at token, stopping generation\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2024 Venere Labs
 // SPDX-License-Identifier: MIT
 
+#include "xllama/chat_prompt.h"
 #include "xllama/cli.h"
 #include "xllama/inference.h"
 
@@ -8,6 +9,15 @@ int main(int argc, char** argv) {
     xllama::InferenceParams params;
     if (!xllama::parse_cli_args(argc, argv, params))
         return 1;
+
+    // --chat: wrap the raw prompt with the model's chat template (ChatML or
+    // Gemma, selected by model name) and stop on its stop token. Without this the
+    // CLI feeds the prompt verbatim and generates to n_predict.
+    if (params.chat_template) {
+        const xllama::ChatFormat fmt = xllama::chat_format_for(params.model_path);
+        params.prompt = fmt.render_prompt(/*system=*/"", /*history=*/{}, params.prompt);
+        params.stop_sequences = fmt.stop_sequences;
+    }
 
     auto res = xllama::run_inference(params);
     return res.success ? 0 : 1;

--- a/tests/test_chat_prompt.cpp
+++ b/tests/test_chat_prompt.cpp
@@ -28,3 +28,138 @@ TEST_CASE("strip empty thinking tags") {
     CHECK(strip_empty_thinking_tags("  \n" + block + "  \n  Risposta") == "Risposta");
     CHECK(strip_empty_thinking_tags("plain text") == "plain text");
 }
+
+TEST_CASE("gemma detection") {
+    CHECK(model_is_gemma("gemma3-270m"));
+    CHECK(model_is_gemma("Gemma-4-E2B-it-Q4_K_M.gguf"));
+    CHECK_FALSE(model_is_gemma("smollm2-360m-cpu-int4"));
+    CHECK_FALSE(model_is_gemma("qwen35-0.8b"));
+    CHECK_FALSE(model_is_gemma("lfm25-350m"));
+}
+
+TEST_CASE("chat format selection") {
+    CHECK(chat_format_for("smollm2-360m-cpu-int4").kind == ChatFormatKind::ChatML);
+    CHECK(chat_format_for("lfm25-350m").kind == ChatFormatKind::ChatML);
+    CHECK(chat_format_for("gemma3-270m").kind == ChatFormatKind::Gemma);
+
+    const ChatFormat qwen = chat_format_for("qwen35-0.8b");
+    CHECK(qwen.kind == ChatFormatKind::ChatML);
+    CHECK_FALSE(qwen.gen_suffix.empty()); // Qwen no-think prefill
+
+    CHECK(chat_format_for("smollm2-360m-cpu-int4").gen_suffix.empty());
+}
+
+TEST_CASE("chat format stop sequences") {
+    CHECK(chat_format_for("smollm2-360m-cpu-int4").stop_sequences ==
+          std::vector<std::string>{"<|im_end|>"});
+    CHECK(chat_format_for("gemma3-270m").stop_sequences ==
+          std::vector<std::string>{"<end_of_turn>"});
+}
+
+TEST_CASE("chatml render is byte-exact with the legacy hand-built prompt") {
+    const ChatFormat f = chat_format_for("smollm2-360m-cpu-int4");
+    const std::string sys = "You are helpful.";
+    const std::vector<ChatTurn> hist = {{"hi", "hello there"}};
+    const std::string final_user = "how are you?";
+
+    // Legacy string builder (from MainPage::BuildChatMLPrompt, no gen_suffix).
+    std::string legacy = "<|im_start|>system\n" + sys + "<|im_end|>\n";
+    for (const ChatTurn& t : hist) {
+        legacy += "<|im_start|>user\n" + t.user + "<|im_end|>\n";
+        legacy += "<|im_start|>assistant\n" + t.assistant + "<|im_end|>\n";
+    }
+    legacy += "<|im_start|>user\n" + final_user + "<|im_end|>\n";
+    legacy += "<|im_start|>assistant\n";
+
+    CHECK(f.render_prompt(sys, hist, final_user) == legacy);
+}
+
+TEST_CASE("chatml render appends qwen suffix only to the trailing header") {
+    const ChatFormat f = chat_format_for("qwen35-0.8b");
+    const std::string p = f.render_prompt("sys", {{"u1", "a1"}}, "u2");
+    // Trailing header carries the suffix...
+    CHECK(p.substr(p.size() - f.gen_suffix.size()) == f.gen_suffix);
+    // ...but the completed history assistant turn does not.
+    const std::string hist_hdr = "<|im_start|>assistant\na1<|im_end|>\n";
+    CHECK(p.find(hist_hdr) != std::string::npos);
+}
+
+TEST_CASE("gemma render merges system into the first user turn, no bos/system") {
+    const ChatFormat f = chat_format_for("gemma3-270m");
+    const std::string p = f.render_prompt("Be nice.", {}, "ciao");
+    CHECK(p == "<start_of_turn>user\nBe nice.\n\nciao<end_of_turn>\n<start_of_turn>model\n");
+    CHECK(p.find("<bos>") == std::string::npos);
+    CHECK(p.find("system") == std::string::npos);
+    CHECK(f.gen_suffix.empty());
+}
+
+TEST_CASE("gemma multi-turn merges system only into the first user turn") {
+    const ChatFormat f = chat_format_for("gemma3-270m");
+    const std::string p = f.render_prompt("SYS", {{"u1", "a1"}}, "u2");
+    CHECK(p == "<start_of_turn>user\nSYS\n\nu1<end_of_turn>\n"
+               "<start_of_turn>model\na1<end_of_turn>\n"
+               "<start_of_turn>user\nu2<end_of_turn>\n"
+               "<start_of_turn>model\n");
+}
+
+TEST_CASE("gemma render with empty system leaves the first user turn unprefixed") {
+    const ChatFormat f = chat_format_for("gemma3-270m");
+    CHECK(f.render_prompt("", {}, "ciao") ==
+          "<start_of_turn>user\nciao<end_of_turn>\n<start_of_turn>model\n");
+}
+
+TEST_CASE("render_delta for both formats and prev_ended_with_stop") {
+    const ChatFormat cm = chat_format_for("smollm2-360m-cpu-int4");
+    CHECK(cm.render_delta("q", /*stop=*/true) ==
+          "\n<|im_start|>user\nq<|im_end|>\n<|im_start|>assistant\n");
+    CHECK(cm.render_delta("q", /*stop=*/false) ==
+          "<|im_end|>\n<|im_start|>user\nq<|im_end|>\n<|im_start|>assistant\n");
+
+    const ChatFormat gm = chat_format_for("gemma3-270m");
+    CHECK(gm.render_delta("q", /*stop=*/true) ==
+          "\n<start_of_turn>user\nq<end_of_turn>\n<start_of_turn>model\n");
+    CHECK(gm.render_delta("q", /*stop=*/false) ==
+          "<end_of_turn>\n<start_of_turn>user\nq<end_of_turn>\n<start_of_turn>model\n");
+}
+
+TEST_CASE("postprocess_output strips empty think for chatml, passthrough otherwise") {
+    const std::string block = std::string("<think>") + "\n\n" + "</think>";
+    CHECK(chat_format_for("qwen35-0.8b").postprocess_output(block + "\n\nCiao!") == "Ciao!");
+    CHECK(chat_format_for("gemma3-270m").postprocess_output("plain gemma") == "plain gemma");
+}
+
+// The core KV-reuse safety net: the string a reused KV holds after a turn — the
+// full prompt, the assistant output, plus the delta for the next turn — must
+// equal a cold full re-prefill of the same conversation with that turn appended.
+// Only meaningful when gen_suffix is empty: a non-empty suffix is prefilled into
+// the KV but intentionally absent from stored output, a known/preserved
+// discrepancy (see chat_prompt.cpp risks), so the strings would differ by design.
+static void check_kv_reuse_invariant(const ChatFormat& f) {
+    REQUIRE(f.gen_suffix.empty());
+    const std::string sys = "sys";
+    const std::vector<ChatTurn> hist = {{"u1", "a1"}};
+    const std::string final_user = "u2";
+    const std::string raw_out = "a2";
+    const std::string next_user = "u3";
+    const std::string stop = f.stop_sequences.front();
+
+    const std::string base = f.render_prompt(sys, hist, final_user); // suffix empty
+
+    std::vector<ChatTurn> hist2 = hist;
+    hist2.push_back({final_user, raw_out});
+    const std::string cold = f.render_prompt(sys, hist2, next_user);
+
+    // Case A: generation stopped on the stop token (token resident in the KV);
+    // the delta only re-opens with a newline.
+    CHECK(base + raw_out + stop + f.render_delta(next_user, /*prev_ended_with_stop=*/true) ==
+          cold);
+
+    // Case B: generation cut short by n_predict (no stop token in the KV); the
+    // delta closes the turn itself.
+    CHECK(base + raw_out + f.render_delta(next_user, /*prev_ended_with_stop=*/false) == cold);
+}
+
+TEST_CASE("kv-reuse invariant holds for chatml and gemma") {
+    check_kv_reuse_invariant(chat_format_for("smollm2-360m-cpu-int4"));
+    check_kv_reuse_invariant(chat_format_for("gemma3-270m"));
+}

--- a/tests/test_chat_prompt.cpp
+++ b/tests/test_chat_prompt.cpp
@@ -151,8 +151,7 @@ static void check_kv_reuse_invariant(const ChatFormat& f) {
 
     // Case A: generation stopped on the stop token (token resident in the KV);
     // the delta only re-opens with a newline.
-    CHECK(base + raw_out + stop + f.render_delta(next_user, /*prev_ended_with_stop=*/true) ==
-          cold);
+    CHECK(base + raw_out + stop + f.render_delta(next_user, /*prev_ended_with_stop=*/true) == cold);
 
     // Case B: generation cut short by n_predict (no stop token in the KV); the
     // delta closes the turn itself.

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -10,7 +10,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="1.1.5.0"
+    Version="1.1.6.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -483,8 +483,7 @@ void MainPageController::AddUserParagraph(std::wstring const& text) {
     m_outputBody.Blocks().Append(m_currentParagraph);
 }
 
-std::string MainPageController::BuildPrompt(const std::string& user_text,
-                                            int* out_dropped) const {
+std::string MainPageController::BuildPrompt(const std::string& user_text, int* out_dropped) const {
     // Estimate token count (heuristic: chars/4). Trim oldest turns if over limit.
     // Threshold aligned with n_ctx=2048: 1800 estimated tokens + ~250 generation buffer.
     constexpr int kMaxEstimatedTokens = 1800;

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -483,8 +483,8 @@ void MainPageController::AddUserParagraph(std::wstring const& text) {
     m_outputBody.Blocks().Append(m_currentParagraph);
 }
 
-std::string MainPageController::BuildChatMLPrompt(const std::string& user_text,
-                                                  int* out_dropped) const {
+std::string MainPageController::BuildPrompt(const std::string& user_text,
+                                            int* out_dropped) const {
     // Estimate token count (heuristic: chars/4). Trim oldest turns if over limit.
     // Threshold aligned with n_ctx=2048: 1800 estimated tokens + ~250 generation buffer.
     constexpr int kMaxEstimatedTokens = 1800;
@@ -518,37 +518,33 @@ std::string MainPageController::BuildChatMLPrompt(const std::string& user_text,
     if (out_dropped)
         *out_dropped = static_cast<int>(first_turn);
 
-    std::string prompt = "<|im_start|>system\n" + m_system_prompt + "<|im_end|>\n";
-
+    // Complete (user, assistant) exchanges surviving the token budget; the new
+    // user_text is the trailing turn. The chat format applies the per-model
+    // template (ChatML default, Gemma, ...) and the generation suffix.
+    std::vector<::xllama::ChatTurn> turns;
     for (size_t ti = first_turn; ti < turn_starts.size(); ++ti) {
         size_t i = turn_starts[ti];
-        prompt += "<|im_start|>user\n" + m_current.messages[i].content + "<|im_end|>\n";
-        prompt += "<|im_start|>assistant\n";
+        std::string assistant;
         if (i + 1 < m_current.messages.size() &&
             m_current.messages[i + 1].role == xllama::ui::MessageRole::Assistant) {
-            prompt += m_current.messages[i + 1].content + "<|im_end|>\n";
+            assistant = m_current.messages[i + 1].content;
         }
+        turns.push_back({m_current.messages[i].content, std::move(assistant)});
     }
-    prompt += "<|im_start|>user\n" + user_text + "<|im_end|>\n";
-    prompt += "<|im_start|>assistant\n";
-    prompt += AssistantGenSuffix();
-    return prompt;
+    return chat_format().render_prompt(m_system_prompt, turns, user_text);
 }
 
-std::string MainPageController::AssistantGenSuffix() const {
-    return ::xllama::qwen_no_think_gen_suffix(::xllama::wstring_to_utf8(m_model_filename));
+xllama::ChatFormat MainPageController::chat_format() const {
+    return ::xllama::chat_format_for(::xllama::wstring_to_utf8(m_model_filename));
 }
 
 std::string MainPageController::BuildDeltaPrompt(const std::string& user_text) const {
     // The persistent KV cache already holds everything through the previous
-    // assistant's generated tokens. Close that turn — the model emits <|im_end|>
-    // when it stops on the stop sequence, so add it only if it didn't (n_predict
-    // cap) — then append the new user turn and the assistant header. Concatenated
-    // onto the KV this reproduces exactly what BuildChatMLPrompt would have built.
-    std::string d = m_kv_last_ended_with_stop ? "\n" : "<|im_end|>\n";
-    d += "<|im_start|>user\n" + user_text + "<|im_end|>\n<|im_start|>assistant\n";
-    d += AssistantGenSuffix();
-    return d;
+    // assistant's generated tokens. The chat format closes that turn (only a
+    // newline if the model already emitted the stop token; the full turn close
+    // otherwise) and appends the new user turn + assistant header. Concatenated
+    // onto the KV this reproduces exactly what BuildPrompt would have built.
+    return chat_format().render_delta(user_text, m_kv_last_ended_with_stop);
 }
 
 void MainPageController::SaveCurrentConversation(bool partial) {
@@ -592,7 +588,7 @@ void MainPageController::RenderConversation() {
         label.FontWeight(winrt::Windows::UI::Text::FontWeights::Bold());
         p.Inlines().Append(label);
         Run content;
-        content.Text(::xllama::utf8_to_wstring(::xllama::strip_empty_thinking_tags(msg.content)));
+        content.Text(::xllama::utf8_to_wstring(chat_format().postprocess_output(msg.content)));
         if (msg.partial)
             content.Text(content.Text() + L" [cancelled]");
         p.Inlines().Append(content);
@@ -1795,14 +1791,14 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
     m_flush_timer.Start();
 
     // Build multi-turn ChatML prompt from conversation history.
-    // BuildChatMLPrompt uses existing m_current.messages (prev turns) and appends user_text.
+    // BuildPrompt uses existing m_current.messages (prev turns) and appends user_text.
     std::string user_text = ::xllama::wstring_to_utf8(prompt_w);
     if (m_current.id.empty()) {
         m_current.id = xllama::ui::ChatHistory::NewId();
         m_current.title = xllama::ui::ChatHistory::TitleFrom(user_text);
     }
     int n_dropped = 0;
-    std::string full_prompt = BuildChatMLPrompt(user_text, &n_dropped);
+    std::string full_prompt = BuildPrompt(user_text, &n_dropped);
     if (n_dropped > 0)
         SetStatus(L"Context trimmed — " + std::to_wstring(n_dropped) + L" old turn(s) dropped");
 
@@ -1897,7 +1893,11 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
         ::xllama::wstring_to_utf8(m_active_model.empty() ? m_model_filename : m_active_model);
     auto dispatcher = m_root.Dispatcher();
 
-    std::thread([self, full_prompt, delta_prompt, do_reuse, kv_reuse, ep_kv_ok, model,
+    // Per-model chat format (stop sequences + output post-processing) — resolved
+    // on the UI thread (chat_format() reads m_model_filename) and captured by value.
+    xllama::ChatFormat fmt = chat_format();
+
+    std::thread([self, full_prompt, delta_prompt, do_reuse, kv_reuse, ep_kv_ok, model, fmt,
                  dispatcher]() {
         try {
             std::string load_err;
@@ -1933,7 +1933,7 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
                 gp.top_k = self->m_top_k;
                 gp.repetition_penalty = self->m_repetition_penalty;
                 gp.abort_flag = &self->m_abort;
-                gp.stop_sequences.push_back("<|im_end|>");
+                gp.stop_sequences = fmt.stop_sequences;
                 gp.reuse_kv = reuse;
                 gp.reset_kv = reset;
                 gp.on_status = on_status;
@@ -1971,7 +1971,7 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
                                                                           : res.error_msg);
             }
 
-            std::string output_text = ::xllama::strip_empty_thinking_tags(res.output_text);
+            std::string output_text = fmt.postprocess_output(res.output_text);
             bool was_aborted = self->m_abort.load();
             dispatcher.RunAsync(CoreDispatcherPriority::Normal, [self, metrics, res, output_text,
                                                                  was_aborted, ep_kv_ok]() {

--- a/uwp/MainPage.h
+++ b/uwp/MainPage.h
@@ -9,6 +9,7 @@
     #include "inference-bridge.h"
     #include "model-downloader.h"
     #include "pch.h"
+    #include "xllama/chat_prompt.h"
     #include "xllama/session.h"
 
     #include <atomic>
@@ -79,11 +80,12 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     void LoadConversation(const std::string& id);
     void RenderConversation();
     void AddUserParagraph(std::wstring const& text);
-    std::string BuildChatMLPrompt(const std::string& user_text, int* out_dropped = nullptr) const;
-    // Only the new turn's ChatML tokens, appended to the reused KV cache.
+    std::string BuildPrompt(const std::string& user_text, int* out_dropped = nullptr) const;
+    // Only the new turn's tokens, appended to the reused KV cache.
     std::string BuildDeltaPrompt(const std::string& user_text) const;
-    // Model-specific suffix after <|im_start|>assistant (e.g. Qwen no-think prefill).
-    std::string AssistantGenSuffix() const;
+    // Per-architecture chat template for the current model (ChatML default, Gemma, ...).
+    // Built on demand (reads m_model_filename); do not call from the worker thread.
+    xllama::ChatFormat chat_format() const;
     void LoadSettings();
     void SaveSettings();
     winrt::fire_and_forget ShowSettings();

--- a/uwp/inference-bridge.cpp
+++ b/uwp/inference-bridge.cpp
@@ -3,6 +3,7 @@
 
 #include "inference-bridge.h"
 
+#include "xllama/chat_prompt.h"
 #include "xllama/inference.h"
 #include "xllama/path_utils.h"
 #include "xllama/platform.h"
@@ -32,11 +33,6 @@ std::string read_local_file(const char* name) {
     while (!out.empty() && (out.back() == '\n' || out.back() == '\r' || out.back() == ' '))
         out.pop_back();
     return out;
-}
-
-std::string chatml(const std::string& sys, const std::string& user) {
-    return "<|im_start|>system\n" + sys + "<|im_end|>\n<|im_start|>user\n" + user +
-           "<|im_end|>\n<|im_start|>assistant\n";
 }
 
 // Multi-turn TTFT bench: measures turn-2 prefill with KV reuse (append only the
@@ -70,28 +66,25 @@ void run_kv_bench(const std::string& model_name, const std::string& sys, const s
         return;
     }
 
+    const ::xllama::ChatFormat fmt = ::xllama::chat_format_for(model_name);
     auto mkgp = [&](const std::string& p, bool reuse, bool reset) {
         ::xllama::GenerateParams gp;
         gp.prompt = p;
         gp.n_predict = 96;
         gp.reuse_kv = reuse;
         gp.reset_kv = reset;
-        gp.stop_sequences.push_back("<|im_end|>");
+        gp.stop_sequences = fmt.stop_sequences;
         return gp;
     };
 
     // Turn 1: seed the persistent generator.
-    auto r1 = sess->generate(mkgp(chatml(sys, u1), /*reuse=*/true, /*reset=*/true));
+    auto r1 = sess->generate(mkgp(fmt.render_prompt(sys, {}, u1), /*reuse=*/true, /*reset=*/true));
     // Turn 2 (KV reuse): append only the new turn's delta.
-    std::string delta = (r1.ended_with_stop ? std::string("\n") : std::string("<|im_end|>\n")) +
-                        "<|im_start|>user\n" + u2 + "<|im_end|>\n<|im_start|>assistant\n";
+    std::string delta = fmt.render_delta(u2, r1.ended_with_stop);
     auto r2 = sess->generate(mkgp(delta, /*reuse=*/true, /*reset=*/false));
     // Turn 2 (cold): full re-prefill of the whole 2-turn context — the pre-Stage-2
     // behaviour. Uses turn-1's actual output so the token count matches.
-    std::string full2 = "<|im_start|>system\n" + sys + "<|im_end|>\n<|im_start|>user\n" + u1 +
-                        "<|im_end|>\n<|im_start|>assistant\n" + r1.output_text +
-                        "<|im_end|>\n<|im_start|>user\n" + u2 +
-                        "<|im_end|>\n<|im_start|>assistant\n";
+    std::string full2 = fmt.render_prompt(sys, {::xllama::ChatTurn{u1, r1.output_text}}, u2);
     auto r2c = sess->generate(mkgp(full2, /*reuse=*/true, /*reset=*/true));
 
     double speedup = (r2.t_p_eval_ms > 0) ? r2c.t_p_eval_ms / r2.t_p_eval_ms : 0.0;
@@ -159,13 +152,6 @@ void main_loop() {
             }
         }
     }
-    // Wrap with ChatML template (required for SmolLM2-Instruct).
-    std::string prompt = "<|im_start|>system\nYou are a helpful AI assistant.<|im_end|>\n"
-                         "<|im_start|>user\n" +
-                         user_prompt +
-                         "<|im_end|>\n"
-                         "<|im_start|>assistant\n";
-
     // Read model directory/filename from LocalFolder/model.txt, fallback to default.
     std::string model_name = "smollm2-360m-cpu-int4";
     {
@@ -216,6 +202,11 @@ void main_loop() {
             return;
         }
     }
+
+    // Apply the per-model chat template (ChatML default, required for
+    // SmolLM2-Instruct; Gemma/Qwen get their own format via the model name).
+    std::string prompt = ::xllama::chat_format_for(model_name).render_prompt(
+        "You are a helpful AI assistant.", {}, user_prompt);
 
     log_output("[xllama] bench model: " + model_name + "\n");
     log_output("[xllama] bench prompt: " + prompt.substr(0, 80) + "...\n");

--- a/uwp/inference-bridge.cpp
+++ b/uwp/inference-bridge.cpp
@@ -205,8 +205,8 @@ void main_loop() {
 
     // Apply the per-model chat template (ChatML default, required for
     // SmolLM2-Instruct; Gemma/Qwen get their own format via the model name).
-    std::string prompt = ::xllama::chat_format_for(model_name).render_prompt(
-        "You are a helpful AI assistant.", {}, user_prompt);
+    std::string prompt = ::xllama::chat_format_for(model_name)
+                             .render_prompt("You are a helpful AI assistant.", {}, user_prompt);
 
     log_output("[xllama] bench model: " + model_name + "\n");
     log_output("[xllama] bench prompt: " + prompt.substr(0, 80) + "...\n");

--- a/uwp/inference-bridge.cpp
+++ b/uwp/inference-bridge.cpp
@@ -205,8 +205,8 @@ void main_loop() {
 
     // Apply the per-model chat template (ChatML default, required for
     // SmolLM2-Instruct; Gemma/Qwen get their own format via the model name).
-    std::string prompt = ::xllama::chat_format_for(model_name)
-                             .render_prompt("You are a helpful AI assistant.", {}, user_prompt);
+    const ::xllama::ChatFormat fmt = ::xllama::chat_format_for(model_name);
+    std::string prompt = fmt.render_prompt("You are a helpful AI assistant.", {}, user_prompt);
 
     log_output("[xllama] bench model: " + model_name + "\n");
     log_output("[xllama] bench prompt: " + prompt.substr(0, 80) + "...\n");
@@ -215,7 +215,8 @@ void main_loop() {
     params.model_path = model_name;
     params.prompt = prompt;
     params.n_predict = 512;
-    params.n_threads = bench_threads; // 0 = auto; set by bench-xbox-ort.sh
+    params.n_threads = bench_threads;           // 0 = auto; set by bench-xbox-ort.sh
+    params.stop_sequences = fmt.stop_sequences; // clean stop for Gemma's <end_of_turn>
 
     char host_buf[64];
     if (bench_threads > 0)

--- a/uwp/models/manifest.json
+++ b/uwp/models/manifest.json
@@ -105,6 +105,19 @@
       ]
     },
     {
+      "_comment": "Gemma-4-E2B (llama.cpp gemma4 arch). Console-validated 2026-07-14: loads (peak RAM 2534 MB, no OOM — the ~2GB Dev Mode per-file limit does not apply to GGUF), decode ~9.9 tok/s @ t6. Heavy/advanced: 2.29 GB IQ2_M, ~6-24s load (no mmap), a 512-token prompt at temp 0.8 can EOG immediately (2-bit); short prompts generate fine. Direct from HF (>2GB exceeds the GitHub release 2GB asset limit; Gemma Terms apply — verify before mirroring).",
+      "name": "gemma4-e2b",
+      "display": "Gemma 4 E2B (GGUF · CPU · 2.3 GB, advanced)",
+      "kind": "gguf",
+      "hf_base_url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main",
+      "files": [
+        {
+          "filename": "gemma-4-E2B-it-UD-IQ2_M.gguf",
+          "approx_bytes": 2290858112
+        }
+      ]
+    },
+    {
       "name": "lfm25-350m",
       "display": "LFM2.5 350M (GGUF · CPU)",
       "kind": "gguf",

--- a/uwp/models/manifest.json
+++ b/uwp/models/manifest.json
@@ -92,6 +92,19 @@
       ]
     },
     {
+      "_comment": "Gemma-3-270M GGUF (llama.cpp gemma3 arch, verified loads on the pinned submodule). Downloaded directly from the original Hugging Face repo (hf_base_url → resolve/main) rather than re-hosted on our release: Gemma Terms of Use govern redistribution — verify before ever mirroring the weights onto models-v1. Uses the <start_of_turn>/<end_of_turn> template via chat_format_for (kind:gguf, CPU-only, KV-reuse/routing disabled).",
+      "name": "gemma3-270m",
+      "display": "Gemma 3 270M (GGUF · CPU)",
+      "kind": "gguf",
+      "hf_base_url": "https://huggingface.co/unsloth/gemma-3-270m-it-GGUF/resolve/main",
+      "files": [
+        {
+          "filename": "gemma-3-270m-it-Q4_K_M.gguf",
+          "approx_bytes": 253115424
+        }
+      ]
+    },
+    {
       "name": "lfm25-350m",
       "display": "LFM2.5 350M (GGUF · CPU)",
       "kind": "gguf",


### PR DESCRIPTION
## Context

Started from "possiamo integrare Gemma 4?". Two findings reframed it: the vendored `llama.cpp` (`9a532ae4b`) already carries `LLM_ARCH_GEMMA3`/`GEMMA4`, and the real blocker was the **hard-coded ChatML** prompt building (Gemma needs `<start_of_turn>…<end_of_turn>`, no system role). The "too big for Xbox" verdict was also stale — Dev Mode disk is now 90 GB (`uwp-constraints.md §9`), so disk is no longer the constraint.

## Chat template abstraction (core)

- `ChatFormat` (data-driven) replaces the duplicated ChatML in `MainPage.cpp` (`BuildPrompt`/`BuildDeltaPrompt`), `inference-bridge.cpp` (`run_kv_bench`, `main_loop`) and the `<|im_end|>` stop.
- `chat_format_for(model_id)` → ChatML (default, keeps Qwen no-think suffix) or Gemma. `render_prompt` / `render_delta` / `postprocess_output` are the single source of truth.
- Chose a custom C++ format over the vendored llama.cpp Jinja engine (Jinja is llama.cpp-only; the Xbox default runs on ORT-GenAI; KV-reuse delta needs a precise token suffix, not a two-render diff).
- Stop sequences + output post-processing are resolved on the UI thread and captured by value into the worker.

## Gemma

- Catalogue entry `gemma3-270m` (253 MB, `kind:gguf`), downloaded from the original HF repo (Gemma Terms — not re-hosted).
- `gemma3` **and** `gemma4` arch load + generate, verified via `xllama-cli` (`general.architecture = gemma3`/`gemma4`).
- **Gemma-4-E2B** is a feasibility candidate: smallest usable quant 2.29 GB (UD-IQ2_M), host-dev decode 3.8 tok/s, RAM 2.35 GB. Gated on the community-reported ~2 GB Dev Mode per-file limit (untested on this Xbox) + RAM.

## Benchmarks / docs

- `docs/benchmarks.md` + self-contained `docs/benchmarks-charts.html` consolidate every tested model (decode/prefill/RAM across llama.cpp CPU / ORT CPU / DML) from `bench/results/`.
- `model-selection.md` Gemma verdict revised; `ROADMAP.md` Phase 6 updated; `docs/README.md` index entry added.

## Tests

`ctest` green — 11 new doctest cases including **byte-exact ChatML** (no regression) and the **KV-reuse invariant** for both ChatML and Gemma.

## Verification done / pending

- ✅ Linux: lib + tests build, `xllama-cli` loads/generates gemma3 (253 MB) and gemma4-E2B (2.29 GB), stops on `<end_of_turn>`.
- ⚠️ UWP files can't compile on Linux (WinRT/MSVC) — needs CI `build-uwp`.
- ⛔ Pending (needs the console): `gemma3-270m` on-console bench; test whether a >2 GB GGUF loads under the Dev Mode per-file limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model-specific chat formatting, including Gemma support and improved stop-token handling.
  * Added `--chat` CLI mode for applying supported chat templates automatically.
  * Added the Gemma 3 270M model to the in-app catalogue.
  * Added an interactive benchmark dashboard with charts, filters, performance metrics, and source data.

* **Documentation**
  * Expanded benchmark results, model-selection guidance, roadmap details, and release notes.
  * Updated documentation to link to the new benchmark dashboard.

* **Changed**
  * Updated the application version to 1.1.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->