### PR TITLE
chore(ci): repo automation — concurrency, Dependabot, CodeQL, templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Bug report
+description: Something doesn't work as expected
+labels: [bug]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you did and what went wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where
+      options:
+        - Xbox console (UWP / Dev Mode)
+        - Linux CLI / build
+        - CI (GitHub Actions)
+        - Docs
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: MSIX package version (Settings) or git SHA.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant `xllama.log` (Device Portal → LocalState) or CLI output.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://github.com/gianlucamazza/xllama/tree/main/docs
+    about: Runbooks, UWP constraints, model selection, and benchmarks.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: Feature request
+description: Propose a change or a new model/capability
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do that xllama doesn't support yet?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Console constraints considered
+      description: >-
+        For new models: on-disk size, RAM footprint, backend (ORT GenAI vs GGUF),
+        and the ~2 GB Dev Mode per-file limit. See docs/model-selection.md.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # GitHub Actions used by the CI workflows (checkout, upload-artifact, …).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # Vendored llama.cpp submodule — surface upstream bumps as PRs (arch/quant
+  # support, security). Review carefully: a bump can shift GGUF loader behaviour.
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: deps

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## What & why
+
+<!-- What does this change and why. Link issues/ROADMAP items. -->
+
+## How verified
+
+<!-- Delete rows that don't apply. -->
+
+- [ ] `ctest --test-dir build/linux-test` green
+- [ ] `clang-format --dry-run --Werror` clean (CI gate)
+- [ ] Linux CLI exercised (`xllama-cli …`)
+- [ ] On-console (Xbox) validated — build deployed, `scripts/validate-console.sh`
+- [ ] Docs updated (README / ROADMAP / CHANGELOG / docs/)
+
+## Notes
+
+<!-- Risks, follow-ups, or anything a reviewer should know. UWP code compiles
+     only on the Windows CI (build-uwp) — say if you couldn't build it locally. -->

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -2,7 +2,14 @@ name: build-linux
 
 on:
   push:
+    branches: [main]
   pull_request:
+
+# Feature branches build once via pull_request (not also via push); superseded
+# runs on the same branch cancel so only the latest commit is tested.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-uwp-patched.yml
+++ b/.github/workflows/build-uwp-patched.yml
@@ -10,6 +10,10 @@ name: build-uwp-patched
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     # Pin to windows-2022: has VS2022 (v143) + UWP workload pre-installed

--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -2,7 +2,14 @@ name: build-uwp
 
 on:
   push:
+    branches: [main]
   pull_request:
+
+# Feature branches build once via pull_request (not also via push); superseded
+# runs on the same branch cancel — UWP builds are ~13 min, so this saves the most.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: codeql
+
+# CodeQL security + quality scanning for the C++ bridge/UWP/CLI sources.
+# Uses build-mode: none (no compile) to avoid building the heavy vendored
+# llama.cpp submodule on every run — a lighter, dependency-free scan. Switch to
+# build-mode: manual with the cmake preset if deeper dataflow coverage is needed.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "27 4 * * 1" # weekly, Monday 04:27 UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: analyze (c-cpp)
+    runs-on: ubuntu-22.04
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        # No submodules: build-mode none scans the repo's own sources only.
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: c-cpp
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:c-cpp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to xllama
+
+Thanks for helping. This is a research project targeting **Xbox Series S (Dev
+Mode)**; most constraints come from the UWP/AppContainer sandbox, so read
+[`AGENTS.md`](AGENTS.md) (conventions + repo map) and
+[`docs/uwp-constraints.md`](docs/uwp-constraints.md) first.
+
+## Workflow
+
+1. Branch off `main` (`feat/…`, `fix/…`, `chore/…`) and open a PR — CI builds
+   run on PRs (feature branches don't build on direct push).
+2. Keep PRs focused; put orthogonal infra changes in their own PR.
+3. Fill in the PR template's "How verified" section.
+
+## Before you push
+
+```bash
+cmake --preset linux-test
+cmake --build build/linux-test -j"$(nproc)"
+ctest --test-dir build/linux-test --output-on-failure
+# Formatting gate (CI enforces it with --Werror):
+clang-format -i <changed .cpp/.h files>
+shellcheck scripts/*.sh   # if you touched shell
+```
+
+## Conventions
+
+- **C++17**, RAII, `unique_ptr`; concise, no over-engineering. English for code,
+  comments, and commits.
+- **Formatting** is enforced (`.clang-format`, pinned `clang-format` in CI).
+- **Commits**: conventional prefixes (`feat`, `fix`, `docs`, `ci`, `chore`, …).
+
+## Platform notes
+
+- **UWP code compiles only on the Windows CI** (`build-uwp`) — you usually can't
+  build `uwp/` locally on Linux. Say so in the PR if you couldn't.
+- **Inference backends**: ORT GenAI (Xbox default) and llama.cpp (Linux + GGUF).
+  UWP inference lives under `#ifdef XLLAMA_USE_ORT`; keep the Linux path building.
+- **Adding a model**: usually just a `uwp/models/manifest.json` entry — check the
+  size/RAM/per-file limits in [`docs/model-selection.md`](docs/model-selection.md).
+
+## Reporting issues
+
+Use the issue templates. Include the MSIX version (or git SHA) and, for console
+bugs, the `xllama.log` from Device Portal → LocalState.


### PR DESCRIPTION
Modern CI/repo hygiene, orthogonal to the Gemma feature (#46). Kept as its own PR.

## Changes
- **Concurrency + trigger fix** on all 3 workflows: `push` restricted to `main` and a `concurrency` group keyed on `head_ref`. A PR branch now builds **once** (via `pull_request`) instead of twice (push + PR), and a new commit **cancels** the superseded run. Biggest saving on the ~13 min `build-uwp`.
- **Dependabot** (`.github/dependabot.yml`): weekly `github-actions` + `gitsubmodule` (llama.cpp) update PRs. The repo already has an open Dependabot alert; this keeps actions/submodule current.
- **CodeQL** (`.github/workflows/codeql.yml`): `c-cpp` scanning with `build-mode: none` (no heavy llama.cpp build) on push/PR to main + weekly.
- **Templates**: PR template (with a "How verified" checklist incl. the UWP-only-builds-on-CI caveat), bug/feature issue forms, `ISSUE_TEMPLATE/config.yml`.
- **CONTRIBUTING.md**: points to `AGENTS.md`, the pre-push checklist, and the backend/platform notes.

## Verification
All YAML parses. Effects are visible once merged (workflow changes on a branch apply to that branch's `pull_request` runs). No source/code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)