### PR TITLE
ci: automate MSIX versioning (Revision = CI run number)

### DIFF
--- a/.github/workflows/build-uwp-patched.yml
+++ b/.github/workflows/build-uwp-patched.yml
@@ -71,7 +71,7 @@ jobs:
         run: >-
           ./scripts/build-uwp.ps1 -Configuration Release -Platform x64
           -Backend $('${{ matrix.variant }}' -eq 'default' ? 'ort' : '${{ matrix.variant }}')
-          -PatchedGenAI
+          -PatchedGenAI -BuildRevision ${{ github.run_number }}
 
       - uses: actions/upload-artifact@v7
         if: success()

--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -74,6 +74,9 @@ jobs:
             Configuration = 'Release'
             Platform      = 'x64'
             Backend       = $('${{ matrix.variant }}' -eq 'unified' ? 'unified' : '${{ matrix.variant }}')
+            # Unique, monotonic MSIX Revision per build (Major.Minor.Build stays
+            # the committed semantic version) so console updates never collide.
+            BuildRevision = ${{ github.run_number }}
           }
           if ('${{ matrix.patched }}' -eq 'true') { $buildArgs.PatchedGenAI = $true }
           ./scripts/build-uwp.ps1 @buildArgs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,14 @@ For local builds (requires a Windows VM — see `docs/windows-dev-vm.md`):
 
 Use `-ForceNewCert` only to regenerate the test signing certificate.
 
+**Versioning**: `Major.Minor.Build` in `uwp/AppxManifest.xml` is the semantic
+version — bump it manually per release (with `CHANGELOG.md`). The `Revision` (4th
+component) is stamped automatically in CI to the workflow run number
+(`build-uwp.ps1 -BuildRevision`, wired from `github.run_number` in the
+workflows), so every CI package is uniquely and monotonically versioned and the
+console always takes an **in-place update** — no manual per-build bump, and never
+the "same identity, different contents" install block. Local builds leave `.0`.
+
 ## Tests
 
 - Framework: **doctest** (header-only, fetched via CMake).

--- a/scripts/build-uwp.ps1
+++ b/scripts/build-uwp.ps1
@@ -31,7 +31,13 @@ param(
     [string]$Backend        = "ort",
     # Replace onnxruntime-genai.dll with the #2280 DML fallback build when available
     # (vendor/onnxruntime-genai-patched/ or -Build via vendor-genai-dml-patch.ps1).
-    [switch]$PatchedGenAI   = $false
+    [switch]$PatchedGenAI   = $false,
+    # MSIX version Revision (the 4th component). Each CI build passes a unique,
+    # monotonic value (the workflow run number) so every package gets a distinct,
+    # increasing version — in-place console updates never hit the same-identity
+    # block. 0 (the local default) leaves the committed X.Y.Z.0 unchanged, so a
+    # local build never pollutes the working tree.
+    [int]$BuildRevision     = $(if ($env:GITHUB_RUN_NUMBER) { [int]$env:GITHUB_RUN_NUMBER } else { 0 })
 )
 
 $ErrorActionPreference = "Stop"
@@ -146,6 +152,27 @@ if ($PatchedGenAI -and $Backend -ne "llamacpp") {
         Write-Error "vendor-genai-dml-patch.ps1 failed ($LASTEXITCODE) — refusing to package a mislabeled patched build."
         exit $LASTEXITCODE
     }
+}
+
+# ---------------------------------------------------------------------------
+# Version stamping. Major.Minor.Build (the semantic version) stays the source of
+# truth in the committed AppxManifest.xml; the Revision (4th component) is set to
+# $BuildRevision so every CI build is uniquely and monotonically versioned. This
+# is what lets the console take an in-place update without a manual version bump.
+# The negative-lookbehind avoids the TargetDeviceFamily Min/MaxVersion attributes;
+# only the first (Identity) Version is rewritten.
+# ---------------------------------------------------------------------------
+if ($BuildRevision -gt 0) {
+    $ManifestPath = Join-Path $UwpDir "AppxManifest.xml"
+    $manifestText = Get-Content -Raw $ManifestPath
+    $rx = [regex]'(?<!\w)Version="(\d+)\.(\d+)\.(\d+)\.\d+"'
+    $newText = $rx.Replace($manifestText, {
+        param($m)
+        'Version="{0}.{1}.{2}.{3}"' -f $m.Groups[1].Value, $m.Groups[2].Value, $m.Groups[3].Value, $BuildRevision
+    }, 1)
+    Set-Content -Path $ManifestPath -Value $newText -NoNewline
+    $stamped = ([regex]::Match($newText, '(?<!\w)Version="(\d+\.\d+\.\d+\.\d+)"')).Groups[1].Value
+    Write-Host "Version stamped: $stamped (revision = build $BuildRevision)"
 }
 
 Write-Host "Building $Configuration|$Platform ..."

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -7,6 +7,11 @@
   xmlns:xbox="http://schemas.microsoft.com/appx/manifest/xbox/windows10"
   IgnorableNamespaces="mp uap uap3 xbox">
 
+  <!-- Version: Major.Minor.Build is the semantic version (bump manually per
+       release, alongside CHANGELOG). The Revision (the trailing .0) is stamped
+       automatically in CI to the workflow run number (build-uwp.ps1
+       -BuildRevision) so every build is uniquely, monotonically versioned and
+       the console always accepts an in-place update. Local builds keep .0. -->
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"


### PR DESCRIPTION
## Problem
Deploying a rebuilt package to the console hit WDP's **"same identity, different contents"** block whenever `Major.Minor.Build` was unchanged — every redeploy needed a manual version bump (as this session's 1.1.5.0→1.1.6.0 did).

## Fix — best-practice MSIX versioning
`Major.Minor.Build` stays the **committed semantic version** (bump per release with `CHANGELOG.md`); the **Revision** (4th component) is stamped automatically in CI from `github.run_number`:

- `build-uwp.ps1` gains `-BuildRevision` (defaults to `$env:GITHUB_RUN_NUMBER`, else `0`). When `> 0` it rewrites **only** the Identity `Version`'s revision in `AppxManifest.xml` — a negative-lookbehind leaves `TargetDeviceFamily` Min/MaxVersion untouched. Local builds keep `.0`, so no working-tree pollution.
- `build-uwp.yml` + `build-uwp-patched.yml` pass `BuildRevision = ${{ github.run_number }}`.

Result: every CI package is uniquely and monotonically versioned → the console always accepts an **in-place update**, no manual per-build bump, no reinstall.

## Verified
- `pwsh` parse of `build-uwp.ps1` OK; the stamping block run in isolation produces `1.1.6.<rev>` with `MinVersion` intact.
- Workflow + AppxManifest validate. Documented in `AGENTS.md` + a manifest comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows packages now receive unique, incrementing revision numbers in CI builds.
  * CI-generated package updates can be installed in place more reliably.

* **Documentation**
  * Updated Windows build documentation to explain automatic CI versioning and local build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->