### PR TITLE
deps: bump llama.cpp to 657e011 (+ UWP vcxproj sources) — fixes #48

### DIFF
--- a/uwp/ggml-uwp.vcxproj
+++ b/uwp/ggml-uwp.vcxproj
@@ -158,6 +158,8 @@
     <ClCompile Include="..\llama.cpp\src\llama-impl.cpp" />
     <ClCompile Include="..\llama.cpp\src\llama-io.cpp" />
     <ClCompile Include="..\llama.cpp\src\llama-kv-cache.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-kv-cache-dsa.cpp" />
+    <ClCompile Include="..\llama.cpp\src\llama-kv-cache-dsv4.cpp" />
     <ClCompile Include="..\llama.cpp\src\llama-kv-cache-iswa.cpp" />
     <ClCompile Include="..\llama.cpp\src\llama-memory.cpp" />
     <ClCompile Include="..\llama.cpp\src\llama-memory-hybrid.cpp" />
@@ -301,7 +303,16 @@
     <ClCompile Include="..\llama.cpp\src\models\starcoder2.cpp" />
     <ClCompile Include="..\llama.cpp\src\models\step35.cpp" />
     <ClCompile Include="..\llama.cpp\src\models\t5.cpp" />
+    <ClCompile Include="..\llama.cpp\src\models\cohere2moe.cpp" />
+    <ClCompile Include="..\llama.cpp\src\models\deepseek32.cpp" />
+    <ClCompile Include="..\llama.cpp\src\models\deepseek4.cpp" />
+    <ClCompile Include="..\llama.cpp\src\models\dflash.cpp" />
+    <ClCompile Include="..\llama.cpp\src\models\eagle3.cpp" />
+    <ClCompile Include="..\llama.cpp\src\models\gemma4-assistant.cpp" />
+    <ClCompile Include="..\llama.cpp\src\models\hy-v3.cpp" />
+    <ClCompile Include="..\llama.cpp\src\models\mellum.cpp" />
     <ClCompile Include="..\llama.cpp\src\models\t5encoder.cpp" />
+    <ClCompile Include="..\llama.cpp\src\models\talkie.cpp" />
     <ClCompile Include="..\llama.cpp\src\models\wavtokenizer-dec.cpp" />
     <ClCompile Include="..\llama.cpp\src\models\xverse.cpp" />
   </ItemGroup>


### PR DESCRIPTION
Completes the Dependabot llama.cpp bump (#48), which **failed the UWP build** with `LNK2001` unresolved externals.

## Root cause
`657e011` split more architectures into `src/models/*.cpp` and added `src/llama-kv-cache-dsa/dsv4.cpp`. Linux auto-globs sources (passed); the UWP `ggml-uwp.vcxproj` lists sources **by hand**, so 11 new files were missing at link time — exactly the symbols the linker reported (`llama_model_gemma4_assistant`, `deepseek4`, `llama_kv_cache_dsv4`, …).

## Fix
- Submodule `9a532ae` → `657e011`.
- `ggml-uwp.vcxproj`: add the 9 new `src/models` files + the 2 `llama-kv-cache-dsa/dsv4`. Source list now matches the submodule **exactly** (verified 0 missing / 0 stale).

## Validation
- Linux `cmake --build` + `ctest` green with the new submodule.
- `gemma3-270m` and `gemma4-E2B` still load and generate (no behavioural regression).
- UWP AppContainer patch applies cleanly (unchanged).
- The UWP CI build on this PR is the final gate (couldn't build UWP locally).

Closes #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)