### PR TITLE
refactor: unify stop-sequence handling (Tier2 #3)

### DIFF
--- a/include/xllama/chat_prompt.h
+++ b/include/xllama/chat_prompt.h
@@ -22,6 +22,14 @@ std::string qwen_no_think_gen_suffix(const std::string& model_id);
 // Remove leading empty </think> blocks (whitespace-only inside tags).
 std::string strip_empty_thinking_tags(std::string text);
 
+// Stop-sequence check for streamed generation. Call after each token is appended
+// to `output`: if `output` now ENDS WITH any (non-empty) stop sequence, trim that
+// trailing match off `output` and return true. Suffix-match (not substring) is
+// the correct streaming semantics and handles multi-piece stop tokens (e.g.
+// Gemma's <end_of_turn>, split across llama_token_to_piece calls). Shared by the
+// llama and ORT decode loops so their stop behaviour can't diverge.
+bool apply_stop_sequences(std::string& output, const std::vector<std::string>& stops);
+
 // ---------------------------------------------------------------------------
 // Per-architecture chat template
 //

--- a/src/bridge/chat_prompt.cpp
+++ b/src/bridge/chat_prompt.cpp
@@ -61,6 +61,17 @@ std::string strip_empty_thinking_tags(std::string text) {
     return text;
 }
 
+bool apply_stop_sequences(std::string& output, const std::vector<std::string>& stops) {
+    for (const std::string& stop : stops) {
+        if (!stop.empty() && output.size() >= stop.size() &&
+            output.compare(output.size() - stop.size(), stop.size(), stop) == 0) {
+            output.erase(output.size() - stop.size());
+            return true;
+        }
+    }
+    return false;
+}
+
 ChatFormat chat_format_for(const std::string& model_id) {
     ChatFormat f;
     // Gemma is checked before the ChatML default; the Qwen no-think suffix is

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "xllama/inference.h"
+#include "xllama/chat_prompt.h"
 #include "xllama/path_utils.h"
 #include "xllama/platform.h"
 
@@ -375,20 +376,9 @@ InferenceResult run_inference_llama(const InferenceParams& params) {
             std::fflush(stdout);
         }
 
-        // Stop strings (e.g. Gemma's <end_of_turn>, which is not an EOG token in
-        // every GGUF): if the accumulated output now ends with one, trim it and
-        // stop. Handles multi-piece stop tokens since we match on the full suffix.
-        bool hit_stop = false;
-        for (const std::string& stop : params.stop_sequences) {
-            if (!stop.empty() && res.output_text.size() >= stop.size() &&
-                res.output_text.compare(res.output_text.size() - stop.size(), stop.size(), stop) ==
-                    0) {
-                res.output_text.erase(res.output_text.size() - stop.size());
-                hit_stop = true;
-                break;
-            }
-        }
-        if (hit_stop) {
+        // Stop strings (e.g. Gemma's <end_of_turn>, not an EOG token in every
+        // GGUF): shared suffix-match helper, trims the trailing match.
+        if (apply_stop_sequences(res.output_text, params.stop_sequences)) {
             res.ended_with_stop = true;
             log_output(
                 ("[xllama] stop sequence after " + std::to_string(n_generated + 1) + " tokens\n")

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -5,6 +5,7 @@
 // llama.cpp path (Linux): model kept alive; context rebuilt per generate().
 
 #include "xllama/session.h"
+#include "xllama/chat_prompt.h"
 #include "xllama/inference_params.h"
 #include "xllama/path_utils.h"
 #include "xllama/platform.h"
@@ -163,16 +164,10 @@ class OrtSession final : public Session {
             }
             ++n_generated;
 
-            for (const auto& stop : gp.stop_sequences) {
-                auto pos = res.output_text.find(stop);
-                if (pos != std::string::npos) {
-                    res.output_text.erase(pos);
-                    stopped_by_seq = true;
-                    break;
-                }
-            }
-            if (stopped_by_seq)
+            if (apply_stop_sequences(res.output_text, gp.stop_sequences)) {
+                stopped_by_seq = true;
                 break;
+            }
         }
 
         auto t_end = std::chrono::steady_clock::now();
@@ -439,17 +434,11 @@ class LlamaSession final : public Session {
                     gp.on_token(std::string(buf, static_cast<size_t>(len)));
             }
 
-            // Stop sequences
-            for (const auto& stop : gp.stop_sequences) {
-                auto pos = res.output_text.find(stop);
-                if (pos != std::string::npos) {
-                    res.output_text.erase(pos);
-                    stopped_by_seq = true;
-                    break;
-                }
-            }
-            if (stopped_by_seq)
+            // Stop sequences (shared suffix-match helper).
+            if (apply_stop_sequences(res.output_text, gp.stop_sequences)) {
+                stopped_by_seq = true;
                 break;
+            }
 
             llama_batch next = llama_batch_get_one(&token, 1);
             if (llama_decode(ctx.get(), next) != 0) {

--- a/tests/test_chat_prompt.cpp
+++ b/tests/test_chat_prompt.cpp
@@ -29,6 +29,39 @@ TEST_CASE("strip empty thinking tags") {
     CHECK(strip_empty_thinking_tags("plain text") == "plain text");
 }
 
+TEST_CASE("apply_stop_sequences: suffix match trims and reports") {
+    // Ends with the stop -> true, trailing match trimmed.
+    std::string a = "Hello there<end_of_turn>";
+    CHECK(apply_stop_sequences(a, {"<end_of_turn>"}));
+    CHECK(a == "Hello there");
+
+    // ChatML stop.
+    std::string b = "Ciao<|im_end|>";
+    CHECK(apply_stop_sequences(b, {"<|im_end|>"}));
+    CHECK(b == "Ciao");
+
+    // Does not end with a stop -> false, unchanged.
+    std::string c = "still going";
+    CHECK_FALSE(apply_stop_sequences(c, {"<end_of_turn>"}));
+    CHECK(c == "still going");
+
+    // The divergence fix: a stop that appears MID-output (not at the end) must
+    // NOT trigger (substring find() would have wrongly truncated here).
+    std::string d = "a<end_of_turn>b";
+    CHECK_FALSE(apply_stop_sequences(d, {"<end_of_turn>"}));
+    CHECK(d == "a<end_of_turn>b");
+
+    // Empty stop ignored; multiple stops, first suffix match wins.
+    std::string e = "done<|im_end|>";
+    CHECK(apply_stop_sequences(e, {"", "<end_of_turn>", "<|im_end|>"}));
+    CHECK(e == "done");
+
+    // No stops -> false.
+    std::string f = "text";
+    CHECK_FALSE(apply_stop_sequences(f, {}));
+    CHECK(f == "text");
+}
+
 TEST_CASE("gemma detection") {
     CHECK(model_is_gemma("gemma3-270m"));
     CHECK(model_is_gemma("Gemma-4-E2B-it-Q4_K_M.gguf"));


### PR DESCRIPTION
Tier 2 #3 from the perf/arch backlog.

## Problem
Three stop-string loops, divergent: `inference.cpp` used suffix-match (correct for streaming); both `session.cpp` loops used substring `find()+erase`, which wrongly truncates if a stop string appears mid-output.

## Fix
- `apply_stop_sequences(output, stops)` in `chat_prompt` — suffix-match, trims the trailing match, handles multi-piece stop tokens (Gemma `<end_of_turn>`).
- All three call sites (inference.cpp llama, session.cpp llama + ORT) use it. Behaviour can no longer diverge.
- 6 unit tests incl. the mid-output non-match the old `find()` got wrong.

## Verified
Host build + ctest green (12 new assertions). ORT path (`#ifdef XLLAMA_USE_ORT`) validated by UWP CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)