### PR TITLE
chore: install --bench opt-in + refresh stale docs (Tier4)

### DIFF
--- a/docs/console-validation-runbook.md
+++ b/docs/console-validation-runbook.md
@@ -132,7 +132,11 @@ was removed after validation — purpose served; retrieve it from git history at
 `v1.0.0` if ever needed again. The result CSV stays at
 `bench/results/phase35-imgspike.csv`._
 
-## 5. int4 DML — confirm/falsify the §12 desk-check (5a ✅ done; 5b ⏳ PENDING — variants rebuilt 2026-07-09)
+## 5. int4 DML — confirm/falsify the §12 desk-check (5a ✅ done; 5b ⛔ closed inconclusive 2026-07-09)
+
+> **Status**: closed. The §12 desk-check stands (non-fused low-bit GEMM is the
+> decode floor); the 5b config-tests were rebuilt but not console-benched and are
+> not a local lever (see ROADMAP Phase 3.5 / Phase 5). Retained below for record.
 
 Two distinct levers; keep them separate. The desk-check (§12) predicts **neither** moves
 the 8.8 tok/s decode floor, because the limit is the **non-fused** `MatMulNBits` kernel

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -160,9 +160,10 @@ contract is different (three components + CLIP assets): see `diffusion/README.md
 
 The ORT GenAI model builder is frozen at the Qwen3 / Gemma3 architectures.
 Newer small models (Qwen3.5, LFM2, Gemma-4) ship as GGUF and run **only via
-llama.cpp** — reachable once the `unified` backend build (PR #27) is the default
-and the catalogue carries `kind: gguf` entries. Host-validated 2026-07-09;
-on-console decode/prefill benches pending.
+llama.cpp** — reachable via the shipping `unified` backend build with
+`kind: gguf` catalogue entries. **Console-measured**: Qwen3.5-0.8B 35.1 /
+LFM2.5-350M 94.2 tok/s (`phase5-gguf.csv`); Gemma-3-270M 76.8 / Gemma-4-E2B
+9.9 tok/s (`phase6-gemma.csv`).
 
 | Model            | Path      | Size (Q4_K_M / int4) | Status                                                                   |
 | ---------------- | --------- | -------------------- | ------------------------------------------------------------------------ |

--- a/scripts/install-latest-build.sh
+++ b/scripts/install-latest-build.sh
@@ -3,13 +3,14 @@
 #
 # Usage:
 #   source ~/.config/xllama/xbox-env
-#   ./scripts/install-latest-build.sh [branch]
+#   ./scripts/install-latest-build.sh [branch] [--bench]
 #
 # Defaults to the current git branch if no branch argument is given.
 # Requires: gh CLI (authenticated), jq, curl.
 #
-# Side effect: uploads bench.flag so the next launch runs headless bench mode.
-# Delete LocalState\bench.flag (via WDP) before UI or validate-console.sh runs.
+# By default the app launches into the normal UI. Pass --bench to also upload
+# bench.flag so the next launch runs headless bench mode (delete
+# LocalState\bench.flag via WDP before UI or validate-console.sh otherwise).
 # MSIX uninstall wipes LocalState — re-provision models after a fresh install.
 
 set -euo pipefail
@@ -17,7 +18,15 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-BRANCH="${1:-$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)}"
+UPLOAD_BENCH=false
+BRANCH=""
+for arg in "$@"; do
+	case "$arg" in
+	--bench) UPLOAD_BENCH=true ;;
+	*) [[ -z "$BRANCH" ]] && BRANCH="$arg" ;;
+	esac
+done
+BRANCH="${BRANCH:-$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)}"
 ARTIFACT_NAME="xllama-appx"
 WORK_DIR="/tmp/xllama-install-$$"
 
@@ -86,12 +95,13 @@ echo "==> Installing on Xbox at ${XBOX_IP} ..."
 
 NEW_PFN=$("${SCRIPT_DIR}/deploy.sh" pfn 2>/dev/null || echo "")
 
-# Upload bench.flag so bench mode fires on next launch.
+# Upload bench.flag only when --bench is passed, so a normal install launches
+# straight into the UI (no leftover headless-bench state to clean up).
 # LocalState may not be accessible via WDP right after a fresh install (before first app run).
 # Strategy: try once; if it fails, start the app briefly to init LocalState, stop it, retry.
-if [[ -n "$NEW_PFN" ]]; then
+if [[ "$UPLOAD_BENCH" == true && -n "$NEW_PFN" ]]; then
 	echo ""
-	echo "==> Uploading bench.flag ..."
+	echo "==> Uploading bench.flag (--bench) ..."
 	touch /tmp/bench.flag
 	if ! "${SCRIPT_DIR}/deploy.sh" upload-file /tmp/bench.flag "$NEW_PFN" "" 2>/dev/null; then
 		echo "  (first upload failed — starting app briefly to init LocalState...)"


### PR DESCRIPTION
Tier 4 (zero-risk polish) from the backlog.

- **install-latest-build.sh**: `bench.flag` now uploaded only with `--bench` — a plain install launches into the UI (no leftover headless-bench state). ROADMAP Phase 6 item.
- **docs/model-selection.md**: the GGUF "on-console benches pending" line is stale → replaced with measured numbers (phase5-gguf + phase6-gemma).
- **docs/console-validation-runbook.md §5**: 5b marked closed-inconclusive (the §12 desk-check stands), matching ROADMAP Phase 3.5/5.

Docs + one script; shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)