### PR TITLE
perf: KV-cache reuse for GGUF (persistent llama_context) — Tier2 #4

### DIFF
--- a/include/xllama/routing_policy.h
+++ b/include/xllama/routing_policy.h
@@ -56,7 +56,11 @@ inline bool routing_allowed_for_kind(const std::wstring& kind) {
 }
 
 inline bool kv_reuse_allowed_for_kind(const std::wstring& kind) {
-    return kind != L"gguf";
+    // GGUF (llama.cpp) now supports KV reuse via a persistent llama_context
+    // (LlamaSession), so it is allowed alongside ORT-GenAI. (Routing stays
+    // ORT-only — the llama.cpp UWP build is CPU-only, no GPU model to route to.)
+    (void)kind;
+    return true;
 }
 
 // ORT GenAI continuous decoding (KV reuse) is CPU-only today; DirectML rejects

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -357,6 +357,10 @@ class LlamaSession final : public Session {
     LlamaModelPtr m_model;
     int m_n_ctx;
     int m_n_threads;
+    // Persistent context across turns: the KV cache lives here so a reuse turn
+    // (reuse_kv && !reset_kv) can append only the delta instead of re-prefilling
+    // the whole conversation. Created lazily on the first generate().
+    LlamaContextPtr m_ctx;
 
     explicit LlamaSession(LlamaModelPtr model, int n_ctx, int n_threads)
         : m_model(std::move(model)), m_n_ctx(n_ctx), m_n_threads(n_threads) {}
@@ -364,23 +368,33 @@ class LlamaSession final : public Session {
     InferenceResult generate(const GenerateParams& gp) override {
         InferenceResult res;
 
-        llama_context_params cparams = llama_context_default_params();
-        cparams.n_ctx = m_n_ctx;
-        cparams.n_threads = m_n_threads;
-
-        llama_context* raw_ctx = llama_init_from_model(m_model.get(), cparams);
-        if (!raw_ctx) {
-            res.error_msg = "failed to create context";
-            log_output("[xllama] session generate: failed to create context\n");
-            return res;
+        if (!m_ctx) {
+            llama_context_params cparams = llama_context_default_params();
+            cparams.n_ctx = m_n_ctx;
+            cparams.n_threads = m_n_threads;
+            m_ctx.reset(llama_init_from_model(m_model.get(), cparams));
+            if (!m_ctx) {
+                res.error_msg = "failed to create context";
+                log_output("[xllama] session generate: failed to create context\n");
+                return res;
+            }
         }
-        LlamaContextPtr ctx(raw_ctx);
+        llama_context* ctx = m_ctx.get();
+
+        // KV-cache reuse: a continuation turn (reuse_kv && !reset_kv) keeps the
+        // existing cache and appends the delta; otherwise clear it and re-prefill
+        // the full prompt. add_bos only on a full prompt — a delta must not carry
+        // a BOS mid-conversation.
+        const bool full_prompt = gp.reset_kv || !gp.reuse_kv;
+        if (full_prompt) {
+            llama_memory_clear(llama_get_memory(ctx), true);
+        }
 
         const llama_vocab* vocab = llama_model_get_vocab(m_model.get());
 
         int32_t n_tokens =
             llama_tokenize(vocab, gp.prompt.c_str(), static_cast<int32_t>(gp.prompt.size()),
-                           nullptr, 0, true, false);
+                           nullptr, 0, full_prompt, false);
         if (n_tokens == INT32_MIN) {
             res.error_msg = "tokenize overflow";
             return res;
@@ -390,18 +404,26 @@ class LlamaSession final : public Session {
 
         std::vector<llama_token> tokens(static_cast<size_t>(n_tokens));
         n_tokens = llama_tokenize(vocab, gp.prompt.c_str(), static_cast<int32_t>(gp.prompt.size()),
-                                  tokens.data(), n_tokens, true, false);
+                                  tokens.data(), n_tokens, full_prompt, false);
         if (n_tokens < 0) {
             res.error_msg = "tokenize failed";
             return res;
         }
         tokens.resize(static_cast<size_t>(n_tokens));
 
+        // Prefill: positions continue automatically from the KV cache end, so a
+        // reuse turn appends after the retained context.
+        const auto t_prefill0 = std::chrono::steady_clock::now();
         llama_batch batch = llama_batch_get_one(tokens.data(), static_cast<int32_t>(tokens.size()));
-        if (llama_decode(ctx.get(), batch) != 0) {
+        if (llama_decode(ctx, batch) != 0) {
             res.error_msg = "prompt decode failed";
+            log_output("[xllama] session generate: prompt decode failed\n");
             return res;
         }
+        res.t_p_eval_ms =
+            std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_prefill0)
+                .count();
+        res.n_p_eval = static_cast<int>(tokens.size());
 
         const llama_sampler_chain_params sparams = llama_sampler_chain_default_params();
         LlamaSamplerPtr sampler(llama_sampler_chain_init(sparams));
@@ -416,12 +438,13 @@ class LlamaSession final : public Session {
 
         int n_generated = 0;
         bool stopped_by_seq = false;
+        const auto t_decode0 = std::chrono::steady_clock::now();
 
         while (n_generated < gp.n_predict) {
             if (gp.abort_flag && gp.abort_flag->load())
                 break;
 
-            llama_token token = llama_sampler_sample(sampler.get(), ctx.get(), -1);
+            llama_token token = llama_sampler_sample(sampler.get(), ctx, -1);
             if (llama_vocab_is_eog(vocab, token))
                 break;
 
@@ -441,18 +464,24 @@ class LlamaSession final : public Session {
             }
 
             llama_batch next = llama_batch_get_one(&token, 1);
-            if (llama_decode(ctx.get(), next) != 0) {
+            if (llama_decode(ctx, next) != 0) {
                 log_output("[xllama] session generate: decode failed, stopping\n");
                 break;
             }
             ++n_generated;
         }
 
+        res.t_eval_ms =
+            std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_decode0)
+                .count();
         res.n_eval = n_generated;
+        res.ended_with_stop = stopped_by_seq;
         res.success = true;
 
         char log_buf[256];
-        snprintf(log_buf, sizeof(log_buf), "[xllama] session generate: n=%d\n", n_generated);
+        snprintf(log_buf, sizeof(log_buf),
+                 "[xllama] session generate: n=%d prefill=%.1fms (%d tok) reuse=%d\n", n_generated,
+                 res.t_p_eval_ms, res.n_p_eval, gp.reuse_kv && !gp.reset_kv);
         log_output(log_buf);
 
         return res;

--- a/tests/test_routing_policy.cpp
+++ b/tests/test_routing_policy.cpp
@@ -84,7 +84,8 @@ TEST_CASE("capability gates") {
     CHECK(routing_allowed_for_kind(L"ort-genai"));
     CHECK_FALSE(routing_allowed_for_kind(L"gguf"));
     CHECK(kv_reuse_allowed_for_kind(L"ort-genai"));
-    CHECK_FALSE(kv_reuse_allowed_for_kind(L"gguf"));
+    // GGUF now supports KV reuse (persistent llama_context in LlamaSession).
+    CHECK(kv_reuse_allowed_for_kind(L"gguf"));
 }
 
 TEST_CASE("kv reuse: dml ep disabled") {

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -1070,7 +1070,9 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
     // them for ORT entries). Wired live on the model ComboBox.
     auto sync_backend_toggles = [kvToggle, routingBox, model_is_gguf](int idx) {
         bool gguf = idx >= 0 && idx < (int)model_is_gguf.size() && model_is_gguf[idx];
-        kvToggle.IsEnabled(!gguf);
+        // KV reuse works on GGUF now (persistent llama_context); only EP routing
+        // stays ORT-only (the llama.cpp UWP build is CPU-only).
+        kvToggle.IsEnabled(true);
         routingBox.IsEnabled(!gguf);
     };
     sync_backend_toggles(model_sel);
@@ -1874,9 +1876,12 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
     // (re)prefill the full prompt — which also (re)seeds the persistent generator.
     const std::string routed_model =
         ::xllama::wstring_to_utf8(m_active_model.empty() ? m_model_filename : m_active_model);
+    // KV reuse now works for both backends: ORT-GenAI (persistent generator) and
+    // GGUF/llama.cpp (persistent llama_context in LlamaSession). ep_kv_ok still
+    // excludes the DirectML routing model (continuous decoding unsupported there).
     const bool ep_kv_ok = ::xllama::kv_reuse_supported_for_model(routed_model);
-    bool do_reuse = m_kv_reuse && m_kv_valid && n_dropped == 0 && !base_is_gguf && ep_kv_ok;
-    bool kv_reuse = m_kv_reuse && !base_is_gguf && ep_kv_ok;
+    bool do_reuse = m_kv_reuse && m_kv_valid && n_dropped == 0 && ep_kv_ok;
+    bool kv_reuse = m_kv_reuse && ep_kv_ok;
     std::string delta_prompt = do_reuse ? BuildDeltaPrompt(user_text) : std::string();
 
     // Record user message in history AFTER building prompt (avoids duplicate)

--- a/uwp/inference-bridge.cpp
+++ b/uwp/inference-bridge.cpp
@@ -41,20 +41,8 @@ std::string read_local_file(const char* name) {
 // bench-kv-result.csv (+ .done) and logs the numbers.
 void run_kv_bench(const std::string& model_name, const std::string& sys, const std::string& u1,
                   const std::string& u2, int n_threads, const char* host) {
-    // KV-reuse bench is ORT GenAI specific (persistent generator + reuse_kv).
-    // GGUF / llama.cpp is stateless; guard early and produce a clear artifact.
-    if (::xllama::model_uses_llama_backend(model_name)) {
-        log_output("[xllama] kv-bench: skipping (GGUF model is stateless via llama.cpp)\n");
-        // Write a minimal .done so orchestrators do not hang.
-        FILE* done =
-            _wfopen(utf8_to_wstring(resolve_local_path("bench-kv-result.csv.done")).c_str(), L"w");
-        if (done) {
-            fputs("skipped-gguf\n", done);
-            fclose(done);
-        }
-        return;
-    }
-
+    // KV-reuse now works on both backends: ORT-GenAI (persistent generator) and
+    // GGUF/llama.cpp (persistent llama_context in LlamaSession). No early skip.
     std::string err;
     ::xllama::SessionParams sp;
     sp.model_path = model_name;


### PR DESCRIPTION
Tier 2 #4 — the last big backlog item. GGUF chat re-prefilled the whole conversation every turn because `LlamaSession` recreated the context each `generate()`.

## Change
- **session.cpp**: `m_ctx` is now a persistent member. reset/non-reuse clears the KV (`llama_memory_clear`) and re-prefills the full prompt (add_bos); a continuation turn appends only the delta (no BOS, positions continue from the cache). Also reports `t_p_eval_ms`/`n_p_eval`/`t_eval_ms`/`ended_with_stop` (were missing) so the kv-bench and UI decode-rate work for GGUF.
- **routing_policy.h**: `kv_reuse_allowed_for_kind` → true for `gguf`; test updated.
- **MainPage.cpp**: drop the `!base_is_gguf` gates; keep the KV toggle enabled for GGUF (routing stays ORT-only — llama.cpp UWP is CPU-only).
- **inference-bridge.cpp**: `run_kv_bench` no longer skips GGUF → on-console validation path.

## Validation
- Host: build + ctest green.
- Correctness: the delta contract is the one the `chat_prompt` KV-reuse **invariant test** already covers (render_delta + retained KV == cold re-prefill). Multi-turn coherence checked on host with a Session harness; **timing speedup measured on-console via kv-bench** (turn-2 prefill reuse vs cold) after merge.
- Gate: the UWP CI build here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled persistent KV-cache reuse across generation requests.
  * Added KV-cache reuse support for GGUF models.
  * Added timing and token metrics for prompt processing and generation.

* **Bug Fixes**
  * Improved tokenization and decoding error handling.
  * Prevented unnecessary beginning-of-sequence tokens during reused conversations.

* **Tests**
  * Updated capability checks and benchmarks to cover GGUF KV-cache reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->