### PR TITLE
models: gemma4-e2b default IQ2_M → Q3_K_S (fixes 2-bit EOG)

### DIFF
--- a/bench/results/phase6-gemma.csv
+++ b/bench/results/phase6-gemma.csv
@@ -1,3 +1,4 @@
 model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,host,date
 gemma3-270m,Q4_K_M,cpu,2048,6,394.98,76.78,368,1095,0,0,xbox-series-s-t6,2026-07-14T10:48:30Z
 gemma4-e2b,IQ2_M,cpu,2048,6,13.49,9.88,2534,6169,0,0,xbox-series-s-t6,2026-07-14T10:53:41Z
+gemma4-e2b,Q3_K_S,cpu,2048,6,26.12,15.31,2742,13837,0,0,xbox-series-s,2026-07-14T17:41:14Z

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -72,7 +72,12 @@ architectures load and generate on the pinned `llama.cpp` (`9a532ae4b`);
 | Model           | Params           | Quant  |    Size | Prefill tok/s | Decode tok/s | Peak RAM MB | Load ms |
 | --------------- | ---------------- | ------ | ------: | ------------: | -----------: | ----------: | ------: |
 | Gemma-3-270M-it | 270M             | Q4_K_M |  253 MB |         395.0 |     **76.8** |         368 |    1095 |
+| Gemma-4-E2B-it  | ~5B raw (2B eff) | Q3_K_S | 2.45 GB |          26.1 |     **15.3** |        2742 |   13837 |
 | Gemma-4-E2B-it  | ~5B raw (2B eff) | IQ2_M  | 2.29 GB |          13.5 |          9.9 |        2534 |    6169 |
+
+Catalogue default for `gemma4-e2b` is now **Q3_K_S** (was IQ2_M): it decodes
+faster (15.3 vs 9.9) and, crucially, generates full responses on long prompts
+where the 2-bit IQ2_M collapsed to an immediate EOG (see below).
 
 Both use the Gemma template on-device (log: `bench prompt: <start_of_turn>user
 …`). **Gemma-3-270M** is a fast, tiny chat model (76.8 tok/s, 368 MB).
@@ -114,10 +119,12 @@ question) — the correct response is to end the turn. Two amplifiers: (1) the
 **IQ2_M 2-bit quant** degrades the logits and inflates specific tokens incl. EOG;
 (2) gemma4 is better turn-calibrated than the tiny under-trained gemma3-270m,
 which rambles instead. Stochastic under temp 0.8 → sometimes the very first
-sample. **Not a bug.** Mitigation: bench decode with a _question/generative_
-prompt (done → **9.9 tok/s**), use a higher-bit quant (Q3_K_S 2.45 GB), or lower
-temperature. `standard-512.txt` is a poor decode probe for a well-calibrated
-instruct model.
+sample. **Not a bug.** Mitigation confirmed: **Q3_K_S (2.45 GB) fixes it** — on
+the exact same 280-token declarative prompt it generates a full 266-token
+response (15.3 tok/s) where IQ2_M produced 0 decode tokens. So the catalogue
+`gemma4-e2b` default is now Q3_K_S. (The 2-bit IQ2_M also works with
+question/generative prompts; `standard-512.txt` is just a poor decode probe for
+a well-calibrated instruct model at aggressive quant.)
 
 ### Gemma-4-E2B slow load (23.6 s cold → 6.2 s warm)
 

--- a/uwp/models/manifest.json
+++ b/uwp/models/manifest.json
@@ -105,15 +105,15 @@
       ]
     },
     {
-      "_comment": "Gemma-4-E2B (llama.cpp gemma4 arch). Console-validated 2026-07-14: loads (peak RAM 2534 MB, no OOM — the ~2GB Dev Mode per-file limit does not apply to GGUF), decode ~9.9 tok/s @ t6. Heavy/advanced: 2.29 GB IQ2_M, ~6-24s load (no mmap), a 512-token prompt at temp 0.8 can EOG immediately (2-bit); short prompts generate fine. Direct from HF (>2GB exceeds the GitHub release 2GB asset limit; Gemma Terms apply — verify before mirroring).",
+      "_comment": "Gemma-4-E2B (llama.cpp gemma4 arch). Console-validated 2026-07-14 with Q3_K_S (2.45 GB): peak RAM 2742 MB, decode ~15.3 tok/s, generates full responses on long prompts (266 tok). Upgraded from UD-IQ2_M (2.29 GB) — the 2-bit quant collapsed to an immediate EOG on ~512-token declarative prompts (0 decode tok); Q3_K_S fixes that and is faster. Heavy/advanced: >2GB (fine on GGUF — the ~2GB Dev Mode per-file limit does not apply). Direct from HF (>2GB exceeds the GitHub release 2GB asset limit; Gemma Terms apply — verify before mirroring).",
       "name": "gemma4-e2b",
-      "display": "Gemma 4 E2B (GGUF · CPU · 2.3 GB, advanced)",
+      "display": "Gemma 4 E2B (GGUF · CPU · 2.45 GB, advanced)",
       "kind": "gguf",
       "hf_base_url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main",
       "files": [
         {
-          "filename": "gemma-4-E2B-it-UD-IQ2_M.gguf",
-          "approx_bytes": 2290858112
+          "filename": "gemma-4-E2B-it-Q3_K_S.gguf",
+          "approx_bytes": 2445650048
         }
       ]
     },


### PR DESCRIPTION
Tier 3 #9, console-validated.

On the same 280-token declarative prompt that made **IQ2_M collapse to an immediate EOG** (0 decode tokens), **Q3_K_S generates a full 266-token response at 15.3 tok/s** (vs 9.9 for IQ2_M), peak RAM 2742 MB. The higher-bit quant is both faster and robust, so it becomes the `gemma4-e2b` catalogue default (2.45 GB, still direct-from-HF).

`phase6-gemma.csv` + `docs/benchmarks.md` updated (the EOG root-cause note's "use a higher-bit quant" mitigation is now confirmed). Docs/config + one CSV — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)