### PR TITLE
docs: GGUF KV-reuse console result (4.07× turn-2 prefill)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -285,6 +285,13 @@ validation gates, patched GenAI in XAML.
 
 Open items only — everything above is measured or shipped.
 
+- [x] **Perf + architecture backlog** (2026-07-14, PRs #53–#60). CI: `src/models`
+      wildcard + drift-check (no more per-bump LNK2001); unified stop-sequence
+      helper; bench `.done` verified-delete. Perf: **GGUF KV-reuse** (persistent
+      `llama_context`) — turn-2 prefill **4.07×** on gemma3-270m
+      (`phase6-gemma-kv.csv`); **gemma4-e2b → Q3_K_S** (fixes the 2-bit EOG,
+      15.3 tok/s). Investigated + reverted: AppContainer mmap (load is repack-bound,
+      not file-read-bound — no benefit). See `docs/benchmarks.md`.
 - [x] **Per-architecture chat template** — hard-coded ChatML replaced by a
       data-driven `ChatFormat` (`src/bridge/chat_prompt.cpp`, `chat_format_for()`);
       byte-identical ChatML preserved, Gemma (`<start_of_turn>…<end_of_turn>`)

--- a/bench/results/phase6-gemma-kv.csv
+++ b/bench/results/phase6-gemma-kv.csv
@@ -1,0 +1,2 @@
+model,prefill1_ms,n_p1,prefill2_reuse_ms,n_p2_reuse,prefill2_cold_ms,n_p2_cold,speedup,decode_tok_s,n_ctx,host,date
+gemma3-270m,113.4,44,107.5,39,437.4,179,4.07,83.94,2048,xbox-series-s,2026-07-14T17:52:58Z

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -35,18 +35,22 @@ Notes:
 - **Routing**: Auto switches SmolLM2-360M CPU → DML fp16 above a 600-token prompt
   (`routing_policy.h`), trading decode (70.9 → 46.8) for prefill (219 → 353).
 
-## KV-cache reuse (ORT-GenAI, CPU)
+## KV-cache reuse — both backends, CPU
 
-Turn-2 prefill with continuous decoding vs a cold full re-prefill
-(`phase35-kv.csv`, SmolLM2-360M):
+Turn-2 prefill with continuous decoding vs a cold full re-prefill. Both the
+ORT-GenAI path (persistent generator) and the GGUF/llama.cpp path (persistent
+`llama_context`, `LlamaSession`) reuse the cache and append only the new turn's
+delta:
 
-|                        | Prefill turn-2 (ms) | Tokens |   Speedup |
-| ---------------------- | ------------------: | -----: | --------: |
-| Reuse (delta only)     |               103.7 |     22 | **4.87×** |
-| Cold (full re-prefill) |               505.2 |    114 |         — |
+| Backend / model                              | Reuse turn-2 (ms) | Cold turn-2 (ms) |   Speedup |
+| -------------------------------------------- | ----------------: | ---------------: | --------: |
+| ORT-GenAI · SmolLM2-360M (`phase35-kv`)      |    103.7 (22 tok) |  505.2 (114 tok) | **4.87×** |
+| llama.cpp · Gemma-3-270M (`phase6-gemma-kv`) |    107.5 (39 tok) |  437.4 (179 tok) | **4.07×** |
 
-KV-reuse is ORT-GenAI-only and CPU-only (DirectML rejects continuous decoding;
-GGUF/llama.cpp is stateless on-console).
+GGUF KV-reuse was previously disabled (llama.cpp recreated the context per turn);
+now enabled and console-measured. Routing (CPU↔GPU) stays ORT-only — the
+llama.cpp UWP build is CPU-only. DirectML still rejects continuous decoding, so
+the ORT reuse path is CPU-only.
 
 ## Diffusion — SD-Turbo fp16 (on-console, DirectML)
 

--- a/uwp/models/manifest.json
+++ b/uwp/models/manifest.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Model catalogue for xllama. Bundled at InstalledPath\\models\\manifest.json; a LocalState\\manifest.json (uploadable via Device Portal, no reinstall) is merged per entry: same-name entries replace bundled ones, new names are appended, unmentioned bundled entries stay. Entries without hf_base_url are USB/Device-Portal-provisioned only. approx_bytes drives the download progress bar. kind: 'ort-genai' (default, chat picker, ORT backend), 'diffusion' (image dialog), or 'gguf' (chat picker, llama.cpp backend — CPU-only, KV-reuse/routing disabled). files[].filename is the local path under models\\<name> (subdirs allowed); files[].remote is the flat asset name in the release (defaults to filename). TAESD VAE (optional, Image dialog toggle): models-v1 asset sd-turbo-fp16_taesd_vae_decoder_model.onnx — export via diffusion/export_taesd.py.",
+  "_comment": "Model catalogue for xllama. Bundled at InstalledPath\\models\\manifest.json; a LocalState\\manifest.json (uploadable via Device Portal, no reinstall) is merged per entry: same-name entries replace bundled ones, new names are appended, unmentioned bundled entries stay. Entries without hf_base_url are USB/Device-Portal-provisioned only. approx_bytes drives the download progress bar. kind: 'ort-genai' (default, chat picker, ORT backend), 'diffusion' (image dialog), or 'gguf' (chat picker, llama.cpp backend — CPU-only, KV-reuse enabled via a persistent llama_context, routing disabled). files[].filename is the local path under models\\<name> (subdirs allowed); files[].remote is the flat asset name in the release (defaults to filename). TAESD VAE (optional, Image dialog toggle): models-v1 asset sd-turbo-fp16_taesd_vae_decoder_model.onnx — export via diffusion/export_taesd.py.",
   "models": [
     {
       "name": "smollm2-360m-cpu-int4",
@@ -92,7 +92,7 @@
       ]
     },
     {
-      "_comment": "Gemma-3-270M GGUF (llama.cpp gemma3 arch, verified loads on the pinned submodule). Downloaded directly from the original Hugging Face repo (hf_base_url → resolve/main) rather than re-hosted on our release: Gemma Terms of Use govern redistribution — verify before ever mirroring the weights onto models-v1. Uses the <start_of_turn>/<end_of_turn> template via chat_format_for (kind:gguf, CPU-only, KV-reuse/routing disabled).",
+      "_comment": "Gemma-3-270M GGUF (llama.cpp gemma3 arch, verified loads on the pinned submodule). Downloaded directly from the original Hugging Face repo (hf_base_url → resolve/main) rather than re-hosted on our release: Gemma Terms of Use govern redistribution — verify before ever mirroring the weights onto models-v1. Uses the <start_of_turn>/<end_of_turn> template via chat_format_for (kind:gguf, CPU-only, KV-reuse enabled, routing disabled).",
       "name": "gemma3-270m",
       "display": "Gemma 3 270M (GGUF · CPU)",
       "kind": "gguf",


### PR DESCRIPTION
Records the on-console validation of #59 (GGUF KV-reuse).

kv-bench (MSIX 1.1.6.452, `phase6-gemma-kv.csv`): **gemma3-270m turn-2 prefill reuse 107.5 ms (39 tok) vs cold 437.4 ms (179 tok) = 4.07×** — matching the ORT path's 4.87×. GGUF KV-reuse was previously disabled (llama.cpp recreated the context per turn); now enabled and measured.

- `benchmarks.md` KV-reuse section now covers both backends.
- manifest comments: gguf is no longer "KV-reuse disabled".
- ROADMAP Phase 6: perf+arch backlog summary (PRs #53–#60).

Docs + one CSV — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)