### PR TITLE
docs: consolidate onto SSOTs + fix stale/duplicated content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **GGUF KV-cache reuse** — `LlamaSession` keeps a persistent `llama_context`, so
+  a continuation turn appends only the new turn's delta instead of re-prefilling
+  the whole conversation. Console-measured **4.07×** turn-2 prefill on gemma3-270m
+  (`bench/results/phase6-gemma-kv.csv`); previously GGUF was stateless. Enabled in
+  the Settings KV toggle (routing stays ORT-only — llama.cpp UWP is CPU-only).
+- **CI: `src/models/*.cpp` MSBuild wildcard** in `ggml-uwp.vcxproj` + a
+  `scripts/check-uwp-sources.sh` drift-check — new llama.cpp architectures no
+  longer break the UWP link on a submodule bump (as `657e011` did).
+
+### Changed
+
+- **`gemma4-e2b` catalogue default: UD-IQ2_M → Q3_K_S** (2.45 GB). Console-measured
+  15.3 tok/s and generates full responses on long declarative prompts, where the
+  2-bit IQ2_M collapsed to an immediate EOG. See `docs/benchmarks.md`.
+- **llama.cpp submodule bumped to `657e011`** (was `9a532ae4b`); `ggml-uwp.vcxproj`
+  gained the new per-arch sources.
+- **Stop-sequence handling unified** into one suffix-match helper
+  (`apply_stop_sequences`, `chat_prompt`) shared by the llama and ORT decode loops.
+- **`scripts/install-latest-build.sh`**: `bench.flag` is now `--bench` opt-in — a
+  plain install launches into the UI.
+- Consolidated documentation onto single-source-of-truth docs (perf →
+  `benchmarks.md`, constraints → `uwp-constraints.md`, catalogue →
+  `model-selection.md` + `manifest.json`); refreshed stale version/quant/KV claims.
+
+### Fixed
+
+- `scripts/bench-xbox-ort.sh`: verify `bench-result.csv.done` is actually deleted
+  before a run, so `wait_for_done` can't return off a stale marker (silent wrong row).
+
+### Investigated (no change shipped)
+
+- **AppContainer file mmap** (`CreateFileMappingFromApp`/`MapViewOfFileFromApp`,
+  with a loader fallback): built and deployed, but **no measured benefit** —
+  GGUF load on CPU is dominated by the AVX2 tensor repack, not the file read.
+  Reverted; finding recorded in `docs/benchmarks.md`.
+
 ---
 
 ## [1.1.6.0] - 2026-07-14

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![build-linux](https://github.com/gianlucamazza/xllama/actions/workflows/build-linux.yml/badge.svg)](https://github.com/gianlucamazza/xllama/actions/workflows/build-linux.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-**Status:** v1.1.5.0 shipping (unified + PatchedGenAI) · research-grade
+**Status:** shipping (unified + PatchedGenAI) · research-grade — current version in [CHANGELOG](CHANGELOG.md) / [ROADMAP](ROADMAP.md)
 **Maintainer:** [Venere Labs](https://github.com/gianlucamazza)
 
 ---
@@ -87,7 +87,14 @@ See [docs/install-release.md](./docs/install-release.md) to install a tagged rel
 - **Accessible Dev Mode**: one-time ~$19 activation via Partner Center unlocks unsigned UWP deployment.
 - **Underexplored**: no prior LLM port to the platform at time of writing.
 
-**Measured performance (Xbox Series S, 2026-07-08):** chat decode **66.3 tok/s** (CPU int4, SmolLM2-360M, ORT GenAI 0.14.1); prefill at ~1k prompt tokens **354 tok/s on GPU fp16** vs 198 CPU (the crossover that motivates routing); KV-cache reuse makes turn-2 prefill **4.87×** faster; SD-Turbo generates a 512×512 image in **~6.9 s** on DirectML. Full matrices: `bench/results/` and [docs/technical-report.md](./docs/technical-report.md).
+**Measured performance (Xbox Series S):** fastest chat decode **94.2 tok/s**
+(LFM2.5-350M GGUF); the shipped default SmolLM2-360M int4 runs ~66–71 tok/s; Gemma
+models run on-device (Gemma-3-270M **76.8 tok/s**); prefill at ~1k tokens is
+**354 tok/s on GPU fp16** vs 198 CPU (the crossover that motivates routing);
+KV-cache reuse makes turn-2 prefill ~**4×** faster on **both** backends; SD-Turbo
+draws a 512×512 image in **~6.9 s** on DirectML. **The full, disambiguated tables
+are the single source of truth in [docs/benchmarks.md](./docs/benchmarks.md)**
+(with [comparative charts](./docs/benchmarks-charts.html)).
 
 ---
 
@@ -230,17 +237,22 @@ No model upload is required: the app downloads the default model on first launch
 
 Models come from the catalogue `uwp/models/manifest.json` (assets hosted on the [`models-v1` GitHub Release](https://github.com/gianlucamazza/xllama/releases/tag/models-v1)): the app downloads any catalogue entry on demand, with the default chat model fetched on first launch. A `LocalState\manifest.json` uploaded via Device Portal is merged per-entry into the catalogue without a reinstall — see [docs/model-selection.md](./docs/model-selection.md) for adding your own model.
 
-| Model                          | Format        | Size    | Xbox UWP | Notes                                                            |
-| ------------------------------ | ------------- | ------- | -------- | ---------------------------------------------------------------- |
-| SmolLM2-360M-Instruct INT4 CPU | ONNX GenAI    | 417 MB  | ✅       | Default; decode 66.3 tok/s                                       |
-| SmolLM2-360M-Instruct fp16 DML | ONNX GenAI    | ~700 MB | ✅       | Routing target (prefill 354 tok/s @1k)                           |
-| SD-Turbo fp16 (image)          | ONNX DirectML | 2.4 GB  | ✅       | 512×512 in ~6.9 s ([diffusion/README.md](./diffusion/README.md)) |
-| SmolLM2-1.7B-Instruct INT4 CPU | ONNX GenAI    | 1.4 GB  | ✅       | Measured 20.6 tok/s                                              |
-| Qwen3.5-0.8B Q4_K_M            | GGUF          | 508 MB  | ✅       | `unified` builds (llama.cpp); decode 35.1 tok/s                  |
-| LFM2.5-350M Q4_K_M             | GGUF          | 219 MB  | ✅       | `unified` builds (llama.cpp); decode 94.2 tok/s                  |
-| Phi-3.5-mini CPU INT4          | ONNX GenAI    | ~2.7 GB | ❌       | GPU OOM history + >2 GB single-file ONNX (see constraints §8)    |
+Catalogue overview (roles + sizes; **decode/prefill/RAM numbers live in
+[docs/benchmarks.md](./docs/benchmarks.md)**, the perf SSOT):
 
-Numbers are measured on Xbox Series S Dev Mode. See [docs/uwp-constraints.md](./docs/uwp-constraints.md) for the measured GPU budget (3801 MB), the disk budget, and the `weakly_canonical` AppContainer workaround.
+| Model                      | Format        | Size    | Xbox UWP | Role                                                     |
+| -------------------------- | ------------- | ------- | -------- | -------------------------------------------------------- |
+| SmolLM2-360M-Instruct INT4 | ONNX GenAI    | 417 MB  | ✅       | Default chat (CPU); routing base                         |
+| SmolLM2-360M fp16 DML      | ONNX GenAI    | ~700 MB | ✅       | Routing target (long-prompt prefill on GPU)              |
+| SmolLM2-1.7B-Instruct INT4 | ONNX GenAI    | 1.4 GB  | ✅       | Larger CPU chat (USB/LocalState)                         |
+| LFM2.5-350M Q4_K_M         | GGUF          | 219 MB  | ✅       | Default chat on `unified` builds; fastest+lightest       |
+| Qwen3.5-0.8B Q4_K_M        | GGUF          | 508 MB  | ✅       | `unified` builds (llama.cpp)                             |
+| Gemma-3-270M Q4_K_M        | GGUF          | 253 MB  | ✅       | `unified` builds; fast, tiny                             |
+| Gemma-4-E2B Q3_K_S         | GGUF          | 2.45 GB | ✅       | `unified` builds; heavy/advanced                         |
+| SD-Turbo fp16 (image)      | ONNX DirectML | 2.4 GB  | ✅       | Image gen ([diffusion/README.md](./diffusion/README.md)) |
+| Phi-3.5-mini CPU INT4      | ONNX GenAI    | ~2.7 GB | ❌       | Not attempted (>2 GB single-file ONNX, §8)               |
+
+See [docs/uwp-constraints.md](./docs/uwp-constraints.md) for the measured GPU budget (3801 MB), the disk budget, and AppContainer workarounds.
 
 ---
 
@@ -266,7 +278,7 @@ See [ROADMAP.md](./ROADMAP.md). Headlines:
 3. **Phase 3 / 3.5 — Benchmarks + hardware ceiling** ✅ Measured matrices, routing, KV reuse, llama.cpp A/B (parity), diffusion on console.
 4. **Phase 4 — In-app model download + publication** ✅ Catalogue download, v1.0.0 release, technical report (demo video pending).
 5. **Phase 5 — Post-1.0 improvements** ✅ Unified+PatchedGenAI shipping; console gates ALL PASS.
-6. **Phase 6 — Publication + polish** 🔮 Demo video, optional catalogue assets (see [ROADMAP.md](./ROADMAP.md)).
+6. **Phase 6 — Publication + polish** 🔮 Shipped: per-architecture chat template, **Gemma** (gemma3-270m, gemma4-e2b Q3_K_S), **GGUF KV-reuse** (4.07×), automated MSIX versioning + repo automation. Open: demo video, publication venue (see [ROADMAP.md](./ROADMAP.md)).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,8 @@
 **Shipping (2026-07-14):** MSIX **1.1.6.x** — `xllama-appx` from `build-uwp.yml`
 (unified ORT + llama.cpp + PatchedGenAI #2280; Revision auto-stamped from the CI
 run number). Adds the per-architecture chat template + **Gemma** (`gemma3-270m`
-76.8 tok/s, `gemma4-e2b` 9.9 tok/s — console-validated, `phase6-gemma.csv`).
+76.8 tok/s, `gemma4-e2b` Q3_K_S 15.3 tok/s — console-validated, `phase6-gemma.csv`)
+and GGUF **KV-reuse** (turn-2 prefill 4.07×). Full numbers: `docs/benchmarks.md`.
 Prior console gates still pass: `validate-console.sh all` → **ALL PASS** (routing,
 GGUF `lfm25-350m`, TAESD). Catalogue `models-v1` includes `smollm2-360m-dml-fp16`
 (~691 MB merged) for in-app routing-GPU download. See
@@ -154,7 +155,7 @@ Milestones:
       Catalogue entry + `package-catalogue-ort-model.sh` ready; **1.4 GB asset
       upload to `models-v1` optional** (WDP works today). **fp16-DML 1.7B blocked**
       (protobuf > 2 GB — cannot merge self-contained; external data hits §8).
-      int4-DML 1.7B is mergeable but hits the §12 dead kernel. The fp16-at-scale
+      int4-DML 1.7B is mergeable but hits the §12 non-fused low-bit GEMM. The fp16-at-scale
       bandwidth crossover stays blocked by serialization/AppContainer, not GPU.
 - [x] **Desk check upstream int4 status** — ✅ done 2026-07-08
       (`docs/uwp-constraints.md §12`). Verdict: `MatMulNBits` is present and runs
@@ -238,7 +239,8 @@ validation gates, patched GenAI in XAML.
       `bench/configs/settings-modern.json`.
 - [x] **Interactive validations** — autopilot + `validate-console.sh all` →
       **ALL PASS** on console 2026-07-14 (routing, GGUF `lfm25-350m`, TAESD §7c).
-      Shipping MSIX **1.1.5.0** (unified + PatchedGenAI) CI-green and deployed.
+      Shipping MSIX at the time was **1.1.5.0** (unified + PatchedGenAI), CI-green
+      and deployed; current shipping version is in the header above.
 - [x] Closure benches: int4 `block_size=128` / `accuracy_level=4` (§12
       confirm/refute) — closed inconclusive (PR #29, §12 stands)
 - [x] Fase 2: catalogue `kind:gguf` → `sp.backend`, gate KV-reuse/routing off
@@ -299,9 +301,9 @@ Open items only — everything above is measured or shipped.
 - [x] **Gemma family — console-validated** (MSIX 1.1.6.x, `phase6-gemma.csv`).
       Vendored `llama.cpp` carries `gemma3` + `gemma4`; catalogue entries
       `gemma3-270m` and `gemma4-e2b`. On Xbox Series S: **gemma3-270m** 76.8 tok/s
-      decode (368 MB); **gemma4-e2b** (2.29 GB IQ2_M) loads at 2534 MB RAM and
-      decodes 9.9 tok/s. **The "Gemma-4 too big" verdict is overturned** — the
-      ~2 GB Dev Mode per-file limit does not apply to GGUF (a 2.29 GB single file
+      decode (368 MB); **gemma4-e2b** (2.45 GB Q3_K_S) loads at 2742 MB RAM and
+      decodes 15.3 tok/s. **The "Gemma-4 too big" verdict is overturned** — the
+      ~2 GB Dev Mode per-file limit does not apply to GGUF (a >2 GB single file
       loads). See `docs/benchmarks.md` (incl. root-cause notes on the negative
       performers).
 - [x] **Benchmark report + comparative charts** — `docs/benchmarks.md` +

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,14 @@
 
 Technical notes and design decisions for xllama.
 
+**Single sources of truth (SSOT)** — each fact has one authoritative home; other
+docs quote a headline and link back:
+
+- **Performance numbers** → [benchmarks.md](./benchmarks.md)
+- **Model catalogue + backend selection** → [model-selection.md](./model-selection.md) (narrative) + [`../uwp/models/manifest.json`](../uwp/models/manifest.json) (data)
+- **UWP/AppContainer constraints** (§1–§12) → [uwp-constraints.md](./uwp-constraints.md)
+- **Version / current state** → [../CHANGELOG.md](../CHANGELOG.md) + [../ROADMAP.md](../ROADMAP.md)
+
 | Document                                                         | Description                                                                                                               |
 | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | [install-release.md](./install-release.md)                       | Install a tagged GitHub Release build on your Xbox (cert + VCLibs + MSIX)                                                 |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,10 +1,21 @@
 # Benchmarks
 
+> **This is the single source of truth (SSOT) for xllama performance numbers.**
+> Decode/prefill/RAM/load figures live here; other docs (README, ROADMAP,
+> technical-report, model-selection, recommended-config) quote at most a headline
+> value and link back to this file.
+
 Consolidated performance data for every model xllama has run. Unless noted, all
 figures are **measured on Xbox Series S in Dev Mode** (the target device) and
 come from the CSVs in `bench/results/`. Host-dev figures (Intel i7-1165G7,
 Linux) are called out separately and are **not** comparable to console numbers —
 they exist only to sanity-check a model loads and generates.
+
+**On the SmolLM2-360M CPU int4 decode number** (it appears elsewhere as 66.3,
+68.0 or 70.9 — same model, different runs): **70.9** is the best control run
+(`phase2-dml`); **66.3** is the ORT-GenAI 0.14.1 shipping config; **68.0 / 50.9**
+are the v0.3.6 utilization-matrix short/long-prompt runs. When in doubt, the table
+below is authoritative.
 
 Metrics: **prefill** = prompt tok/s (throughput ingesting the prompt), **decode**
 = generation tok/s (autoregressive, the number a user feels), **peak RAM** =
@@ -86,14 +97,15 @@ where the 2-bit IQ2_M collapsed to an immediate EOG (see below).
 Both use the Gemma template on-device (log: `bench prompt: <start_of_turn>user
 …`). **Gemma-3-270M** is a fast, tiny chat model (76.8 tok/s, 368 MB).
 
-**Gemma-4-E2B verdict — the "too big" call is overturned:**
+**Gemma-4-E2B verdict — the "too big" call is overturned** (shipping default is
+**Q3_K_S**, 15.3 tok/s / 2742 MB; the IQ2_M row above is the earlier 2-bit build):
 
-- ✅ **The ~2 GB Dev Mode per-file limit does not apply to GGUF** — a 2.29 GB
-  single `.gguf` uploaded via Device Portal and loaded; **peak RAM 2534 MB**, no
-  OOM under the Game budget. (This was the project's main open unknown.)
-- ✅ Generates at **9.9 tok/s** @ t6 — faster than the i7-1165G7 host (3.8).
-- ⚠️ Load is slow (6–24 s, 2.3 GB heap read, `use_mmap=false`); a ~512-token
-  prompt at temp 0.8 can EOG immediately (2-bit) — short prompts generate fine.
+- ✅ **The ~2 GB Dev Mode per-file limit does not apply to GGUF** — a >2 GB single
+  `.gguf` loads with no OOM under the Game budget. (This was the project's main
+  open unknown.)
+- ✅ Generates coherently on-device, faster than the i7-1165G7 host.
+- ⚠️ Load is a few seconds — **repack-bound, not file-read-bound** (see the mmap
+  note below); a smaller quant is the only real load lever.
 
 Disk was never the constraint (Dev Mode is 90 GB). E4B/12B+ stay out of scope on
 size/speed. Catalogue entry `gemma4-e2b` (downloads from HF; 2.29 GB exceeds the

--- a/docs/console-validation-runbook.md
+++ b/docs/console-validation-runbook.md
@@ -3,8 +3,10 @@
 On-console checks for merged, CI-green work (merge-on-CI-green policy). Most of the
 Phase 3.5 batch was **measured 2026-07-08** (§1, §3, §4, §6-CPU, §7 below carry their
 results). **§2 routing** and **§7c TAESD** were **measured 2026-07-14** via
-`validate-console.sh` (autopilot, no pad). Still open: §5b int4 rebuild variants
-(inconclusive 2026-07-09). §7b in-process diffusion was **PASS 2026-07-09**.
+`validate-console.sh` (autopilot, no pad); the same day added **Gemma** (gemma3-270m,
+gemma4-e2b Q3_K_S) and **GGUF KV-reuse** (4.07×) — see `docs/benchmarks.md`.
+§5b int4 rebuild variants were **closed inconclusive 2026-07-09** (not a lever).
+§7b in-process diffusion was **PASS 2026-07-09**.
 
 This runbook batches all of them into **one Xbox session**. Each step writes a CSV/artifact
 fetched via Device Portal, with an explicit sanity gate. Mechanics (deploy, WDP quirks,

--- a/docs/install-release.md
+++ b/docs/install-release.md
@@ -59,14 +59,16 @@ downloads the default chat model (~417 MB) with a progress bar, then opens the
 chat. See [using-the-app.md](./using-the-app.md) from here.
 
 For image generation, the SD-Turbo model (2.4 GB) is downloaded from the
-catalogue on the first **Generate** — mind the Dev Mode disk budget
-(~2.2–2.5 GB free total). Device Portal provisioning remains available
+catalogue on the first **Generate** — mind the Dev Mode disk budget (~2.2–2.5 GB
+free by default, **expandable to 90 GB** via Dev Home → Manage Dev Storage; see
+[uwp-constraints.md §9](uwp-constraints.md)). Device Portal provisioning remains available
 ([../diffusion/README.md](../diffusion/README.md), runbook §7).
 
 ## Troubleshooting
 
 - `0x80070070` (disk full) while installing models: the Dev Mode partition has
-  ~2.2–2.5 GB free in total — remove unused models from LocalState first.
+  ~2.2–2.5 GB free by default — remove unused models from LocalState, or raise the
+  Dev Mode allocation (up to 90 GB, `uwp-constraints.md §9`).
 - Startup issues: `./scripts/deploy.sh diagnose-startup` prints the process
   state, the app log, and any crash dumps in one shot.
 - Log at any time: `./scripts/deploy.sh get-log`; individual files:

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -1,7 +1,13 @@
 # Model Selection Checklist
 
-Operational criteria for choosing or evaluating an ONNX GenAI model for the
-xllama UWP build (Xbox Series S Dev Mode, CPU EP).
+> **SSOT for the model catalogue and backend selection.** The catalogue data
+> lives in [`uwp/models/manifest.json`](../uwp/models/manifest.json); this file
+> is the narrative source of truth for limits, licensing, backend routing, and
+> "add your own model". Performance numbers live in [`benchmarks.md`](benchmarks.md).
+
+Operational criteria for choosing or evaluating a model for the xllama UWP build
+(Xbox Series S Dev Mode). Covers both backends — ONNX Runtime GenAI (CPU/DirectML)
+and llama.cpp (GGUF, CPU).
 
 ## Hard limits (must pass)
 
@@ -9,7 +15,7 @@ xllama UWP build (Xbox Series S Dev Mode, CPU EP).
 | --------------------------------------- | --------------------------------------------------------------------------- | ---------------------------- |
 | Format                                  | ONNX GenAI directory (`genai_config.json` + `model.onnx` + tokenizer files) | ORT GenAI 0.14.1 requirement |
 | External data files                     | Must be merged into a self-contained `model.onnx` before distribution       | `uwp-constraints.md §8`      |
-| On-disk size (merged ONNX)              | Dev Mode disk budget: ~2.2–2.5 GB free total across all models              | `uwp-constraints.md §9`      |
+| On-disk size (merged ONNX)              | ~2.2–2.5 GB free by default (**expandable to 90 GB**, so rarely binding)    | `uwp-constraints.md §9`      |
 | GPU EP weights (if attempting DirectML) | < ~300 MB                                                                   | `uwp-constraints.md §5`, §7  |
 
 ## Selection sequence
@@ -31,7 +37,8 @@ xllama UWP build (Xbox Series S Dev Mode, CPU EP).
 
    The script prints a `NOTE` or `WARNING` if the merged size exceeds budget thresholds.
 
-4. Check on-disk size against the Dev Mode disk budget (~2.2–2.5 GB free total):
+4. Check on-disk size against the Dev Mode disk budget (~2.2–2.5 GB free by
+   default, expandable to 90 GB — `uwp-constraints.md §9`):
 
    ```bash
    du -sm models/<name>
@@ -161,18 +168,18 @@ contract is different (three components + CLIP assets): see `diffusion/README.md
 The ORT GenAI model builder is frozen at the Qwen3 / Gemma3 architectures.
 Newer small models (Qwen3.5, LFM2, Gemma-4) ship as GGUF and run **only via
 llama.cpp** — reachable via the shipping `unified` backend build with
-`kind: gguf` catalogue entries. **Console-measured**: Qwen3.5-0.8B 35.1 /
-LFM2.5-350M 94.2 tok/s (`phase5-gguf.csv`); Gemma-3-270M 76.8 / Gemma-4-E2B
-9.9 tok/s (`phase6-gemma.csv`).
+`kind: gguf` catalogue entries. All are console-measured — **decode/prefill/RAM
+numbers live in [`benchmarks.md`](benchmarks.md)** (the perf SSOT); this table is
+the catalogue status only.
 
-| Model            | Path      | Size (Q4_K_M / int4) | Status                                                                   |
-| ---------------- | --------- | -------------------- | ------------------------------------------------------------------------ |
-| Qwen3.5-0.8B     | llama.cpp | 507 MB               | ✅ loads+generates via submodule (`qwen35`); modern default candidate    |
-| LFM2.5-350M      | llama.cpp | 218 MB               | ✅ loads via submodule; hybrid edge arch                                 |
-| Qwen3-0.6B       | ORT GenAI | 969 MB merged        | ✅ builds; heavy (151k-vocab embedding dominates)                        |
-| Gemma-3-270M     | llama.cpp | 253 MB               | ✅ loads+generates via GGUF (`gemma3-270m`); catalogue entry added, fits |
-| Gemma-4-E2B      | llama.cpp | 2.29 GB (IQ2_M)      | ✅ **console-validated** (`gemma4-e2b`): loads, ~9.9 tok/s (see below)   |
-| Gemma-4 E4B/12B+ | llama.cpp | ≥4.5 GB              | ⛔ too big / too slow for the console                                    |
+| Model            | Path      | Disk size        | Status                                                             |
+| ---------------- | --------- | ---------------- | ------------------------------------------------------------------ |
+| Qwen3.5-0.8B     | llama.cpp | 507 MB           | ✅ `qwen35-0.8b` — modern default candidate                        |
+| LFM2.5-350M      | llama.cpp | 218 MB           | ✅ `lfm25-350m` — hybrid edge arch; default chat on unified builds |
+| Qwen3-0.6B       | ORT GenAI | 969 MB merged    | ✅ builds; heavy (151k-vocab embedding dominates)                  |
+| Gemma-3-270M     | llama.cpp | 253 MB           | ✅ `gemma3-270m` — fast, tiny, fits easily                         |
+| Gemma-4-E2B      | llama.cpp | 2.45 GB (Q3_K_S) | ✅ **console-validated** `gemma4-e2b` (see verdict below)          |
+| Gemma-4 E4B/12B+ | llama.cpp | ≥4.5 GB          | ⛔ too big / too slow for the console                              |
 
 **Gemma chat template**: the ORT GenAI _builder_ is frozen at Gemma3, but the
 vendored `llama.cpp` (`9a532ae4b`) already carries `LLM_ARCH_GEMMA3` **and**
@@ -183,18 +190,18 @@ now selects the Gemma template (`<start_of_turn>…<end_of_turn>`, no system rol
 stop `<end_of_turn>`, `<bos>` via `add_bos`) by model id, so any `gemma*` GGUF
 gets the right template with zero per-model code.
 
-**Gemma-4-E2B verdict** (console-validated 2026-07-14, MSIX 1.1.6.0): the "too
-big" call is **overturned**. E2B is ~5B raw params (2B effective, MatFormer);
-UD-IQ2_M is 2.29 GB. Measured on Xbox Series S Dev Mode:
+**Gemma-4-E2B verdict** (console-validated 2026-07-14): the "too big" call is
+**overturned**. E2B is ~5B raw params (2B effective, MatFormer). Key findings
+(full numbers in [`benchmarks.md`](benchmarks.md)):
 
-- ✅ **The ~2 GB Dev Mode per-file limit does not apply to GGUF** — a 2.29 GB
-  single `.gguf` uploaded via Device Portal and loaded; **peak RAM 2534 MB**, no
-  OOM under the Game budget.
-- ✅ **Generates**: decode **9.9 tok/s** @ t6 (faster than the i7-1165G7 host's
-  3.8), coherent short answers ending on `<end_of_turn>`.
-- ⚠️ **Load is slow**: 6–24 s (2.3 GB heap read, `use_mmap=false`).
-- ⚠️ A ~512-token prompt at temp 0.8 can emit EOG immediately (2-bit quant);
-  short prompts generate normally. A Q3_K_S (2.45 GB) would trade size for quality.
+- ✅ **The ~2 GB Dev Mode per-file limit does not apply to GGUF** — a >2 GB single
+  `.gguf` loads with no OOM under the Game budget.
+- ✅ **Generates coherently** and stops on `<end_of_turn>`.
+- ⚠️ **Load is slow** (a few seconds; the CPU load is repack-bound, not
+  file-read-bound — mmap does not help, see `benchmarks.md`).
+- The catalogue default is **Q3_K_S (2.45 GB)**, not the smaller 2-bit UD-IQ2_M:
+  IQ2_M collapsed to an immediate EOG on long declarative prompts, which Q3_K_S
+  fixes (and it decodes faster). Details in `benchmarks.md` root-cause notes.
 
 Disk was never the real constraint (Dev Mode is now 90 GB, `uwp-constraints.md §9`).
 Catalogue entry `gemma4-e2b` downloads from HF (2.29 GB > the GitHub release 2 GB

--- a/docs/recommended-config.md
+++ b/docs/recommended-config.md
@@ -23,21 +23,24 @@ Upstream: [microsoft/onnxruntime-genai#2280](https://github.com/microsoft/onnxru
 
 ## UWP build variants
 
-| Variant            | CI artifact / command                    | When to use                        |
-| ------------------ | -------------------------------------- | ---------------------------------- |
+| Variant                      | CI artifact / command              | When to use                              |
+| ---------------------------- | ---------------------------------- | ---------------------------------------- |
 | **unified+#2280** (shipping) | `xllama-appx` from `build-uwp.yml` | Default: GGUF + ORT, routing GPU in XAML |
-| **llamacpp**       | `xllama-appx-llamacpp`                 | Bench A/B only — not for end users |
+| **llamacpp**                 | `xllama-appx-llamacpp`             | Bench A/B only — not for end users       |
 
 ## Chat models
 
-| Use case             | Catalogue `name`        | Backend               | Measured decode                          |
-| -------------------- | ----------------------- | --------------------- | ---------------------------------------- |
-| **Default (unified)**| `lfm25-350m`            | llama.cpp (`unified`) | **94.2 tok/s** (recommended)             |
-| **ORT default**      | `smollm2-360m-cpu-int4` | ORT CPU int4          | ~66 tok/s                                |
-| **Routing GPU**      | `smollm2-360m-dml-fp16` | ORT DML fp16          | ~47 tok/s decode; ~354 tok/s prefill @1k |
-| **Larger chat**      | `smollm2-1.7b-cpu-int4` | ORT CPU int4          | ~21 tok/s (USB / 90 GB disk)             |
-| **Modern GGUF**      | `qwen35-0.8b`           | llama.cpp (`unified`) | 35.1 tok/s (98.1 prefill, t6)            |
-| **Fast modern GGUF** | `lfm25-350m`            | llama.cpp (`unified`) | 94.2 tok/s (241.4 prefill, t6)           |
+The decode figures below are rough guidance; the authoritative, disambiguated
+tables are in [benchmarks.md](benchmarks.md) (the perf SSOT).
+
+| Use case              | Catalogue `name`        | Backend               | Measured decode                          |
+| --------------------- | ----------------------- | --------------------- | ---------------------------------------- |
+| **Default (unified)** | `lfm25-350m`            | llama.cpp (`unified`) | **94.2 tok/s** (recommended)             |
+| **ORT default**       | `smollm2-360m-cpu-int4` | ORT CPU int4          | ~66 tok/s                                |
+| **Routing GPU**       | `smollm2-360m-dml-fp16` | ORT DML fp16          | ~47 tok/s decode; ~354 tok/s prefill @1k |
+| **Larger chat**       | `smollm2-1.7b-cpu-int4` | ORT CPU int4          | ~21 tok/s (USB / 90 GB disk)             |
+| **Modern GGUF**       | `qwen35-0.8b`           | llama.cpp (`unified`) | 35.1 tok/s (98.1 prefill, t6)            |
+| **Fast modern GGUF**  | `lfm25-350m`            | llama.cpp (`unified`) | 94.2 tok/s (241.4 prefill, t6)           |
 
 GGUF thread default: llama.cpp auto-detect is capped at **6** on console
 (`detect_threads_llama` — t6 measured optimum, t7/t8 livelock); explicit
@@ -80,15 +83,15 @@ Models must be **self-contained** `model.onnx` (< 2 GB merged) — run
 
 Copy [`bench/configs/settings-modern.json`](../bench/configs/settings-modern.json) via Device Portal, or use the UI.
 
-| Key                    | Recommended                       | Notes                                          |
-| ---------------------- | --------------------------------- | ---------------------------------------------- |
-| `model`                | `smollm2-360m-cpu-int4`           | Downloaded on first launch                     |
-| `kv_reuse`             | `true`                            | 4.87× turn-2 prefill (measured)                |
-| `routing`              | `0` default; `2` for RAG          | `2` = Auto; needs DML fp16 model + patched DLL |
+| Key                    | Recommended                       | Notes                                            |
+| ---------------------- | --------------------------------- | ------------------------------------------------ |
+| `model`                | `smollm2-360m-cpu-int4`           | Downloaded on first launch                       |
+| `kv_reuse`             | `true`                            | 4.87× turn-2 prefill (measured)                  |
+| `routing`              | `0` default; `2` for RAG          | `2` = Auto; needs DML fp16 model + patched DLL   |
 | `gpu_model`            | `smollm2-360m-dml-fp16`           | Catalogue download (`models-v1`, ~691 MB) or WDP |
-| `diffuse_taesd_vae`    | `true` after asset on `models-v1` | ~4.5 s/image target                            |
-| `sampling.temperature` | `0.8`                             | UI default                                     |
-| `sampling.n_predict`   | `512`                             | UI default                                     |
+| `diffuse_taesd_vae`    | `true` after asset on `models-v1` | ~4.5 s/image target                              |
+| `sampling.temperature` | `0.8`                             | UI default                                       |
+| `sampling.n_predict`   | `512`                             | UI default                                       |
 
 Routing Auto uses **600 tokens** (real tokenizer count), sticky per conversation.
 
@@ -132,7 +135,7 @@ ctest --test-dir build/linux-test --output-on-failure
 
 ## Validation checklist
 
-1. Deploy the default **`xllama-appx`** CI artifact (unified + PatchedGenAI #2280, currently **1.1.5.0**)
+1. Deploy the default **`xllama-appx`** CI artifact (unified + PatchedGenAI #2280; version auto-stamped from the CI run number — see `CHANGELOG.md`)
 2. Ensure models are provisioned (`smollm2-360m-dml-fp16` for routing — catalogue or WDP;
    `sd-turbo-fp16` + TAESD asset for §7c). MSIX **uninstall** wipes LocalState.
 3. Remove `bench.flag` from LocalState if `install-latest-build.sh` left it behind

--- a/docs/technical-report.md
+++ b/docs/technical-report.md
@@ -8,6 +8,11 @@ measured story: which workloads the console's hardware serves well, which it
 does not, and why — with every claim backed by a benchmark row or a falsified
 hypothesis recorded along the way.
 
+> The numbers below are a narrative snapshot (v1.0 draft, 2026-07). The current,
+> consolidated performance tables are maintained in
+> [benchmarks.md](benchmarks.md) (the perf SSOT) — including the GGUF/Gemma models
+> and KV-reuse added after this draft.
+
 ## 1. The machine, as seen from an app
 
 | Resource | Available to a Dev Mode UWP app                                                                                                                                      |

--- a/docs/using-the-app.md
+++ b/docs/using-the-app.md
@@ -47,10 +47,11 @@ Generation shows live tok/s; **■ Cancel** stops a running reply.
     (prefill is 1.8× faster at ~1k tokens), short chats stay on CPU; the
     choice is sticky per conversation.
 
-**Note for GGUF models** (`kind: "gguf"` in the catalogue): the **KV-cache reuse**
-and **EP routing** controls are disabled (greyed out). The llama.cpp backend is
-stateless and runs CPU-only on Xbox; delta-only reuse would produce incorrect
-output and GPU routing does not apply.
+**Note for GGUF models** (`kind: "gguf"` in the catalogue): **KV-cache reuse
+works** (the llama.cpp path keeps a persistent context and appends only the new
+turn's delta — turn-2 prefill ~4× faster, see [benchmarks.md](benchmarks.md)).
+Only **EP routing** is disabled (greyed out): the llama.cpp UWP build is
+CPU-only, so there is no GPU model to route to.
 
 Settings persist to `LocalState\settings.json` and take effect on the next
 inference call.

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -329,7 +329,8 @@ win is prefill (§5, reading 1) and larger-model bandwidth. A genuinely fused
 low-bit GPU GEMM would be a DirectML-team feature, not an ORT-side PR; treat GPU
 int4 decode as blocked upstream, not a local TODO.
 
-**Config tests that confirm the dead-end** (built, pending one console bench —
-expected ≈ 8.8 tok/s, a fast negative): `int4_block_size=128` and
-`int4_accuracy_level=4` variants of SmolLM2-360M. If either materially beat 8.8
-it would refute the above; the kernel structure predicts they will not.
+**Config tests** (`int4_block_size=128`, `int4_accuracy_level=4` variants of
+SmolLM2-360M) were **built but closed inconclusive 2026-07-09** — not console-
+benched, and not a local lever. The §12 desk-check above stands (the kernel
+structure predicts neither materially beats 8.8 tok/s); see `ROADMAP.md`
+Phase 3.5 / Phase 5 and `console-validation-runbook.md §5`.

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -1,12 +1,17 @@
 # UWP Constraints
 
+> **SSOT for UWP/AppContainer constraints** (numbered §1–§12): the measured GPU
+> budget (3801 MB), the 2 GB per-file limit, disk budget, no-mmap, `887A0036`,
+> `weakly_canonical`, thread cap, and the DirectML low-bit GEMM analysis. Other
+> docs link to a `§n` here rather than restating these.
+
 Platform limitations relevant to running LLM inference on Xbox Dev Mode, and how xllama addresses each one.
 
 ## 1. No POSIX `mmap`
 
 **Problem**: `mmap()` is unavailable in the UWP sandbox.
 
-**Status**: Not an issue for the current ORT GenAI path. ORT loads the model internally using Win32 file APIs compatible with UWP. The Linux llama.cpp path uses `mparams.use_mmap = false` to fall back to heap reads.
+**Status**: Not an issue for the ORT GenAI path — ORT loads the model internally using Win32 file APIs compatible with UWP. For the GGUF/llama.cpp path the `patches/0001` guards disable the desktop-only `_WIN32` mmap on the AppContainer, so GGUF weights are read into the heap (buffered). Enabling an AppContainer mmap via `CreateFileMappingFromApp`/`MapViewOfFileFromApp` was **tried and reverted (2026-07-14): no benefit** — the CPU GGUF load is dominated by the AVX2 tensor repack, not the file read (full analysis in [`benchmarks.md`](benchmarks.md) → root-cause notes).
 
 ## 2. Sandboxed Filesystem
 


### PR DESCRIPTION
Documentation consolidation. Two systematic audits found perf numbers duplicated in 5–7 files (with divergent SmolLM2 values 66.3/68.0/70.9), the model catalogue in 6 places, and stale claims after recent merges. Each fact now has one authoritative home.

## SSOT map (declared in each owner + `docs/README.md` index)
- **Performance** → `docs/benchmarks.md` (now disambiguates the SmolLM2 values)
- **Catalogue + backend selection** → `docs/model-selection.md` + `uwp/models/manifest.json`
- **UWP constraints §1–§12** → `docs/uwp-constraints.md`
- **Version / state** → `CHANGELOG.md` + `ROADMAP.md` header

## Correctness fixes
- `using-the-app.md`: GGUF **KV-reuse is enabled** (was "stateless / disabled / would produce incorrect output").
- **Version drift** 1.1.5.0 → de-hardcoded (README, recommended-config).
- **gemma4-e2b IQ2_M → Q3_K_S** (15.3 tok/s) everywhere — fixes a ROADMAP self-contradiction and the model-selection verdict that treated Q3_K_S as hypothetical.
- `uwp-constraints §1`: mmap **investigated + reverted** (repack-bound) cross-ref.
- Disk "2.2–2.5 GB" now notes the 90 GB expansion.
- **CHANGELOG `[Unreleased]`** populated with the 6 post-1.1.6.0 landings.
- README: current perf summary + Models table (adds Gemma) + Phase 6 status.

## Dedup
Non-SSOT docs quote a headline and link to the owner instead of restating full tables.

Docs-only; no code/data/manifest changes. Links + version consistency verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - GGUF models now support persistent KV-cache reuse, reducing repeated context processing.
  - Updated model catalog and Gemma-4-E2B guidance reflect current quantization, sizing, and performance findings.

- **Changed**
  - Stop-sequence behavior and benchmark installation guidance have been clarified.
  - Dev Mode storage guidance now explains expandable capacity up to 90 GB.

- **Documentation**
  - Refreshed benchmark, roadmap, model-selection, installation, and app-usage documentation.
  - Added authoritative references for performance, model support, platform constraints, and release status.
  - Updated performance figures and clarified GGUF loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->