### PR TITLE
chore(tier3): manifest merge tests + prefill knobs + membw micro-bench

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed two more stale in-code comments: `ManifestEntry` (gguf KV-reuse now
   enabled) and `GenerateParams` reuse_kv/reset_kv (honored by both backends now,
   not ORT-only).
+- **CPU memory-bandwidth micro-bench** — `xllama::measure_membw` (STREAM-style
+  read/copy/triad, `include/xllama/membw.h`) with `xllama-cli --membw` (host) and a
+  `membw.flag` headless mode (console → `membw-result.csv`). Pins the DRAM-bandwidth
+  ceiling behind the bandwidth-bound decode number. 4 host doctest cases.
 - Consolidated documentation onto single-source-of-truth docs (perf →
   `benchmarks.md`, constraints → `uwp-constraints.md`, catalogue →
   `model-selection.md` + `manifest.json`); refreshed stale version/quant/KV claims.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (`apply_stop_sequences`, `chat_prompt`) shared by the llama and ORT decode loops.
 - **`scripts/install-latest-build.sh`**: `bench.flag` is now `--bench` opt-in — a
   plain install launches into the UI.
+- **Prefill micro-batch knobs exposed** — `n_batch`/`n_ubatch` plumbed through
+  `InferenceParams`/`SessionParams` into `llama_context_params`, with
+  `xllama-cli --batch/--ubatch` and a `scripts/bench-ubatch-sweep.sh` sweep helper.
+  Host sweep found no reproducible ubatch win (noise-dominated); default (llama.cpp 512) unchanged. See `docs/benchmarks.md`.
+- Fixed two more stale in-code comments: `ManifestEntry` (gguf KV-reuse now
+  enabled) and `GenerateParams` reuse_kv/reset_kv (honored by both backends now,
+  not ORT-only).
 - Consolidated documentation onto single-source-of-truth docs (perf →
   `benchmarks.md`, constraints → `uwp-constraints.md`, catalogue →
   `model-selection.md` + `manifest.json`); refreshed stale version/quant/KV claims.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **CI: `src/models/*.cpp` MSBuild wildcard** in `ggml-uwp.vcxproj` + a
   `scripts/check-uwp-sources.sh` drift-check — new llama.cpp architectures no
   longer break the UWP link on a submodule bump (as `657e011` did).
+- **Manifest per-entry merge factored + unit-tested** — extracted the
+  LocalState-override merge from `LoadModelManifest` into a pure, header-only
+  `xllama::merge_manifest_entries` (`include/xllama/manifest_merge.h`) with 7
+  host doctest cases (`tests/test_manifest_merge.cpp`) covering replace / append /
+  preserve, incl. the 2026-07-10 whole-catalogue-shadow regression.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed two more stale in-code comments: `ManifestEntry` (gguf KV-reuse now
   enabled) and `GenerateParams` reuse_kv/reset_kv (honored by both backends now,
   not ORT-only).
+- **In-app HuggingFace download verified on-console** (2026-07-15) — the app
+  self-downloaded the 2.29 GB single `.gguf` for `gemma4-e2b` from HF and
+  loaded+generated it, confirming the >2 GB self-download path (not just Device
+  Portal provisioning). Surfaced a follow-up: `IsModelProvisioned` doesn't
+  auto-upgrade a stale-quant entry (see ROADMAP). See `docs/benchmarks.md`.
 - **CPU memory-bandwidth micro-bench** — `xllama::measure_membw` (STREAM-style
   read/copy/triad, `include/xllama/membw.h`) with `xllama-cli --membw` (host) and a
   `membw.flag` headless mode (console → `membw-result.csv`). Pins the DRAM-bandwidth

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(xllama STATIC
     src/bridge/inference.cpp
     src/bridge/session.cpp
     src/bridge/bench.cpp
+    src/bridge/membw.cpp
     src/bridge/platform.cpp
     src/bridge/path_utils.cpp
     src/bridge/utf8_utils.cpp

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -319,6 +319,9 @@ Open items only — everything above is measured or shipped.
 - [x] **`install-latest-build.sh`** — no longer leaves `bench.flag` by default;
       headless bench mode is now `--bench` opt-in (a normal install launches
       straight into the UI). See `scripts/install-latest-build.sh`.
-- [ ] (optional) **membw.flag** micro-bench — pin the CPU bandwidth denominator
+- [x] (optional) **membw.flag** micro-bench — pins the CPU bandwidth denominator
+      behind decode. `measure_membw` (STREAM read/copy/triad), `xllama-cli --membw`
+      (host) + `membw.flag` (console → `membw-result.csv`). Host i7: 28.1 GB/s
+      read @8t. See `docs/benchmarks.md`; on-console pass pending.
 - [ ] (upstream, deprioritised) **Fused low-bit GPU GEMM in DirectML** — §12;
       not a local contribution via #2280

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -312,6 +312,12 @@ Open items only — everything above is measured or shipped.
 - [x] **Automated MSIX versioning** — CI stamps the Revision from `run_number`
       (`build-uwp.ps1 -BuildRevision`); Major.Minor.Build stays the semantic
       version. Console in-place updates never hit the same-identity block.
+- [x] **In-app HF download verified on-console** (2026-07-15) — the app's own
+      downloader pulled the 2.29 GB single `.gguf` from HF and loaded+generated it,
+      confirming the >2 GB self-download path (see `docs/benchmarks.md`).
+- [ ] **`IsModelProvisioned` quant-upgrade gap** — a dir with _any_ `.gguf` counts
+      as provisioned, so a stale-quant entry is not auto-upgraded to the manifest's
+      current file. Check the expected manifest filename, not just "a gguf exists".
 - [ ] **Demo video** — model loaded and running on Xbox hardware (Phase 4 carry-over)
 - [ ] **Publication venue** — GitHub Discussions vs arXiv for `docs/technical-report.md`
 - [ ] **`smollm2-1.7b-cpu-int4` on `models-v1`** — manifest ready; optional 1.4 GB

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -316,8 +316,9 @@ Open items only — everything above is measured or shipped.
 - [ ] **Publication venue** — GitHub Discussions vs arXiv for `docs/technical-report.md`
 - [ ] **`smollm2-1.7b-cpu-int4` on `models-v1`** — manifest ready; optional 1.4 GB
       release upload (host build in `~/.cache/xllama-1b-build/`)
-- [ ] **`install-latest-build.sh`** — stop leaving `bench.flag` by default (or
-      `--bench` opt-in); document in README until fixed
+- [x] **`install-latest-build.sh`** — no longer leaves `bench.flag` by default;
+      headless bench mode is now `--bench` opt-in (a normal install launches
+      straight into the UI). See `scripts/install-latest-build.sh`.
 - [ ] (optional) **membw.flag** micro-bench — pin the CPU bandwidth denominator
 - [ ] (upstream, deprioritised) **Fused low-bit GPU GEMM in DirectML** — §12;
       not a local contribution via #2280

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -173,6 +173,27 @@ dispatch overhead at this model scale; CPU `MatMulNBits` on AVX2 wins
 (ROADMAP Phase 2 / `uwp-constraints.md §7`). GPU's win is **prefill** (353 vs
 198 tok/s at ~1k tokens), which is exactly what routing uses it for.
 
+## CPU memory bandwidth — the decode denominator
+
+Decode is a bandwidth-bound M=1 GEMV: each token streams the whole weight matrix
+from DRAM once, so decode tok/s ≈ (effective read bandwidth) / (weight bytes). The
+"~13 GB/s effective from CPU int4 GEMV" quoted elsewhere is a _deduced_ figure; the
+`membw` micro-bench (STREAM-style read / copy / triad over a 256 MB buffer, larger
+than the LLC) measures the sustained ceiling directly, so decode can be stated as a
+fraction of a measured number.
+
+Host reference (i7-1165G7, 2026-07-14, `xllama-cli --membw`):
+
+| Threads | Read GB/s | Copy GB/s | Triad GB/s |
+| ------- | --------: | --------: | ---------: |
+| 1       |      11.8 |      23.0 |       14.0 |
+| 8       |      28.1 |      36.3 |       26.3 |
+
+On-console: drop a `membw.flag` into `LocalState` (the app runs the bench headless
+and writes `membw-result.csv`, single-thread + full-width rows). This pins the
+Xbox Zen 2 / GDDR6 CPU-side ceiling so the 13 GB/s GEMV figure can be reported as a
+fraction of it (pending one console pass).
+
 ## Reproducing
 
 - **On-console**: `./scripts/bench-xbox-ort.sh <model> --runs 3 --out bench/results/<file>.csv`
@@ -183,6 +204,8 @@ dispatch overhead at this model scale; CPU `MatMulNBits` on AVX2 wins
 - **Prefill micro-batch sweep**: `./scripts/bench-ubatch-sweep.sh <model.gguf>` runs
   the CLI across `--ubatch` 128/256/512/1024 and prints prompt tok/s per value
   (`--batch`/`--ubatch` also exposed directly on `xllama-cli`).
+- **Memory bandwidth**: `./build/linux-release/bin/xllama-cli --membw` (host) or a
+  `membw.flag` in `LocalState` (console) → read/copy/triad GB/s.
 - Comparative charts: `docs/benchmarks-charts.html` (self-contained; open in a browser).
 
 ### Prefill micro-batch (n_ubatch) — no reproducible host win

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -111,6 +111,17 @@ Disk was never the constraint (Dev Mode is 90 GB). E4B/12B+ stay out of scope on
 size/speed. Catalogue entry `gemma4-e2b` (downloads from HF; 2.29 GB exceeds the
 GitHub release 2 GB asset limit).
 
+**In-app HF download verified on-console** (2026-07-15): with the catalogue entry
+un-provisioned, the app's own downloader pulled the single 2.29 GB `.gguf` straight
+from the HF `unsloth` repo (`EnsureModel: downloading … from catalogue` →
+`download complete`, 2 290 858 112 bytes), then loaded it (`GGUF model loaded via
+llama.cpp`) and generated — confirming the >2 GB single-file download path (not just
+Device-Portal provisioning). Known gap surfaced in the process: `IsModelProvisioned`
+treats a dir with _any_ `.gguf` as provisioned, so an entry already holding an
+older-quant file (e.g. a stale IQ2_M under `gemma4-e2b`) is **not** auto-upgraded to
+the manifest's current quant — the manifest filename should be checked, not just
+"a gguf exists".
+
 ## Root-cause notes — the negative performers
 
 Investigated 2026-07-14 (reverse-engineered where noted). None is a loader or

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -180,4 +180,21 @@ dispatch overhead at this model scale; CPU `MatMulNBits` on AVX2 wins
   `phase5-diffuse`.
 - **Host (llama.cpp GGUF only)**: `./build/linux-release/bin/xllama-cli -m <model.gguf>
 -p '<prompt>' -n 128` prints `load / prompt tok/s / decode tok/s`.
+- **Prefill micro-batch sweep**: `./scripts/bench-ubatch-sweep.sh <model.gguf>` runs
+  the CLI across `--ubatch` 128/256/512/1024 and prints prompt tok/s per value
+  (`--batch`/`--ubatch` also exposed directly on `xllama-cli`).
 - Comparative charts: `docs/benchmarks-charts.html` (self-contained; open in a browser).
+
+### Prefill micro-batch (n_ubatch) — no reproducible host win
+
+`n_ubatch` (llama.cpp physical prefill chunk, default 512) is the only
+TTFT-relevant batching knob on the CPU path (`n_batch` merely caps the logical
+batch). Now exposed end-to-end (`InferenceParams`/`SessionParams` →
+`llama_context_params`, `xllama-cli --batch/--ubatch`). Host sweep
+(i7-1165G7, Qwen3.5-0.8B-Q4_K_M, 701-token prompt, 2026-07-14): repeated passes
+**disagree** on the ubatch=128 value (82.5 vs 117.4 tok/s) and show **no
+reproducible trend** — on a loaded dev laptop the measurement is noise-dominated.
+The knob is in place and CLI-sweepable; a clean optimum needs a quiet machine or
+an on-console pass (Xbox Zen 2 shares the x86 AVX2 ISA, so a flat curve is the
+expectation). Default (0 → llama.cpp 512) stays until a measured win justifies a
+change.

--- a/include/xllama/inference_params.h
+++ b/include/xllama/inference_params.h
@@ -19,6 +19,11 @@ struct InferenceParams {
     int n_predict = 128;
     int n_ctx = 2048;
     int n_threads = 0; // 0 = auto-detect
+    // llama.cpp prefill batching (GGUF path only; 0 = llama.cpp default, i.e.
+    // n_batch 2048 / n_ubatch 512). n_ubatch is the physical compute chunk that
+    // sets prefill throughput on the Zen 2 CPU — the sweep knob for TTFT tuning.
+    int n_batch = 0;
+    int n_ubatch = 0;
     float temperature = 0.8f;
     uint32_t seed = 0xFFFFFFFF; // 0xFFFFFFFF = LLAMA_DEFAULT_SEED
 

--- a/include/xllama/inference_params.h
+++ b/include/xllama/inference_params.h
@@ -35,6 +35,10 @@ struct InferenceParams {
     // CLI --chat: wrap `prompt` with the model's chat template before inference.
     bool chat_template = false;
 
+    // CLI --membw: run the CPU memory-bandwidth micro-bench and exit (no model
+    // load). Model/prompt are not required in this mode.
+    bool run_membw = false;
+
     // UI callbacks (optional). Called from the inference thread — must marshal
     // to the UI thread before touching XAML controls.
     std::function<void(const std::string&)> on_status; // e.g. "loading model"

--- a/include/xllama/manifest_merge.h
+++ b/include/xllama/manifest_merge.h
@@ -1,0 +1,35 @@
+// Per-entry merge of a model-catalogue override onto a base catalogue.
+//
+// The LocalState override (uploadable via Device Portal, no reinstall) is merged
+// ON TOP of the bundled catalogue: a same-`name` entry REPLACES the base one in
+// place (preserving the base ordering), a new `name` is APPENDED, and a bundled
+// entry the override does not mention STAYS. A stale single-entry override used
+// to shadow the whole catalogue before this per-entry rule (found 2026-07-10).
+//
+// Templated on the entry type so it is unit-testable on the host with a minimal
+// stub struct — the production caller instantiates it with `ManifestEntry`. The
+// only requirement on `Entry` is a `.name` member comparable with `==`.
+#pragma once
+
+#include <utility>
+#include <vector>
+
+namespace xllama {
+
+template <typename Entry>
+void merge_manifest_entries(std::vector<Entry>& base, std::vector<Entry> overrides) {
+    for (auto& oe : overrides) {
+        bool replaced = false;
+        for (auto& e : base) {
+            if (e.name == oe.name) {
+                e = std::move(oe);
+                replaced = true;
+                break;
+            }
+        }
+        if (!replaced)
+            base.push_back(std::move(oe));
+    }
+}
+
+} // namespace xllama

--- a/include/xllama/membw.h
+++ b/include/xllama/membw.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2024 Venere Labs
+// SPDX-License-Identifier: MIT
+//
+// CPU memory-bandwidth micro-bench — pins the denominator behind decode.
+//
+// LLM decode is a bandwidth-bound M=1 GEMV: every token streams the whole weight
+// matrix from DRAM once, so the achievable decode rate is (weight bytes / effective
+// read bandwidth). xllama's docs quote "~13 GB/s effective from CPU int4 GEMV" as a
+// *deduced* figure; this measures the sustained bandwidth ceiling directly (a
+// STREAM-style read / copy / triad over a buffer larger than the LLC), so the
+// decode number can be stated as a fraction of a measured ceiling rather than a
+// guess. Portable (no platform deps) so it runs on the Linux host and, via
+// `membw.flag`, on the Xbox in Game mode.
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace xllama {
+
+struct MembwResult {
+    std::size_t buffer_bytes = 0;
+    int iterations = 0;
+    int threads = 0;
+    double read_gbs = 0.0;  // streaming read (sum reduction), 1×buffer moved
+    double copy_gbs = 0.0;  // memcpy, 2×buffer moved (STREAM copy convention)
+    double triad_gbs = 0.0; // a=b+s*c, 3×buffer moved (STREAM triad convention)
+};
+
+// Measure sustained bandwidth with `threads` workers (0 = hardware_concurrency)
+// over a `buffer_bytes` working set, reporting the best (min-time) of `iterations`
+// passes. GB = 1e9 bytes (decimal, matching the "224 GB/s bus" spec convention).
+MembwResult measure_membw(std::size_t buffer_bytes = static_cast<std::size_t>(256) << 20,
+                          int iterations = 5, int threads = 0);
+
+// CSV serialization (schema is self-contained; not the model-bench schema).
+const char* membw_csv_header(); // "buffer_mb,threads,read_gbs,copy_gbs,triad_gbs,host,date\n"
+std::string format_membw_row(const MembwResult& r, const char* host_label);
+
+} // namespace xllama

--- a/include/xllama/session.h
+++ b/include/xllama/session.h
@@ -25,6 +25,8 @@ struct SessionParams {
     std::string model_path; // same semantics as InferenceParams::model_path
     int n_ctx = 2048;
     int n_threads = 0; // 0 = auto
+    int n_batch = 0;   // llama.cpp only; 0 = default (2048). Logical prefill batch.
+    int n_ubatch = 0;  // llama.cpp only; 0 = default (512). Physical prefill chunk.
     Backend backend = Backend::Auto;
     int n_gpu_layers = 0; // llama.cpp only; 0 = CPU (Xbox has no ggml GPU backend)
 };
@@ -42,8 +44,9 @@ struct GenerateParams {
     // Generation stops and the matching sequence is stripped.
     std::vector<std::string> stop_sequences;
 
-    // Continuous decoding / KV-cache reuse (ORT path only; the llama.cpp path
-    // ignores these and always runs stateless).
+    // Continuous decoding / KV-cache reuse. Honored by BOTH backends now: the
+    // ORT path (persistent generator) and the llama.cpp path (persistent
+    // llama_context, KV cache retained across turns — turn-2 prefill 4.07×).
     //   reuse_kv = false           → legacy stateless turn: a fresh generator is
     //                                created and destroyed; `prompt` is the full
     //                                context. Proven default.

--- a/scripts/bench-ubatch-sweep.sh
+++ b/scripts/bench-ubatch-sweep.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Sweep llama.cpp prefill micro-batch (n_ubatch) and print prompt tok/s per value.
+# The prefill physical chunk is the only TTFT-relevant batching knob on the CPU
+# path (n_batch just caps the logical batch). Use this to find the ubatch that
+# maximises prompt throughput for a given model on a given CPU.
+#
+# Usage: ./scripts/bench-ubatch-sweep.sh <model.gguf> [prompt-repeat] [ubatch-list]
+#   prompt-repeat : how many times to repeat the filler sentence (default 70,
+#                   ~700 prompt tokens — long enough for prefill to dominate).
+#   ubatch-list   : space-separated values (default "128 256 512 1024").
+#
+# Host reference (i7-1165G7, Qwen3.5-0.8B-Q4_K_M, 701-token prompt, 2026-07-14):
+# repeated sweeps DISAGREE on the ubatch=128 value (82.5 vs 117.4 tok/s across two
+# runs) — on a loaded dev laptop the measurement is noise-dominated and shows no
+# reproducible ubatch trend. Run this on a quiet machine (or the Xbox in Game
+# mode) with several passes before trusting any single number.
+set -euo pipefail
+
+MODEL="${1:?usage: bench-ubatch-sweep.sh <model.gguf> [repeat] [ubatch-list]}"
+REPEAT="${2:-70}"
+UBATCHES="${3:-128 256 512 1024}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLI="${SCRIPT_DIR}/../build/linux-release/bin/xllama-cli"
+[ -x "$CLI" ] || {
+	echo "build first: cmake --build build/linux-release --target xllama-cli" >&2
+	exit 1
+}
+
+# Deterministic filler prompt (no python dependency).
+SENTENCE="The quick brown fox jumps over the lazy dog. "
+PROMPT=""
+for _ in $(seq 1 "$REPEAT"); do PROMPT+="$SENTENCE"; done
+
+printf '%-10s %-14s %-14s\n' "ubatch" "prompt_tok/s" "decode_tok/s"
+for ub in $UBATCHES; do
+	line="$("$CLI" -m "$MODEL" -p "$PROMPT" -n 16 --ubatch "$ub" --seed 1 2>&1 |
+		grep -oE 'prompt=[0-9.]+ tok/s decode=[0-9.]+' || true)"
+	p="$(echo "$line" | grep -oE 'prompt=[0-9.]+' | cut -d= -f2)"
+	d="$(echo "$line" | grep -oE 'decode=[0-9.]+' | cut -d= -f2)"
+	printf '%-10s %-14s %-14s\n' "$ub" "${p:-?}" "${d:-?}"
+done

--- a/src/bridge/cli.cpp
+++ b/src/bridge/cli.cpp
@@ -24,6 +24,9 @@ static void print_help(const char* prog) {
                  "      --seed <int>     RNG seed; 0 = random (default: 0)\n"
                  "      --chat           Wrap the prompt with the model's chat template\n"
                  "                       (ChatML/Gemma by model name) and stop on its stop token\n"
+                 "      --batch <N>      Logical prefill batch; 0 = llama default 2048\n"
+                 "      --ubatch <N>     Physical prefill chunk (TTFT sweep knob);\n"
+                 "                       0 = llama default 512\n"
                  "  -h, --help           Show this message\n",
                  prog);
 }
@@ -45,6 +48,8 @@ bool parse_cli_args(int argc, char** argv, InferenceParams& out) {
                                               {"temp", required_argument, nullptr, 1},
                                               {"seed", required_argument, nullptr, 2},
                                               {"chat", no_argument, nullptr, 3},
+                                              {"batch", required_argument, nullptr, 4},
+                                              {"ubatch", required_argument, nullptr, 5},
                                               {"help", no_argument, nullptr, 'h'},
                                               {nullptr, 0, nullptr, 0}};
 
@@ -74,6 +79,12 @@ bool parse_cli_args(int argc, char** argv, InferenceParams& out) {
             break;
         case 3:
             out.chat_template = true;
+            break;
+        case 4:
+            out.n_batch = std::atoi(optarg);
+            break;
+        case 5:
+            out.n_ubatch = std::atoi(optarg);
             break;
         case 'h':
             print_help(argv[0]);

--- a/src/bridge/cli.cpp
+++ b/src/bridge/cli.cpp
@@ -27,6 +27,8 @@ static void print_help(const char* prog) {
                  "      --batch <N>      Logical prefill batch; 0 = llama default 2048\n"
                  "      --ubatch <N>     Physical prefill chunk (TTFT sweep knob);\n"
                  "                       0 = llama default 512\n"
+                 "      --membw          Run the CPU memory-bandwidth micro-bench and\n"
+                 "                       exit (no model needed); prints read/copy/triad GB/s\n"
                  "  -h, --help           Show this message\n",
                  prog);
 }
@@ -50,6 +52,7 @@ bool parse_cli_args(int argc, char** argv, InferenceParams& out) {
                                               {"chat", no_argument, nullptr, 3},
                                               {"batch", required_argument, nullptr, 4},
                                               {"ubatch", required_argument, nullptr, 5},
+                                              {"membw", no_argument, nullptr, 6},
                                               {"help", no_argument, nullptr, 'h'},
                                               {nullptr, 0, nullptr, 0}};
 
@@ -86,6 +89,9 @@ bool parse_cli_args(int argc, char** argv, InferenceParams& out) {
         case 5:
             out.n_ubatch = std::atoi(optarg);
             break;
+        case 6:
+            out.run_membw = true;
+            break;
         case 'h':
             print_help(argv[0]);
             std::exit(0);
@@ -94,6 +100,10 @@ bool parse_cli_args(int argc, char** argv, InferenceParams& out) {
             return false;
         }
     }
+
+    // --membw runs a model-free micro-bench: skip the model/prompt requirement.
+    if (out.run_membw)
+        return true;
 
     if (out.model_path.empty() || out.prompt.empty()) {
         print_usage(argv[0]);

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -300,6 +300,13 @@ InferenceResult run_inference_llama(const InferenceParams& params) {
     llama_context_params cparams = llama_context_default_params();
     cparams.n_ctx = static_cast<uint32_t>(params.n_ctx);
     cparams.n_threads = n_threads;
+    if (params.n_batch > 0)
+        cparams.n_batch = static_cast<uint32_t>(params.n_batch);
+    if (params.n_ubatch > 0)
+        cparams.n_ubatch = static_cast<uint32_t>(params.n_ubatch);
+    if (params.n_batch > 0 || params.n_ubatch > 0)
+        log_output("[xllama] prefill batch override: n_batch=" + std::to_string(cparams.n_batch) +
+                   " n_ubatch=" + std::to_string(cparams.n_ubatch) + "\n");
 
     llama_context* raw_ctx = llama_init_from_model(model.get(), cparams);
     if (!raw_ctx) {

--- a/src/bridge/membw.cpp
+++ b/src/bridge/membw.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2024 Venere Labs
+// SPDX-License-Identifier: MIT
+
+#include "xllama/membw.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <ctime>
+#include <thread>
+#include <vector>
+
+namespace xllama {
+
+namespace {
+
+using clock_t_ = std::chrono::steady_clock;
+
+// Run `fn(begin,end)` across `threads` workers partitioning [0,n), return seconds.
+template <typename Fn> double timed_parallel(std::size_t n, int threads, Fn&& fn) {
+    const auto t0 = clock_t_::now();
+    if (threads <= 1) {
+        fn(std::size_t{0}, n);
+    } else {
+        std::vector<std::thread> pool;
+        pool.reserve(static_cast<std::size_t>(threads));
+        const std::size_t chunk =
+            (n + static_cast<std::size_t>(threads) - 1) / static_cast<std::size_t>(threads);
+        for (int t = 0; t < threads; ++t) {
+            const std::size_t b = std::min(n, static_cast<std::size_t>(t) * chunk);
+            const std::size_t e = std::min(n, b + chunk);
+            if (b >= e)
+                break;
+            pool.emplace_back([&fn, b, e] { fn(b, e); });
+        }
+        for (auto& th : pool)
+            th.join();
+    }
+    return std::chrono::duration<double>(clock_t_::now() - t0).count();
+}
+
+// Volatile sink so the read reduction is not optimized away.
+volatile double g_membw_sink = 0.0;
+
+} // namespace
+
+MembwResult measure_membw(std::size_t buffer_bytes, int iterations, int threads) {
+    MembwResult r;
+    if (threads <= 0) {
+        unsigned hc = std::thread::hardware_concurrency();
+        threads = hc > 0 ? static_cast<int>(hc) : 1;
+    }
+    if (iterations < 1)
+        iterations = 1;
+
+    // Work in doubles; round the element count so all three arrays are equal.
+    const std::size_t elems = std::max<std::size_t>(buffer_bytes / sizeof(double), 1);
+    const std::size_t bytes = elems * sizeof(double);
+    r.buffer_bytes = bytes;
+    r.iterations = iterations;
+    r.threads = threads;
+
+    std::vector<double> a(elems), b(elems), c(elems);
+    // Fault every page in before timing (avoid first-touch cost polluting run 1).
+    for (std::size_t i = 0; i < elems; ++i) {
+        a[i] = 1.0;
+        b[i] = 2.0;
+        c[i] = 3.0;
+    }
+
+    const double GB = 1e9;
+    double best_read = 0, best_copy = 0, best_triad = 0;
+    const double scalar = 3.0;
+
+    for (int it = 0; it < iterations; ++it) {
+        // READ: sum reduction over `a` (1×bytes moved). Four independent
+        // accumulators break the serial add-dependency chain so the loop is
+        // limited by memory bandwidth, not FP-add latency.
+        double read_s = timed_parallel(elems, threads, [&](std::size_t bi, std::size_t ei) {
+            double s0 = 0, s1 = 0, s2 = 0, s3 = 0;
+            std::size_t i = bi;
+            for (; i + 4 <= ei; i += 4) {
+                s0 += a[i];
+                s1 += a[i + 1];
+                s2 += a[i + 2];
+                s3 += a[i + 3];
+            }
+            for (; i < ei; ++i)
+                s0 += a[i];
+            g_membw_sink += s0 + s1 + s2 + s3;
+        });
+        best_read = std::max(best_read, static_cast<double>(bytes) / GB / read_s);
+
+        // COPY: a <- c (2×bytes: read c + write a).
+        double copy_s = timed_parallel(elems, threads, [&](std::size_t bi, std::size_t ei) {
+            std::memcpy(a.data() + bi, c.data() + bi, (ei - bi) * sizeof(double));
+        });
+        best_copy = std::max(best_copy, 2.0 * static_cast<double>(bytes) / GB / copy_s);
+
+        // TRIAD: a <- b + scalar*c (3×bytes: read b,c + write a).
+        double triad_s = timed_parallel(elems, threads, [&](std::size_t bi, std::size_t ei) {
+            for (std::size_t i = bi; i < ei; ++i)
+                a[i] = b[i] + scalar * c[i];
+        });
+        best_triad = std::max(best_triad, 3.0 * static_cast<double>(bytes) / GB / triad_s);
+    }
+
+    r.read_gbs = best_read;
+    r.copy_gbs = best_copy;
+    r.triad_gbs = best_triad;
+    return r;
+}
+
+const char* membw_csv_header() {
+    return "buffer_mb,threads,read_gbs,copy_gbs,triad_gbs,host,date\n";
+}
+
+std::string format_membw_row(const MembwResult& r, const char* host_label) {
+    char date_buf[32];
+    std::time_t now = std::time(nullptr);
+    std::tm* tm_utc = std::gmtime(&now);
+    std::strftime(date_buf, sizeof(date_buf), "%Y-%m-%dT%H:%M:%SZ", tm_utc);
+
+    char buf[256];
+    std::snprintf(buf, sizeof(buf), "%zu,%d,%.2f,%.2f,%.2f,%s,%s\n", r.buffer_bytes / (1024 * 1024),
+                  r.threads, r.read_gbs, r.copy_gbs, r.triad_gbs,
+                  host_label ? host_label : "unknown", date_buf);
+    return std::string(buf);
+}
+
+} // namespace xllama

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -357,13 +357,16 @@ class LlamaSession final : public Session {
     LlamaModelPtr m_model;
     int m_n_ctx;
     int m_n_threads;
+    int m_n_batch;  // 0 = llama.cpp default
+    int m_n_ubatch; // 0 = llama.cpp default
     // Persistent context across turns: the KV cache lives here so a reuse turn
     // (reuse_kv && !reset_kv) can append only the delta instead of re-prefilling
     // the whole conversation. Created lazily on the first generate().
     LlamaContextPtr m_ctx;
 
-    explicit LlamaSession(LlamaModelPtr model, int n_ctx, int n_threads)
-        : m_model(std::move(model)), m_n_ctx(n_ctx), m_n_threads(n_threads) {}
+    explicit LlamaSession(LlamaModelPtr model, int n_ctx, int n_threads, int n_batch, int n_ubatch)
+        : m_model(std::move(model)), m_n_ctx(n_ctx), m_n_threads(n_threads), m_n_batch(n_batch),
+          m_n_ubatch(n_ubatch) {}
 
     InferenceResult generate(const GenerateParams& gp) override {
         InferenceResult res;
@@ -372,6 +375,10 @@ class LlamaSession final : public Session {
             llama_context_params cparams = llama_context_default_params();
             cparams.n_ctx = m_n_ctx;
             cparams.n_threads = m_n_threads;
+            if (m_n_batch > 0)
+                cparams.n_batch = static_cast<uint32_t>(m_n_batch);
+            if (m_n_ubatch > 0)
+                cparams.n_ubatch = static_cast<uint32_t>(m_n_ubatch);
             m_ctx.reset(llama_init_from_model(m_model.get(), cparams));
             if (!m_ctx) {
                 res.error_msg = "failed to create context";
@@ -522,7 +529,8 @@ std::unique_ptr<Session> create_llama(const SessionParams& sp, std::string* err)
     int n_threads = sp.n_threads > 0 ? sp.n_threads : detect_threads_llama();
     int n_ctx = sp.n_ctx > 0 ? sp.n_ctx : 2048;
     log_output("[xllama] Session: GGUF model loaded via llama.cpp (persistent)\n");
-    return std::make_unique<LlamaSession>(LlamaModelPtr(raw_model), n_ctx, n_threads);
+    return std::make_unique<LlamaSession>(LlamaModelPtr(raw_model), n_ctx, n_threads, sp.n_batch,
+                                          sp.n_ubatch);
 }
 } // namespace detail
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,11 +4,30 @@
 #include "xllama/chat_prompt.h"
 #include "xllama/cli.h"
 #include "xllama/inference.h"
+#include "xllama/membw.h"
+
+#include <cstdio>
 
 int main(int argc, char** argv) {
     xllama::InferenceParams params;
     if (!xllama::parse_cli_args(argc, argv, params))
         return 1;
+
+    // --membw: model-free CPU memory-bandwidth micro-bench. Runs a single-thread
+    // pass and a full-width pass so the ratio (scaling) is visible; prints the CSV
+    // row so it can be appended to a results file.
+    if (params.run_membw) {
+        const xllama::MembwResult st = xllama::measure_membw(/*bytes=*/0x10000000, 5, 1);
+        const xllama::MembwResult mt = xllama::measure_membw(/*bytes=*/0x10000000, 5, 0);
+        std::printf("membw (best of 5, %zu MB buffer)\n", st.buffer_bytes / (1024 * 1024));
+        std::printf("  1 thread : read %.1f  copy %.1f  triad %.1f GB/s\n", st.read_gbs,
+                    st.copy_gbs, st.triad_gbs);
+        std::printf("  %d threads: read %.1f  copy %.1f  triad %.1f GB/s\n", mt.threads,
+                    mt.read_gbs, mt.copy_gbs, mt.triad_gbs);
+        std::printf("%s%s", xllama::membw_csv_header(),
+                    xllama::format_membw_row(mt, "host").c_str());
+        return 0;
+    }
 
     // --chat: wrap the raw prompt with the model's chat template (ChatML or
     // Gemma, selected by model name) and stop on its stop token. Without this the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(xllama-tests
     test_diffusion.cpp
     test_routing_policy.cpp
     test_chat_prompt.cpp
+    test_manifest_merge.cpp
 )
 
 target_link_libraries(xllama-tests PRIVATE xllama doctest::doctest)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(xllama-tests
     test_routing_policy.cpp
     test_chat_prompt.cpp
     test_manifest_merge.cpp
+    test_membw.cpp
 )
 
 target_link_libraries(xllama-tests PRIVATE xllama doctest::doctest)

--- a/tests/test_manifest_merge.cpp
+++ b/tests/test_manifest_merge.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2024 Venere Labs
+// SPDX-License-Identifier: MIT
+
+#include <doctest/doctest.h>
+
+#include "xllama/manifest_merge.h"
+
+#include <string>
+#include <vector>
+
+using namespace xllama;
+
+namespace {
+// Minimal stand-in for ManifestEntry: the merge only touches `.name`. `tag`
+// tracks identity so a replace vs a preserve is distinguishable.
+struct Entry {
+    std::wstring name;
+    int tag = 0;
+};
+
+std::vector<int> tags(const std::vector<Entry>& v) {
+    std::vector<int> t;
+    for (auto& e : v)
+        t.push_back(e.tag);
+    return t;
+}
+std::vector<std::wstring> names(const std::vector<Entry>& v) {
+    std::vector<std::wstring> n;
+    for (auto& e : v)
+        n.push_back(e.name);
+    return n;
+}
+} // namespace
+
+TEST_CASE("manifest merge: same-name override replaces in place, order preserved") {
+    std::vector<Entry> base{{L"a", 1}, {L"b", 2}, {L"c", 3}};
+    std::vector<Entry> ov{{L"b", 20}};
+    merge_manifest_entries(base, std::move(ov));
+    CHECK(names(base) == std::vector<std::wstring>{L"a", L"b", L"c"}); // no reorder
+    CHECK(tags(base) == std::vector<int>{1, 20, 3});                   // b replaced
+}
+
+TEST_CASE("manifest merge: new name is appended after base entries") {
+    std::vector<Entry> base{{L"a", 1}, {L"b", 2}};
+    std::vector<Entry> ov{{L"z", 9}};
+    merge_manifest_entries(base, std::move(ov));
+    CHECK(names(base) == std::vector<std::wstring>{L"a", L"b", L"z"});
+    CHECK(tags(base) == std::vector<int>{1, 2, 9});
+}
+
+TEST_CASE("manifest merge: unmentioned base entries survive (no whole-catalogue shadow)") {
+    // Regression for the 2026-07-10 bug: a single-entry override must not hide
+    // the rest of the catalogue.
+    std::vector<Entry> base{{L"sd-turbo-fp16", 1}, {L"gemma3-270m", 2}, {L"gemma4-e2b", 3}};
+    std::vector<Entry> ov{{L"smollm2-360m", 99}};
+    merge_manifest_entries(base, std::move(ov));
+    CHECK(base.size() == 4);
+    CHECK(names(base) == std::vector<std::wstring>{L"sd-turbo-fp16", L"gemma3-270m", L"gemma4-e2b",
+                                                   L"smollm2-360m"});
+}
+
+TEST_CASE("manifest merge: replace + append in one override, applied in override order") {
+    std::vector<Entry> base{{L"a", 1}, {L"b", 2}};
+    std::vector<Entry> ov{{L"b", 20}, {L"c", 30}, {L"a", 10}};
+    merge_manifest_entries(base, std::move(ov));
+    CHECK(names(base) == std::vector<std::wstring>{L"a", L"b", L"c"});
+    CHECK(tags(base) == std::vector<int>{10, 20, 30}); // a,b replaced; c appended
+}
+
+TEST_CASE("manifest merge: empty override leaves base untouched") {
+    std::vector<Entry> base{{L"a", 1}, {L"b", 2}};
+    merge_manifest_entries(base, std::vector<Entry>{});
+    CHECK(tags(base) == std::vector<int>{1, 2});
+}
+
+TEST_CASE("manifest merge: empty base takes all override entries in order") {
+    std::vector<Entry> base;
+    std::vector<Entry> ov{{L"a", 1}, {L"b", 2}};
+    merge_manifest_entries(base, std::move(ov));
+    CHECK(names(base) == std::vector<std::wstring>{L"a", L"b"});
+}
+
+TEST_CASE("manifest merge: duplicate names within override collapse onto first match") {
+    // Two override entries with the same name: the first replaces the base slot,
+    // the second finds that same slot and replaces again (last-wins), no append.
+    std::vector<Entry> base{{L"a", 1}};
+    std::vector<Entry> ov{{L"a", 10}, {L"a", 11}};
+    merge_manifest_entries(base, std::move(ov));
+    CHECK(base.size() == 1);
+    CHECK(base[0].tag == 11);
+}

--- a/tests/test_membw.cpp
+++ b/tests/test_membw.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2024 Venere Labs
+// SPDX-License-Identifier: MIT
+
+#include <doctest/doctest.h>
+
+#include "xllama/membw.h"
+
+#include <string>
+
+using namespace xllama;
+
+TEST_CASE("membw: small buffer yields plausible positive bandwidths") {
+    // Tiny buffer + 2 iterations keeps the test fast; we assert shape, not a
+    // specific GB/s (that is hardware-dependent and measured, not unit-tested).
+    MembwResult r = measure_membw(/*bytes=*/1u << 20, /*iterations=*/2, /*threads=*/1);
+    CHECK(r.threads == 1);
+    CHECK(r.iterations == 2);
+    CHECK(r.buffer_bytes > 0);
+    CHECK(r.read_gbs > 0.0);
+    CHECK(r.copy_gbs > 0.0);
+    CHECK(r.triad_gbs > 0.0);
+    // Sanity ceiling: no CPU moves petabytes/s — catches a bogus zero-time div.
+    CHECK(r.read_gbs < 100000.0);
+    CHECK(r.copy_gbs < 100000.0);
+    CHECK(r.triad_gbs < 100000.0);
+}
+
+TEST_CASE("membw: threads<=0 auto-detects at least one worker") {
+    MembwResult r = measure_membw(1u << 20, 1, /*threads=*/0);
+    CHECK(r.threads >= 1);
+}
+
+TEST_CASE("membw: buffer is rounded to a whole number of doubles") {
+    // An odd byte count must not crash and must round down to a double multiple.
+    MembwResult r = measure_membw(/*bytes=*/(1u << 20) + 3, 1, 1);
+    CHECK(r.buffer_bytes % sizeof(double) == 0);
+}
+
+TEST_CASE("membw: CSV row matches the header column count") {
+    MembwResult r = measure_membw(1u << 20, 1, 1);
+    std::string header = membw_csv_header();
+    std::string row = format_membw_row(r, "unittest");
+    auto commas = [](const std::string& s) {
+        int n = 0;
+        for (char c : s)
+            if (c == ',')
+                ++n;
+        return n;
+    };
+    CHECK(commas(header) == commas(row));
+    CHECK(row.find("unittest") != std::string::npos);
+    CHECK(row.back() == '\n');
+}

--- a/uwp/App.cpp
+++ b/uwp/App.cpp
@@ -243,6 +243,14 @@ int __stdcall wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
                 winrt::make<HeadlessView>(&::xllama::bridge::main_loop, "bench"));
             return 0; // not reached: CoreApplication::Exit terminates the process
         }
+        std::wstring membw_flag = flag_path_if_present(L"membw.flag");
+        if (!membw_flag.empty()) {
+            _wremove(membw_flag.c_str());
+            ::xllama::log_output("[xllama] membw.flag detected -> headless membw mode\n");
+            winrt::Windows::ApplicationModel::Core::CoreApplication::Run(
+                winrt::make<HeadlessView>(&::xllama::bridge::run_membw, "membw"));
+            return 0; // not reached: CoreApplication::Exit terminates the process
+        }
         winrt::uninit_apartment(); // restore pre-existing thread state for XAML
         winrt::Windows::UI::Xaml::Application::Start(
             [](auto&&) { winrt::make<winrt::xllama::implementation::App>(); });

--- a/uwp/inference-bridge.cpp
+++ b/uwp/inference-bridge.cpp
@@ -5,6 +5,7 @@
 
 #include "xllama/chat_prompt.h"
 #include "xllama/inference.h"
+#include "xllama/membw.h"
 #include "xllama/path_utils.h"
 #include "xllama/platform.h"
 #include "xllama/session.h"
@@ -214,6 +215,45 @@ void main_loop() {
 
     InferenceResult res = ::xllama::run_inference(params);
     xllama::write_bench_csv(params, res, host_buf);
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// run_membw (called from UWP membw.flag mode background thread)
+// ---------------------------------------------------------------------------
+
+void run_membw() {
+#ifdef XLLAMA_UWP
+    log_output("[xllama] membw: measuring CPU memory bandwidth\n");
+    // Two passes: single-thread and full-width, so the scaling ratio is visible.
+    // 256 MB working set overflows the LLC → measures DRAM, not cache.
+    const std::size_t buf = static_cast<std::size_t>(256) << 20;
+    const ::xllama::MembwResult st = ::xllama::measure_membw(buf, 5, 1);
+    const ::xllama::MembwResult mt = ::xllama::measure_membw(buf, 5, 0);
+
+    char lb[256];
+    snprintf(lb, sizeof(lb),
+             "[xllama] membw: 1t read=%.1f copy=%.1f triad=%.1f | %dt read=%.1f copy=%.1f "
+             "triad=%.1f GB/s\n",
+             st.read_gbs, st.copy_gbs, st.triad_gbs, mt.threads, mt.read_gbs, mt.copy_gbs,
+             mt.triad_gbs);
+    log_output(lb);
+
+    const std::string csv = resolve_local_path("membw-result.csv");
+    FILE* fp = _wfopen(utf8_to_wstring(csv).c_str(), L"w");
+    if (fp) {
+        fputs(::xllama::membw_csv_header(), fp);
+        fputs(::xllama::format_membw_row(st, "xbox-series-s-t1").c_str(), fp);
+        fputs(::xllama::format_membw_row(mt, "xbox-series-s").c_str(), fp);
+        fclose(fp);
+        FILE* done =
+            _wfopen(utf8_to_wstring(resolve_local_path("membw-result.csv.done")).c_str(), L"w");
+        if (done) {
+            fputs("done\n", done);
+            fclose(done);
+        }
+        log_output("[xllama] membw-result.csv written\n");
+    }
 #endif
 }
 

--- a/uwp/inference-bridge.h
+++ b/uwp/inference-bridge.h
@@ -19,6 +19,11 @@ inline InferenceResult run_inference(const InferenceParams& params) {
 // Called from UWP App on a background thread (bench mode).
 void main_loop();
 
+// CPU memory-bandwidth micro-bench. Triggered by LocalFolder\membw.flag; writes
+// membw-result.csv (+ .done marker) to LocalState. Pins the DRAM-bandwidth
+// ceiling behind the bandwidth-bound decode number (see docs/benchmarks.md).
+void run_membw();
+
 // Diffusion pipeline (SD-Turbo on plain ORT DirectML). Triggered by
 // LocalFolder\diffuse.flag (headless) or diffuse-inproc.flag (in-process
 // experiment) — see diffuse.cpp for the model contract.

--- a/uwp/model-downloader.cpp
+++ b/uwp/model-downloader.cpp
@@ -8,6 +8,7 @@
 #include "model-downloader.h"
 // clang-format on
 
+    #include "xllama/manifest_merge.h"
     #include "xllama/platform.h"
     #include "xllama/utf8_utils.h"
 
@@ -338,18 +339,7 @@ std::vector<ManifestEntry> LoadModelManifest() {
         read_manifest_file(std::wstring(local.Path().c_str()) + L"\\manifest.json");
     if (!override_entries.empty()) {
         log_output("[manifest] merging LocalState\\manifest.json override (per-entry)\n");
-        for (auto& oe : override_entries) {
-            bool replaced = false;
-            for (auto& e : entries) {
-                if (e.name == oe.name) {
-                    e = std::move(oe);
-                    replaced = true;
-                    break;
-                }
-            }
-            if (!replaced)
-                entries.push_back(std::move(oe));
-        }
+        merge_manifest_entries(entries, std::move(override_entries));
     }
     if (!entries.empty())
         return entries;

--- a/uwp/model-downloader.h
+++ b/uwp/model-downloader.h
@@ -47,8 +47,9 @@ class ModelDownloader {
 // means the model cannot be auto-downloaded (USB/Device-Portal provisioning only).
 // kind selects the consumer AND the backend: "ort-genai" (default, chat picker,
 // ORT GenAI backend), "diffusion" (image dialog; hidden from the chat picker), or
-// "gguf" (chat picker, llama.cpp backend; KV-reuse and EP routing disabled — the
-// llama.cpp path is stateless and CPU-only on Xbox).
+// "gguf" (chat picker, llama.cpp backend). The gguf path is CPU-only on Xbox (no
+// EP routing — llama.cpp UWP build is CPU-only) but KV-reuse IS enabled via a
+// persistent llama_context (turn-2 prefill 4.07×, see docs/benchmarks.md).
 struct ManifestEntry {
     std::wstring name;
     std::wstring display;

--- a/uwp/xllama.vcxproj
+++ b/uwp/xllama.vcxproj
@@ -293,6 +293,7 @@
     <ClCompile Include="..\src\bridge\inference.cpp" />
     <ClCompile Include="..\src\bridge\session.cpp" />
     <ClCompile Include="..\src\bridge\bench.cpp" />
+    <ClCompile Include="..\src\bridge\membw.cpp" />
     <ClCompile Include="..\src\bridge\platform.cpp" />
     <ClCompile Include="..\src\bridge\path_utils.cpp" />
     <ClCompile Include="..\src\bridge\utf8_utils.cpp" />


### PR DESCRIPTION
Closes the autonomous Phase-6 Tier3 backlog (task #22) plus two perf-tooling items selected for this round.

## What's here

**Manifest per-entry merge — factored + unit-tested**
- Extract `LoadModelManifest`'s override merge into a pure, header-only `xllama::merge_manifest_entries` (`include/xllama/manifest_merge.h`).
- 7 doctest cases (`tests/test_manifest_merge.cpp`): replace / append / preserve, order, empty base/override, dup-name, and the 2026-07-10 whole-catalogue-shadow regression.

**Prefill batch knobs (n_batch / n_ubatch)**
- Plumbed through `InferenceParams`/`SessionParams` → `llama_context_params` on both the single-shot and persistent-session paths.
- `xllama-cli --batch/--ubatch` + `scripts/bench-ubatch-sweep.sh`.
- Finding: host sweep is noise-dominated, no reproducible ubatch trend; default (512) kept.

**CPU memory-bandwidth micro-bench (membw)**
- Portable `measure_membw` (STREAM read/copy/triad); `xllama-cli --membw` (host) + `membw.flag` headless mode (console → `membw-result.csv`).
- Pins the DRAM-bandwidth ceiling behind the bandwidth-bound decode number. 4 doctest cases. Host i7: 28.1 GB/s read @8t.

**Stale in-code comments fixed**
- `ManifestEntry` (gguf KV-reuse now enabled) and `GenerateParams` reuse_kv/reset_kv (both backends now, not ORT-only).

**Docs**: `benchmarks.md` (ubatch + membw sections), ROADMAP checkboxes (install-latest-build --bench, membw), CHANGELOG `[Unreleased]`.

## Verification
- Full host test suite: **60 cases / 794 assertions pass**.
- `check-uwp-sources.sh`: in sync. clang-format: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable prefill batch and micro-batch options through the CLI and session settings.
  * Added a CPU memory-bandwidth benchmark with CLI and app-triggered execution, including CSV output.
  * Added tooling to compare performance across micro-batch sizes.
  * Improved manifest updates to preserve existing entries while applying overrides.

* **Documentation**
  * Documented download verification, batching options, benchmark workflows, and current provisioning limitations.

* **Bug Fixes**
  * Fixed manifest overrides that could hide unmodified model entries.
  * Clarified persistent KV-cache reuse behavior across backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->