### PR TITLE
fix(provisioning): auto-upgrade stale quant to the manifest's current file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Model provisioning now auto-upgrades a stale quant** — `IsModelProvisioned`
+  gained an expected-aware overload (compares the dir against the manifest's
+  current `files[].filename` via the new pure `dir_satisfies_expected_files`,
+  `include/xllama/model_provision.h`), and `EnsureModelNamedAsync` loads the
+  manifest before the provisioned-check and reconciles the dir (deletes any
+  non-expected `*.gguf` + drops the stale `.complete`) before re-downloading. A
+  directory holding an older `.gguf` than the manifest names (e.g. a stale IQ2_M
+  under `gemma4-e2b`) is no longer treated as provisioned, and the coexisting-file
+  hazard in `first_gguf_in_dir` is closed. `EnsureGpuModelIfNeeded` is
+  expected-aware too. 13 host doctest cases (`tests/test_model_provision.cpp`).
+- Fixed a stale comment in `MainPage.cpp::StartInference`: GGUF KV-cache reuse is
+  supported (persistent `llama_context`), gated by `kv_reuse_supported_for_model`;
+  only EP routing stays gated off for GGUF.
 - `scripts/bench-xbox-ort.sh`: verify `bench-result.csv.done` is actually deleted
   before a run, so `wait_for_done` can't return off a stale marker (silent wrong row).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   read/copy/triad, `include/xllama/membw.h`) with `xllama-cli --membw` (host) and a
   `membw.flag` headless mode (console → `membw-result.csv`). Pins the DRAM-bandwidth
   ceiling behind the bandwidth-bound decode number. 4 host doctest cases.
+  Console-measured 2026-07-15: Xbox Zen 2 read 12.35 GB/s @1t / 30.29 @8t — the
+  single-thread read matches the deduced ~13 GB/s GEMV denominator.
 - Consolidated documentation onto single-source-of-truth docs (perf →
   `benchmarks.md`, constraints → `uwp-constraints.md`, catalogue →
   `model-selection.md` + `manifest.json`); refreshed stale version/quant/KV claims.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -315,9 +315,11 @@ Open items only — everything above is measured or shipped.
 - [x] **In-app HF download verified on-console** (2026-07-15) — the app's own
       downloader pulled the 2.29 GB single `.gguf` from HF and loaded+generated it,
       confirming the >2 GB self-download path (see `docs/benchmarks.md`).
-- [ ] **`IsModelProvisioned` quant-upgrade gap** — a dir with _any_ `.gguf` counts
-      as provisioned, so a stale-quant entry is not auto-upgraded to the manifest's
-      current file. Check the expected manifest filename, not just "a gguf exists".
+- [x] **`IsModelProvisioned` quant-upgrade** (2026-07-15, PR #64) — expected-aware
+      overload + dir reconcile: a stale-quant dir is now re-downloaded to the
+      manifest's file. Verified on-console — `gemma4-e2b` with a stale IQ2_M +
+      `.complete` marker → removed IQ2_M → downloaded Q3_K_S (2.45 GB) → loaded.
+      13 host doctest cases. See `docs/benchmarks.md`.
 - [ ] **Demo video** — model loaded and running on Xbox hardware (Phase 4 carry-over)
 - [ ] **Publication venue** — GitHub Discussions vs arXiv for `docs/technical-report.md`
 - [ ] **`smollm2-1.7b-cpu-int4` on `models-v1`** — manifest ready; optional 1.4 GB
@@ -327,7 +329,8 @@ Open items only — everything above is measured or shipped.
       straight into the UI). See `scripts/install-latest-build.sh`.
 - [x] (optional) **membw.flag** micro-bench — pins the CPU bandwidth denominator
       behind decode. `measure_membw` (STREAM read/copy/triad), `xllama-cli --membw`
-      (host) + `membw.flag` (console → `membw-result.csv`). Host i7: 28.1 GB/s
-      read @8t. See `docs/benchmarks.md`; on-console pass pending.
+      (host) + `membw.flag` (console → `membw-result.csv`). **Console-measured
+      2026-07-15**: Xbox Zen 2 read 12.35 GB/s @1t / 30.29 @8t — the single-thread
+      read matches the deduced ~13 GB/s GEMV denominator. See `docs/benchmarks.md`.
 - [ ] (upstream, deprioritised) **Fused low-bit GPU GEMM in DirectML** — §12;
       not a local contribution via #2280

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -200,10 +200,21 @@ Host reference (i7-1165G7, 2026-07-14, `xllama-cli --membw`):
 | 1       |      11.8 |      23.0 |       14.0 |
 | 8       |      28.1 |      36.3 |       26.3 |
 
-On-console: drop a `membw.flag` into `LocalState` (the app runs the bench headless
-and writes `membw-result.csv`, single-thread + full-width rows). This pins the
-Xbox Zen 2 / GDDR6 CPU-side ceiling so the 13 GB/s GEMV figure can be reported as a
-fraction of it (pending one console pass).
+On-console (Xbox Series S, Zen 2 / GDDR6, MSIX 1.1.6.464, 2026-07-15,
+`membw.flag`):
+
+| Threads | Read GB/s | Copy GB/s | Triad GB/s |
+| ------- | --------: | --------: | ---------: |
+| 1       |     12.35 |     28.34 |      18.29 |
+| 8       |     30.29 |     42.02 |      24.20 |
+
+**This closes the loop on the "~13 GB/s effective" GEMV figure**: the measured
+single-thread read is **12.35 GB/s** — essentially the deduced decode denominator —
+and the full-width ceiling is **~30 GB/s** read. So CPU int4 decode streams weights
+at roughly single-thread bandwidth (~40% of the 8-thread ceiling); the GEMV is
+latency/dispatch-bound per token rather than saturating aggregate DRAM bandwidth,
+consistent with why more threads help prefill (batched) but not decode (M=1). Drop
+a `membw.flag` into `LocalState` to reproduce (`membw-result.csv`, 1t + full-width).
 
 ## Reproducing
 
@@ -228,7 +239,8 @@ batch). Now exposed end-to-end (`InferenceParams`/`SessionParams` →
 (i7-1165G7, Qwen3.5-0.8B-Q4_K_M, 701-token prompt, 2026-07-14): repeated passes
 **disagree** on the ubatch=128 value (82.5 vs 117.4 tok/s) and show **no
 reproducible trend** — on a loaded dev laptop the measurement is noise-dominated.
-The knob is in place and CLI-sweepable; a clean optimum needs a quiet machine or
-an on-console pass (Xbox Zen 2 shares the x86 AVX2 ISA, so a flat curve is the
-expectation). Default (0 → llama.cpp 512) stays until a measured win justifies a
-change.
+The knob is in place and CLI-sweepable; a clean optimum needs a quiet machine (the
+headless console bench reads `bench_threads.txt` but not an ubatch override, so an
+on-console sweep would need a bench-mode change — out of scope). Xbox Zen 2 shares
+the x86 AVX2 ISA, so a flat curve is the expectation. Default (0 → llama.cpp 512)
+stays until a measured win justifies a change.

--- a/include/xllama/model_provision.h
+++ b/include/xllama/model_provision.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2024 Venere Labs
+// SPDX-License-Identifier: MIT
+//
+// Provisioning predicate — is a model directory populated with the manifest's
+// CURRENT expected files?
+//
+// The loose "any .gguf counts as provisioned" check (model-downloader.cpp) can't
+// tell a stale quant from the current one, so a directory holding an outdated
+// file (e.g. gemma-4-E2B-it-UD-IQ2_M.gguf) is never auto-upgraded to the
+// manifest's file (gemma-4-E2B-it-Q3_K_S.gguf). This predicate compares the
+// directory listing against the manifest's expected filename set so EnsureModel
+// can force a re-download when they diverge.
+//
+// Pure (no WinRT / no pch.h), mirroring manifest_merge.h, so it is host
+// doctest-testable. The UWP caller lists the directory and maps
+// ManifestEntry.files[].filename into `expected`.
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace xllama {
+
+// Normalize a path for comparison: backslashes → '/', ASCII-lowercased. Windows
+// filesystems are case-insensitive and the manifest uses '/' while a native
+// listing yields '\\'; the gemma filenames are mixed-case, so both axes matter.
+inline std::wstring normalize_model_path(std::wstring s) {
+    for (auto& ch : s) {
+        if (ch == L'\\')
+            ch = L'/';
+        else if (ch >= L'A' && ch <= L'Z')
+            ch = static_cast<wchar_t>(ch - L'A' + L'a');
+    }
+    return s;
+}
+
+// True iff EVERY expected file is present in the directory listing. `present` =
+// directory-relative paths of the files on disk; `expected` = the manifest's
+// files[].filename values. Comparison is separator- and case-insensitive. Extra
+// present files are ignored (a superset is fine). An empty `expected` returns
+// false: the predicate never guesses — the caller applies the loose fallback.
+inline bool dir_satisfies_expected_files(const std::vector<std::wstring>& present,
+                                         const std::vector<std::wstring>& expected) {
+    if (expected.empty())
+        return false;
+    std::vector<std::wstring> norm_present;
+    norm_present.reserve(present.size());
+    for (const auto& p : present)
+        norm_present.push_back(normalize_model_path(p));
+
+    for (const auto& want : expected) {
+        const std::wstring w = normalize_model_path(want);
+        bool found = false;
+        for (const auto& have : norm_present) {
+            if (have == w) {
+                found = true;
+                break;
+            }
+        }
+        if (!found)
+            return false;
+    }
+    return true;
+}
+
+} // namespace xllama

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(xllama-tests
     test_chat_prompt.cpp
     test_manifest_merge.cpp
     test_membw.cpp
+    test_model_provision.cpp
 )
 
 target_link_libraries(xllama-tests PRIVATE xllama doctest::doctest)

--- a/tests/test_model_provision.cpp
+++ b/tests/test_model_provision.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2024 Venere Labs
+// SPDX-License-Identifier: MIT
+
+#include <doctest/doctest.h>
+
+#include "xllama/model_provision.h"
+
+#include <string>
+#include <vector>
+
+using namespace xllama;
+
+using WS = std::vector<std::wstring>;
+
+TEST_CASE("provision: gguf current quant present -> true") {
+    WS present{L"gemma-4-E2B-it-Q3_K_S.gguf"};
+    WS expected{L"gemma-4-E2B-it-Q3_K_S.gguf"};
+    CHECK(dir_satisfies_expected_files(present, expected));
+}
+
+TEST_CASE("provision: stale quant present, current expected -> false (the bug)") {
+    // The reported on-console case: dir holds the old IQ2_M, manifest wants Q3_K_S.
+    WS present{L"gemma-4-E2B-it-UD-IQ2_M.gguf"};
+    WS expected{L"gemma-4-E2B-it-Q3_K_S.gguf"};
+    CHECK_FALSE(dir_satisfies_expected_files(present, expected));
+}
+
+TEST_CASE("provision: old + new both present, expects new -> true (extra ignored)") {
+    WS present{L"gemma-4-E2B-it-UD-IQ2_M.gguf", L"gemma-4-E2B-it-Q3_K_S.gguf"};
+    WS expected{L"gemma-4-E2B-it-Q3_K_S.gguf"};
+    CHECK(dir_satisfies_expected_files(present, expected));
+}
+
+TEST_CASE("provision: ort-genai full set present -> true") {
+    WS present{L"genai_config.json", L"tokenizer.json", L"tokenizer_config.json", L"model.onnx"};
+    WS expected{L"genai_config.json", L"tokenizer.json", L"tokenizer_config.json", L"model.onnx"};
+    CHECK(dir_satisfies_expected_files(present, expected));
+}
+
+TEST_CASE("provision: ort-genai missing model.onnx -> false") {
+    WS present{L"genai_config.json", L"tokenizer.json", L"tokenizer_config.json"};
+    WS expected{L"genai_config.json", L"tokenizer.json", L"tokenizer_config.json", L"model.onnx"};
+    CHECK_FALSE(dir_satisfies_expected_files(present, expected));
+}
+
+TEST_CASE("provision: diffusion multi-subdir set present -> true") {
+    WS present{L"text_encoder/model.onnx", L"unet/model.onnx", L"vae_decoder/model.onnx"};
+    WS expected{L"text_encoder/model.onnx", L"unet/model.onnx", L"vae_decoder/model.onnx"};
+    CHECK(dir_satisfies_expected_files(present, expected));
+}
+
+TEST_CASE("provision: native backslash present vs forward-slash expected -> true") {
+    WS present{L"unet\\model.onnx", L"vae_decoder\\model.onnx"};
+    WS expected{L"unet/model.onnx", L"vae_decoder/model.onnx"};
+    CHECK(dir_satisfies_expected_files(present, expected));
+}
+
+TEST_CASE("provision: case-insensitive filename match -> true") {
+    WS present{L"model.onnx"};
+    WS expected{L"Model.ONNX"};
+    CHECK(dir_satisfies_expected_files(present, expected));
+}
+
+TEST_CASE("provision: empty expected -> false (caller does loose fallback)") {
+    WS present{L"anything.gguf"};
+    CHECK_FALSE(dir_satisfies_expected_files(present, WS{}));
+}
+
+TEST_CASE("provision: empty present, non-empty expected -> false") {
+    WS expected{L"model.gguf"};
+    CHECK_FALSE(dir_satisfies_expected_files(WS{}, expected));
+}
+
+TEST_CASE("provision: present is a strict superset of expected -> true") {
+    WS present{L"model.gguf", L"README.md", L".complete", L"extra.bin"};
+    WS expected{L"model.gguf"};
+    CHECK(dir_satisfies_expected_files(present, expected));
+}
+
+TEST_CASE("provision: diffusion with one required subdir file missing -> false") {
+    WS present{L"text_encoder/model.onnx", L"unet/model.onnx"};
+    WS expected{L"text_encoder/model.onnx", L"unet/model.onnx", L"vae_decoder/model.onnx"};
+    CHECK_FALSE(dir_satisfies_expected_files(present, expected));
+}
+
+TEST_CASE("provision: normalize_model_path lowercases and unifies separators") {
+    CHECK(normalize_model_path(L"UNet\\Model.ONNX") == L"unet/model.onnx");
+}

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -11,6 +11,7 @@
     #include "chat-history.h"
     #include "inference-bridge.h"
     #include "xllama/chat_prompt.h"
+    #include "xllama/model_provision.h"
     #include "xllama/platform.h"
     #include "xllama/routing_policy.h"
     #include "xllama/utf8_utils.h"
@@ -1417,7 +1418,17 @@ void MainPageController::EnsureGpuModelIfNeeded() {
     if (m_routing == 0)
         return;
     const std::wstring gpu = ::xllama::utf8_to_wstring(m_gpu_model);
-    if (::xllama::IsModelProvisioned(gpu))
+    // Expected-aware so a stale-quant GPU model is upgraded like the chat model
+    // (EnsureModelNamedAsync would otherwise be short-circuited here). Empty
+    // expected → loose fallback.
+    std::vector<std::wstring> gpu_expected;
+    {
+        auto manifest = ::xllama::LoadModelManifest();
+        if (const auto* e = ::xllama::FindManifestEntry(manifest, gpu))
+            for (const auto& f : e->files)
+                gpu_expected.push_back(f.filename);
+    }
+    if (::xllama::IsModelProvisioned(gpu, gpu_expected))
         return;
     log_output(
         ("[xllama] EnsureModel: gpu_model '" + m_gpu_model + "' missing — background provision\n")
@@ -1441,12 +1452,22 @@ fire_and_forget MainPageController::EnsureModelNamedAsync(std::wstring model_nam
         ("[xllama] EnsureModel: begin '" + ::xllama::wstring_to_utf8(model_name) + "'\n").c_str());
     co_await resume_background();
 
+    // Load the catalogue up-front so every provisioning check can compare against
+    // the entry's CURRENT expected files (auto-upgrade a stale quant) instead of
+    // accepting any gguf. Empty expected → loose fallback (USB/WDP/no entry).
+    auto manifest = ::xllama::LoadModelManifest();
+    const ::xllama::ManifestEntry* entry = ::xllama::FindManifestEntry(manifest, model_name);
+    std::vector<std::wstring> expected_files;
+    if (entry)
+        for (const auto& f : entry->files)
+            expected_files.push_back(f.filename);
+
     // Check 1: LocalState model complete?
     auto local_folder = winrt::Windows::Storage::ApplicationData::Current().LocalFolder();
     std::wstring local_models_root = std::wstring(local_folder.Path().c_str()) + L"\\models";
     std::wstring local_model_dir = local_models_root + L"\\" + model_name;
 
-    if (IsModelProvisioned(model_name)) {
+    if (IsModelProvisioned(model_name, expected_files)) {
         log_output(("[xllama] EnsureModel: '" + ::xllama::wstring_to_utf8(model_name) +
                     "' already provisioned\n")
                        .c_str());
@@ -1610,11 +1631,9 @@ fire_and_forget MainPageController::EnsureModelNamedAsync(std::wstring model_nam
             co_return;
         }
     }
-    // Neither found: consult the model catalogue (models/manifest.json) — any
-    // entry with an hf_base_url can be auto-downloaded; anything else must be
-    // provided via USB or Device Portal upload.
-    auto manifest = ::xllama::LoadModelManifest();
-    const ::xllama::ManifestEntry* entry = ::xllama::FindManifestEntry(manifest, model_name);
+    // Neither found: consult the model catalogue (loaded above) — any entry with
+    // an hf_base_url can be auto-downloaded; anything else must be provided via
+    // USB or Device Portal upload.
     if (!entry || entry->hf_base_url.empty() || entry->files.empty()) {
         log_output(("[xllama] EnsureModel: '" + ::xllama::wstring_to_utf8(model_name) +
                     "' not in catalogue (no hf_base_url)\n")
@@ -1661,6 +1680,43 @@ fire_and_forget MainPageController::EnsureModelNamedAsync(std::wstring model_nam
                             StatusKind::Error);
             co_return;
         }
+    }
+
+    // Reconcile the dir to the expected set before downloading: drop any *.gguf
+    // that isn't in the manifest's expected files (a stale quant we're upgrading
+    // away from) and clear the stale .complete marker. Without this the old and
+    // new gguf coexist and first_gguf_in_dir() may load the wrong one; it also
+    // frees the ~2.3 GB the old quant occupies.
+    {
+        std::vector<std::wstring> expected_norm;
+        for (const auto& e : expected_files)
+            expected_norm.push_back(::xllama::normalize_model_path(e));
+        // Collect stale gguf paths first, then remove — mutating the directory
+        // mid-iteration is undefined.
+        std::vector<std::filesystem::path> stale;
+        std::error_code ec;
+        for (const auto& de :
+             std::filesystem::directory_iterator(std::filesystem::path(local_model_dir), ec)) {
+            if (!de.is_regular_file(ec) || de.path().extension() != L".gguf")
+                continue;
+            std::wstring rel = ::xllama::normalize_model_path(de.path().filename().wstring());
+            bool wanted = false;
+            for (const auto& w : expected_norm)
+                if (w == rel) {
+                    wanted = true;
+                    break;
+                }
+            if (!wanted)
+                stale.push_back(de.path());
+        }
+        for (const auto& p : stale) {
+            std::error_code rm_ec;
+            std::filesystem::remove(p, rm_ec);
+            log_output(("[xllama] EnsureModel: removed stale file '" +
+                        ::xllama::wstring_to_utf8(p.filename().wstring()) + "'\n")
+                           .c_str());
+        }
+        ModelDownloader::Invalidate(local_model_dir);
     }
 
     co_await resume_foreground(dispatcher);
@@ -1804,10 +1860,11 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
         SetStatus(L"Context trimmed — " + std::to_wstring(n_dropped) + L" old turn(s) dropped");
 
     // Is the base model a GGUF (llama.cpp backend)? On Xbox llama.cpp is CPU-only
-    // (no ggml GPU backend) and LlamaSession is stateless, so both EP routing and
-    // KV-cache reuse are meaningless — and reuse would be *incorrect* (it sends
-    // only the turn delta, which a stateless backend would treat as the whole
-    // prompt). Gate both off for GGUF models.
+    // (no ggml GPU backend), so EP routing is meaningless and stays gated off for
+    // GGUF (below). KV-cache reuse, however, IS supported: LlamaSession keeps a
+    // persistent llama_context, so a reuse turn appends only the delta (turn-2
+    // prefill 4.07×). Reuse is gated by kv_reuse_supported_for_model(), not by
+    // this flag.
     bool base_is_gguf = false;
     {
         auto manifest = ::xllama::LoadModelManifest();

--- a/uwp/model-downloader.cpp
+++ b/uwp/model-downloader.cpp
@@ -9,6 +9,7 @@
 // clang-format on
 
     #include "xllama/manifest_merge.h"
+    #include "xllama/model_provision.h"
     #include "xllama/platform.h"
     #include "xllama/utf8_utils.h"
 
@@ -278,24 +279,64 @@ bool dir_has_ort_or_gguf(const std::filesystem::path& dir) {
     return false;
 }
 
+// Directory-relative paths of every regular file under `dir` (recursive, so
+// diffusion subdir files like unet/model.onnx are seen). The .complete marker is
+// bookkeeping, not a model file — omit it. Empty if the dir is absent.
+std::vector<std::wstring> list_relative_files(const std::filesystem::path& dir) {
+    std::vector<std::wstring> out;
+    std::error_code ec;
+    if (!std::filesystem::is_directory(dir, ec))
+        return out;
+    for (const auto& ent : std::filesystem::recursive_directory_iterator(dir, ec)) {
+        if (!ent.is_regular_file(ec))
+            continue;
+        std::error_code rel_ec;
+        auto rel = std::filesystem::relative(ent.path(), dir, rel_ec);
+        if (rel_ec)
+            continue;
+        std::wstring w = rel.wstring();
+        if (w == L".complete")
+            continue;
+        out.push_back(std::move(w));
+    }
+    return out;
+}
+
+// Is `dir` provisioned? Loose mode (empty expected) keeps the historical
+// any-gguf/genai_config check; expected mode requires the manifest's current file
+// set to be present (so a stale quant no longer counts as provisioned).
+bool dir_provisioned(const std::filesystem::path& dir, const std::vector<std::wstring>& expected) {
+    if (expected.empty())
+        return dir_has_ort_or_gguf(dir);
+    return dir_satisfies_expected_files(list_relative_files(dir), expected);
+}
+
 } // namespace
 
 bool IsModelProvisioned(std::wstring const& model_name) {
+    return IsModelProvisioned(model_name, {});
+}
+
+bool IsModelProvisioned(std::wstring const& model_name,
+                        std::vector<std::wstring> const& expected_files) {
     if (model_name.empty())
         return false;
 
     auto local = ApplicationData::Current().LocalFolder();
     std::wstring local_dir = std::wstring(local.Path().c_str()) + L"\\models\\" + model_name;
-    if (ModelDownloader::IsComplete(local_dir))
+    // The .complete marker is a fast-path ONLY in loose mode: in expected mode a
+    // stale-quant dir can still carry a valid old marker — exactly what defeats
+    // auto-upgrade — so the expected-file scan is authoritative there.
+    if (expected_files.empty() && ModelDownloader::IsComplete(local_dir))
         return true;
-    if (dir_has_ort_or_gguf(std::filesystem::path(local_dir)))
+    if (dir_provisioned(std::filesystem::path(local_dir), expected_files))
         return true;
 
     try {
         auto pkg = winrt::Windows::ApplicationModel::Package::Current();
         std::wstring installed =
             std::wstring(pkg.InstalledPath().c_str()) + L"\\models\\" + model_name;
-        if (dir_has_ort_or_gguf(std::filesystem::path(installed)))
+        if (dir_provisioned(std::filesystem::path(installed), expected_files))
             return true;
     } catch (...) {
     }
@@ -314,7 +355,7 @@ bool IsModelProvisioned(std::wstring const& model_name) {
                 usb.pop_back();
             if (!usb.empty()) {
                 std::wstring usb_dir = usb + L"\\xllama\\models\\" + model_name;
-                if (dir_has_ort_or_gguf(std::filesystem::path(usb_dir)))
+                if (dir_provisioned(std::filesystem::path(usb_dir), expected_files))
                     return true;
             }
         }

--- a/uwp/model-downloader.h
+++ b/uwp/model-downloader.h
@@ -77,8 +77,16 @@ inline const ManifestEntry* FindManifestEntry(const std::vector<ManifestEntry>& 
 
 // True when the model dir is usable without a download: .complete marker, a
 // WDP/USB upload (genai_config.json or *.gguf present), bundled in the MSIX,
-// or on removable storage at xllama\models\<name>.
+// or on removable storage at xllama\models\<name>. This LOOSE form accepts any
+// gguf/ORT layout and cannot tell a stale quant from the current one.
 bool IsModelProvisioned(std::wstring const& model_name);
+
+// Expected-aware form: a dir counts as provisioned only if it holds the manifest's
+// CURRENT expected files (`expected_files` = entry.files[].filename). An empty
+// list falls back to the loose behavior above. Use this so a stale-quant dir (an
+// older .gguf than the manifest now names) is re-downloaded instead of loaded.
+bool IsModelProvisioned(std::wstring const& model_name,
+                        std::vector<std::wstring> const& expected_files);
 
 } // namespace xllama
 


### PR DESCRIPTION
## Problem
`IsModelProvisioned` treated a model dir containing **any** `.gguf` as provisioned, so a directory holding a stale quant (e.g. `gemma-4-E2B-it-UD-IQ2_M.gguf`) was never auto-upgraded to the manifest's current file (`gemma-4-E2B-it-Q3_K_S.gguf`). Verified on-console 2026-07-15 during the in-app HF download check.

Adjacent hazard: `first_gguf_in_dir` (path_utils.cpp) returns the first `.gguf` in arbitrary order, and `DownloadAsync` writes only the manifest files with `ReplaceExisting` without removing the stale one — so after a re-download both quants coexist and the loader could pick the old one.

## Fix
- **`include/xllama/model_provision.h`** (new, pure/header-only like `manifest_merge.h`): `dir_satisfies_expected_files(present, expected)` — separator/case-insensitive, all-expected-present, empty-expected→false (caller does loose fallback). **13 host doctest cases** (`tests/test_model_provision.cpp`), incl. the stale-quant regression.
- **`model-downloader.{h,cpp}`**: expected-aware `IsModelProvisioned` overload + `dir_provisioned`/`list_relative_files` helpers. The 1-arg loose form is unchanged (delegates with `{}`); the `.complete` fast-path is honored only in loose mode (a stale dir can carry a valid old marker).
- **`MainPage.cpp` `EnsureModelNamedAsync`**: hoist the manifest load above the provisioned early-return, pass `expected`, and **reconcile the dir before download** (delete non-expected `*.gguf` + `Invalidate`) — closes the coexisting-file hazard and frees ~2.3 GB. `EnsureGpuModelIfNeeded` is expected-aware too; the `gpu_provisioned` UX gate stays loose by design.
- Fixed a stale `StartInference` comment: GGUF KV-reuse **is** supported (persistent `llama_context`, gated by `kv_reuse_supported_for_model`); only EP routing stays gated off for GGUF.

## Verification
- Host suite: **73 cases / 807 assertions pass**. clang-format clean, `check-uwp-sources.sh` in sync.
- On-console end-to-end (after this build ships): `gemma4-e2b` dir holds stale IQ2_M + manifest names Q3_K_S → provisioned-check returns false → re-download → reconcile removes IQ2_M → loads Q3_K_S (decode ~15.3 tok/s, not the IQ2_M 0-token EOG). Console still has `gemma4-q3` (Q3_K_S) as a backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Model provisioning now validates downloaded files against the current manifest, preventing stale quantization files from being treated as up to date.
  - Automatically removes outdated GGUF files and stale completion markers before downloading updated model assets.
  - Improved provisioning checks for GPU, local, and USB-cached models.
  - Corrected documentation describing GGUF inference behavior, including continued KV-cache reuse support.

- **Tests**
  - Added coverage for expected-file matching, path normalization, case differences, missing assets, and stale model files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->