### PR TITLE
release: v1.1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.1.7.0] - 2026-07-15
+
 ### Added
 
 - **GGUF KV-cache reuse** — `LlamaSession` keeps a persistent `llama_context`, so

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # xllama Roadmap
 
-**Shipping (2026-07-14):** MSIX **1.1.6.x** — `xllama-appx` from `build-uwp.yml`
+**Shipping (2026-07-15):** MSIX **1.1.7.x** — `xllama-appx` from `build-uwp.yml`
 (unified ORT + llama.cpp + PatchedGenAI #2280; Revision auto-stamped from the CI
 run number). Adds the per-architecture chat template + **Gemma** (`gemma3-270m`
 76.8 tok/s, `gemma4-e2b` Q3_K_S 15.3 tok/s — console-validated, `phase6-gemma.csv`)

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -15,7 +15,7 @@
   <Identity
     Name="VenereLabs.xllama"
     Publisher="CN=xllama-dev"
-    Version="1.1.6.0"
+    Version="1.1.7.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity


### PR DESCRIPTION
Cuts the **v1.1.7.0** release.

- `uwp/AppxManifest.xml`: 1.1.6.0 → **1.1.7.0** (CI auto-stamps the Revision from the run number).
- `CHANGELOG.md`: `[Unreleased]` → `[1.1.7.0] - 2026-07-15` (fresh empty `[Unreleased]` on top).
- `ROADMAP.md`: shipping banner → 1.1.7.x.

## Release highlights (since v1.1.5.0)
- **GGUF KV-cache reuse** — persistent `llama_context`, turn-2 prefill **4.07×**.
- **Per-architecture chat template + Gemma family** console-validated (gemma3-270m 76.8 tok/s; gemma4-e2b Q3_K_S 15.3 tok/s).
- **Model provisioning auto-upgrade** — a stale-quant dir is re-downloaded to the manifest's current file (verified on-console).
- **Prefill batch knobs** (`--batch/--ubatch`) + **membw micro-bench** (console: Xbox Zen 2 read 12.35 GB/s @1t / 30.29 @8t).
- Manifest/model-provision unit tests; docs consolidated onto SSOTs.

Once merged, tag `v1.1.7.0` and publish the GitHub Release with the CI MSIX (1.1.7.x) + test cert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)