### PR TITLE
docs: propagate fp16-extdata findings across SSOTs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -159,10 +159,16 @@ Milestones:
 - [x] **1B+ scale bench (CPU int4)** — ✅ SmolLM2-1.7B **cpu-int4 measured
       2026-07-08: 20.6 tok/s decode, peak 2423 MB** (`phase35-1b-cpu.csv`).
       Catalogue entry + `package-catalogue-ort-model.sh` ready; **1.4 GB asset
-      upload to `models-v1` optional** (WDP works today). **fp16-DML 1.7B blocked**
-      (protobuf > 2 GB — cannot merge self-contained; external data hits §8).
-      int4-DML 1.7B is mergeable but hits the §12 non-fused low-bit GEMM. The fp16-at-scale
-      bandwidth crossover stays blocked by serialization/AppContainer, not GPU.
+      upload to `models-v1` optional** (WDP works today). **fp16-DML at scale —
+      resolved 2026-07-15**: external-data loading >2 GB is now **unblocked** by the
+      patched ORT DLL (§8 Fix B: `weakly_canonical` guard + `ReadFile` 16 MB chunk,
+      console-validated with a 1.86 GB-extdata model). But the fp16-at-scale prefill
+      crossover is **not reachable on Series S for other reasons**: a native-DML
+      1B fp16 (2.49 GB) loads (2878/3801 MB) yet OOMs _inference_
+      (`AppendTokenSequences … 8007000E`, §7) — the GPU budget can't hold weights +
+      the DML inference working set at ≥1 B. int4-DML 1.7B is mergeable but hits the
+      §12 non-fused low-bit GEMM. Net: the >2 GB unblock helps **CPU** external-data
+      models, not bigger fp16 on the GPU (budget wall). See `docs/fp16-extdata-runbook.md`.
 - [x] **Desk check upstream int4 status** — ✅ done 2026-07-08
       (`docs/uwp-constraints.md §12`). Verdict: `MatMulNBits` is present and runs
       on the DML GPU (not missing, not CPU fallback); DirectML implements it

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -186,6 +186,21 @@ dispatch overhead at this model scale; CPU `MatMulNBits` on AVX2 wins
 (ROADMAP Phase 2 / `uwp-constraints.md §7`). GPU's win is **prefill** (353 vs
 198 tok/s at ~1k tokens), which is exactly what routing uses it for.
 
+### fp16 >2 GB external data — loads, but 1B fp16 OOMs GPU inference (2026-07-15)
+
+The AppContainer external-data blocker is fixed (patched ORT DLL, `uwp-constraints.md §8`
+Fix B): a 1.86 GB-extdata **int4/CPU** model loads and runs (6/6 restarts, 0×
+`weakly_canonical`, 0× `errcode 1450`). But the **fp16-at-scale GPU prefill
+crossover has no measurable point on Series S**: a native-DML Llama-3.2-1B fp16
+(2.49 GB, GQA) loads (`gpu-mem 2878/3801 MB`) then OOMs every inference call
+(`AppendTokenSequences … DmlCommittedResourceAllocator … 8007000E`, even at
+ctx 2048 — `uwp-constraints.md §7`). Weights fit; the ~900 MB headroom is too small
+for the DML inference working set. Any fp16 >2 GB is ≥~1B → same wall. So the
+usable DML-fp16 model stays ~360-500 M (the existing `smollm2-360m-dml-fp16`), and
+the >2 GB unblock is a **CPU-side** win, not a bigger-fp16-on-GPU one. (A cuda-fp16
+re-host also loads/partitions to DML but fails DML inference at runtime — a native
+`-p fp16 -e dml` build is required.)
+
 ## CPU memory bandwidth — the decode denominator
 
 Decode is a bandwidth-bound M=1 GEMV: each token streams the whole weight matrix

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -105,6 +105,16 @@ Sizes below are the published `model.onnx.data` file sizes on Hugging Face
 
 Verify with `merge_onnx_external_data.py` output before committing to a build.
 
+**External data >2 GB (un-mergeable) — unblocked for loading, but not for fp16-GPU
+(2026-07-15).** The 2 GB protobuf merge ceiling no longer blocks _loading_: the
+patched ORT DLL (`uwp-constraints.md §8` Fix B) loads external-`.onnx.data` models
+directly, console-validated with a 1.86 GB int4 model. **But this does not make big
+fp16 models viable on the GPU**: a native-DML 1B fp16 (2.49 GB) loads yet OOMs
+inference within the 3801 MB budget (`uwp-constraints.md §7`). Practical takeaway:
+the >2 GB path is a **CPU/int4** enabler; DML-fp16 stays ≤~360-500 M
+(`smollm2-360m-dml-fp16`). Build DML models natively (`builder … -p fp16 -e dml`) —
+a cuda-fp16 re-host loads but fails DML inference.
+
 **Future — BitNet / INT2 models**: Microsoft BitNet b1.58 (1-bit/1.58-bit quantization)
 could bring a 1.7B–3B model under 400 MB, fitting both the disk and GPU budgets.
 ORT GenAI does not natively support INT2 as of 0.14.1. Re-evaluate when

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -146,6 +146,8 @@ When `OgaCreateModel` initialises the DirectML execution provider, the DML alloc
 
 The fault manifests before any inference call — at model load time. There is no recovery path short of using a smaller model or switching to CPU EP.
 
+**The binding limit is the inference working set, not just the weights (measured 2026-07-15).** A native-DML Llama-3.2-1B fp16 (2.49 GB weights, GQA) **loads** fine — `gpu-mem post-load: 2878/3801 MB` — but every inference call then OOMs: `AppendTokenSequences … DmlCommittedResourceAllocator … 8007000E Not enough memory`, even at `context_length=2048`. The DML inference working set (graph-capture command allocators + prefill activations + the `past_present_share_buffer` KV buffer) needs more than the ~900 MB left after weights. So the usable DML-fp16 ceiling on Series S is set by **weights + working set ≤ 3801 MB**, which in practice caps fp16 at ~360-500 M (e.g. `smollm2-360m-dml-fp16`, ~700 MB weights). Any fp16 model large enough to require the >2 GB external-data path (§8) is ≥~1 B → over this wall.
+
 **Distinct failure mode — DML EP init `887A0036` in XAML apps** (2026-07-07,
 GPU-truth run, ORT GenAI 0.13.2 / ORT 1.24.4 / DirectML 1.15.4) — **root cause
 found at the exact source line and fixed architecturally in v0.3.4**:
@@ -216,9 +218,9 @@ informed inference unless backed by a Microsoft source.
 
 The `\\?\` long-path prefix does not help: it bypasses MAX_PATH but not the access check.
 
-**Fix**: before MSIX packaging, merge `model.onnx.data` into `model.onnx` to produce a self-contained model file. With no external data file, `ValidateExternalDataPath` is never called and `weakly_canonical` is never invoked.
+**Fix A (default, ≤2 GB)**: before MSIX packaging, merge `model.onnx.data` into `model.onnx` to produce a self-contained model file. With no external data file, `ValidateExternalDataPath` is never called and `weakly_canonical` is never invoked. Tool: `scripts/merge_onnx_external_data.py`. CI runs this automatically as part of `build-uwp`. **Caps at the 2 GB protobuf single-file ceiling.**
 
-Tool: `scripts/merge_onnx_external_data.py`. CI runs this automatically as part of `build-uwp`.
+**Fix B (patched ORT DLL, any size — console-validated 2026-07-15)**: for models whose `.onnx.data` is >2 GB (un-mergeable), a patched `onnxruntime.dll` guards the walk directly (`patches/onnxruntime-extdata-appcontainer.patch`, built via the `build-uwp-ort-patched` lane; see `docs/fp16-extdata-runbook.md`). The patch replaces the throwing `weakly_canonical()` with the `std::error_code` overload + `lexically_normal` fallback. **Validated**: a 1.86 GB-extdata int4 model that crashed pre-patch now loads and runs, 6/6 restarts, 0 crashes. A **second** patch in the same DLL shrinks ORT's `ReadFileIntoBuffer` chunk (`env.cc`) from 1 GB to 16 MB — a single ~0.5-1 GB `ReadFile` of a large un-quantized tensor (e.g. the 128k-vocab embedding) locks too many pages in the AppContainer and fails with `errcode 1450` (ERROR_NO_SYSTEM_RESOURCES); 16 MB chunks fix it. Note: Fix B unblocks _loading_, but fp16 >2 GB models still hit the GPU **inference** budget wall (§7).
 
 **Diagnosis**: Win32 probes on the model path — `GetFileAttributesW` and `CreateFile2` with `GENERIC_READ` succeed on `model_dir\model.onnx`, but the crash occurs inside the ORT segment-walking loop. Confirmed by matching the call site to `onnxruntime/core/framework/tensorprotoutils.cc` L337/338/346.
 


### PR DESCRIPTION
Coherence pass so the SSOTs reflect the console-validated results from the fp16>2GB-extdata work (#67/#68/#71/#72).

- **uwp-constraints.md §8** — add **Fix B** (patched ORT DLL: `weakly_canonical` guard + `ReadFile` 16 MB chunk) beside the merge workaround; note it unblocks *loading* only.
- **uwp-constraints.md §7** — the binding GPU limit is the **inference working set**, not just weights: a 1B fp16 loads (2878/3801 MB) but OOMs inference (`8007000E`).
- **ROADMAP.md** — fp16-DML-at-scale resolved: external-data loading unblocked; the fp16 GPU crossover is **not reachable on Series S** (budget wall); the >2 GB unblock is a **CPU** win.
- **benchmarks.md** — new root-cause note.
- **model-selection.md** — >2 GB path is CPU/int4-side; DML-fp16 stays ~360-500 M; build DML natively (cuda re-host fails DML inference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)