### PR TITLE
docs: record external-data unblock in ROADMAP Phase 6 + CHANGELOG currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   KV-reuse, routing, model provisioning + quant auto-upgrade, membw, and the
   diffusion pipeline. Cross-linked from `docs/README.md`, README, and ROADMAP.
 
-- **fp16 >2 GB on GPU — external-data loading unblocked on AppContainer** (patched
-  ORT DLL; weakly_canonical fix console-validated 2026-07-15, chunk-size fix pending
-  re-validation). Goal: load ONNX models with external `.onnx.data` >2 GB on
+- **External-data ONNX loading unblocked >2 GB on AppContainer** (patched ORT DLL,
+  both fixes console-validated 2026-07-15). Goal: load ONNX models with external
+  `.onnx.data` >2 GB on
   DirectML (the merge workaround caps at the 2 GB protobuf ceiling; DirectML is in
   maintenance mode, so this is the last local GPU lever). A zero-code USB spike
   (`scripts/build-fp16-dml-model.sh` + `scripts/spike-fp16-extdata-usb.sh`) was
@@ -34,7 +34,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     now loads and generates (`bench/results/phase6-fp16-extdata.csv`); (2) `env.cc`
     `ReadFileIntoBuffer` chunk 1 GB→16 MB — fixes the intermittent `errcode 1450`
     (a ~1 GB single `ReadFile` of the un-quantized embedding exhausts AppContainer
-    page-lock resources). Runbook: `docs/fp16-extdata-runbook.md`.
+    page-lock resources). **Status**: in the dispatch-only `build-uwp-ort-patched`
+    lane — **not yet promoted into the default shipping build** (`build-uwp.yml` still
+    ships vanilla ORT), and no new catalogue model added. **Scope**: the unblock is a
+    **CPU/int4 enabler** — a native-DML 1B fp16 (2.49 GB) loads (2878/3801 MB) but
+    OOMs GPU inference (§7 budget wall), so bigger fp16 on the GPU stays out of reach.
+    Runbook: `docs/fp16-extdata-runbook.md`.
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,10 @@ published on the `models-v1` catalogue (in-app download, ~20.6 tok/s). Carries o
 `docs/benchmarks.md`; architecture: `docs/architecture.md`. Prior console gates
 still pass: `validate-console.sh all` → **ALL PASS** (routing, GGUF `lfm25-350m`,
 TAESD). Catalogue `models-v1` also includes `smollm2-360m-dml-fp16` (~691 MB merged)
-for in-app routing-GPU download. See
+for in-app routing-GPU download. **In flight (not yet in this shipping build):** a
+patched ORT DLL that loads external-`.onnx.data` models >2 GB on the AppContainer
+(console-validated) lives in the dispatch-only `build-uwp-ort-patched` lane — see
+Phase 6 and `docs/fp16-extdata-runbook.md`. See
 [`docs/benchmarks.md`](docs/benchmarks.md),
 [`docs/recommended-config.md`](docs/recommended-config.md) and
 [`docs/console-validation-runbook.md`](docs/console-validation-runbook.md).
@@ -346,5 +349,19 @@ Open items only — everything above is measured or shipped.
       (host) + `membw.flag` (console → `membw-result.csv`). **Console-measured
       2026-07-15**: Xbox Zen 2 read 12.35 GB/s @1t / 30.29 @8t — the single-thread
       read matches the deduced ~13 GB/s GEMV denominator. See `docs/benchmarks.md`.
+- [x] **External-data ONNX loading unblocked >2 GB** (2026-07-15, PRs #67/#68/#71/#72/#73)
+      — patched ORT DLL (`patches/onnxruntime-extdata-appcontainer.patch`, built by the
+      dispatch-only `build-uwp-ort-patched` lane): `weakly_canonical` guard
+      (`uwp-constraints.md §8` Fix B) + `ReadFileIntoBuffer` 1 GB→16 MB chunk (fixes
+      `errcode 1450`). Console-validated with a 1.86 GB-extdata int4 model — loads and
+      runs, **6/6 restarts, 0 crashes**. ⚠️ **In the dispatch-only lane, not yet promoted
+      into the default shipping build** (`build-uwp.yml` still ships vanilla ORT); no new
+      catalogue model added yet. Investigated + **closed negative**: a native-DML 1B fp16
+      (2.49 GB) loads (2878/3801 MB) but OOMs GPU inference (`§7` budget wall) — the unblock
+      is a **CPU/int4 enabler, not bigger fp16 on the GPU**. See `docs/fp16-extdata-runbook.md`.
+- [ ] **Promote the patched ORT DLL into the shipping build** — wire
+      `vendor-ort-extdata-patch.ps1` into `build-uwp.yml` (cached DLL) + publish/register a
+      real >2 GB external-data (int4) model in `models-v1`, to turn the validated capability
+      into user-facing model support.
 - [ ] (upstream, deprioritised) **Fused low-bit GPU GEMM in DirectML** — §12;
       not a local contribution via #2280


### PR DESCRIPTION
Records this session's external-data work as a proper roadmap deliverable and brings the CHANGELOG current.

- **ROADMAP Phase 6**: new `[x]` entry for the >2 GB external-data unblock (PRs #67–#73) — patched ORT DLL, console-validated (6/6 restarts) — **flagged as dispatch-only, not yet in the default shipping build, no catalogue model added yet**; plus the closed-negative fp16-GPU budget wall. New `[ ]` follow-up: promote the DLL into `build-uwp.yml` + publish a real >2 GB int4 model. Shipping banner notes the in-flight capability.
- **CHANGELOG**: both fixes marked console-validated (was "chunk-size pending"); added the dispatch-only status and the CPU/int4-enabler scope (fp16 stays budget-walled on GPU).

Honest framing throughout: a validated **loading capability**, not yet a shipping feature or a new user-facing model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)