### PR TITLE
docs: publish technical report as Discussion #76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- **Project health snapshot** — `docs/project-analysis-2026-07.md` (status matrix,
-  risks, Phase 6 priorities). Not a perf SSOT.
+- **Technical report publication** — GitHub Discussions enabled;
+  [Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76) is the
+  public entrypoint for `docs/technical-report.md` (linked from README + docs index).
 
 ## [1.1.8.0] - 2026-07-15
 

--- a/README.md
+++ b/README.md
@@ -284,9 +284,18 @@ See [ROADMAP.md](./ROADMAP.md). Headlines:
 1. **Phase 1 — CPU baseline** ✅ Working UWP, ORT GenAI, CI green.
 2. **Phase 2 — GPU acceleration** ✅ GPU proven; verdict per-workload (CPU decode, GPU prefill/images).
 3. **Phase 3 / 3.5 — Benchmarks + hardware ceiling** ✅ Measured matrices, routing, KV reuse, llama.cpp A/B (parity), diffusion on console.
-4. **Phase 4 — In-app model download + publication** ✅ Catalogue download, v1.0.0 release, technical report (demo video pending).
+4. **Phase 4 — In-app model download + publication** ✅ Catalogue download, v1.0.0 release, technical report (demo video still open — Phase 6).
 5. **Phase 5 — Post-1.0 improvements** ✅ Unified+PatchedGenAI shipping; console gates ALL PASS.
-6. **Phase 6 — Publication + polish** 🔮 Patched ORT extdata **promoted to shipping** (cached vendor-dlls-v1 DLL); first-launch default **LFM2.5-350M** on unified. Still open: demo video, publication venue (see [ROADMAP.md](./ROADMAP.md)).
+6. **Phase 6 — Publication + polish** 🔮 Patched ORT + LFM default shipping (1.1.8); technical report published as [Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76). Still open: demo video (see [ROADMAP.md](./ROADMAP.md)).
+
+---
+
+## Technical report
+
+The measured narrative (CPU/GPU verdicts, falsified hypotheses, diffusion on console)
+lives in [docs/technical-report.md](./docs/technical-report.md). Publication entrypoint:
+[Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76). Live numbers:
+[docs/benchmarks.md](./docs/benchmarks.md).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -213,10 +213,10 @@ Milestones:
 - [x] Validate Exp 2 on console — ✅ 2026-07-08: the nobundle app downloaded the full model (417 MB merged) from the GitHub Release catalogue inside the AppContainer, byte-exact, `.complete` written. (The upstream HF repo turned out to ship a non-merged model.onnx + a file list with a nonexistent entry — the download had been broken from the start; distribution moved to Release assets.)
 - [x] Remove model bundle from MSIX — ✅ 2026-07-08 (ItemGroup deleted; CI matrix simplified to default+llamacpp; `xllama-appx` is now the 19 MB no-model package)
 - [x] `model-manifest.json` — ✅ 2026-07-08 (`uwp/models/manifest.json` catalogue + LocalState override; ComboBox and downloader de-hardcoded)
-- [ ] Demo video: model loaded and running on Xbox hardware
-- [x] Technical report — ✅ 2026-07-08 draft written (`docs/technical-report.md`,
-      the measured story 0.3.x→1.0); publication venue (GitHub Discussions vs
-      arXiv) still to pick
+- [ ] Demo video: model loaded and running on Xbox hardware — **tracked under Phase 6**
+- [x] Technical report — ✅ 2026-07-08 draft (`docs/technical-report.md`); published
+      as [Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76)
+      (2026-07-15). arXiv only if a formal citation is needed later.
 - [x] Tagged v1.0.0 release — ✅ 2026-07-08 (`gh release view v1.0.0`: 19 MB
       MSIX + `.cer` + VCLibs x64; models on the `models-v1` release)
 
@@ -334,10 +334,11 @@ Open items only — everything above is measured or shipped.
       **Checklist:** (1) deploy 1.1.8 shipping MSIX, (2) first-launch LFM download,
       (3) chat short + long (routing), (4) Image Generate one frame, (5) 60–90 s
       capture via capture card / Game Bar if available. No code blocker.
-- [x] **Publication venue** — **decision: GitHub Discussions** (or a pinned
-      Discussion + README link) for `docs/technical-report.md` first; arXiv only
-      if a formal citation is needed later. The report stays a dated v1.0
-      snapshot; live numbers stay in `docs/benchmarks.md`.
+- [x] **Publication venue** — GitHub Discussions; **posted**
+      [Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76)
+      (technical-report entrypoint + SSOT links). arXiv only if a formal citation
+      is needed later. Report stays a dated v1.0 snapshot; live numbers stay in
+      `docs/benchmarks.md`.
 - [x] **`smollm2-1.7b-cpu-int4` on `models-v1`** (2026-07-15) — the 4 catalogue
       assets (incl. the 1.47 GB `model.onnx`) uploaded to the `models-v1` release;
       verified on-console: in-app download of all 4 files → load → generate (63

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ docs quote a headline and link back:
 | [install-release.md](./install-release.md)                       | Install a tagged GitHub Release build on your Xbox (cert + VCLibs + MSIX)                                                                  |
 | [using-the-app.md](./using-the-app.md)                           | App guide: chat, settings (model picker, routing, KV reuse), image generation                                                              |
 | [uwp-constraints.md](./uwp-constraints.md)                       | UWP sandbox limitations, measured GPU budget, AppContainer filesystem quirks, and how xllama works around them                             |
-| [technical-report.md](./technical-report.md)                     | The measured story: per-workload CPU/GPU verdict, falsified hypotheses, diffusion on console                                               |
+| [technical-report.md](./technical-report.md)                     | The measured story (v1.0 snapshot); published as [Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76)                  |
 | [console-validation-runbook.md](./console-validation-runbook.md) | Ordered on-console validation checklist with measured results per section                                                                  |
 | [fp16-extdata-runbook.md](./fp16-extdata-runbook.md)             | Unblock fp16 models >2 GB on the GPU: zero-code USB spike, then the ORT `weakly_canonical` patch (Fase 1) — entrypoint for the scripts     |
 | [windows-dev-vm.md](./windows-dev-vm.md)                         | Windows VM setup for local UWP/MSIX builds                                                                                                 |

--- a/docs/project-analysis-2026-07.md
+++ b/docs/project-analysis-2026-07.md
@@ -56,8 +56,8 @@ leave MainPage split and DirectML fused int4 out of the critical path.
 | Membw micro-bench | **Shipped + console** | 12.35 GB/s @1t read |
 | 1B fp16 DML inference | **Closed negative** | load OK, OOM inference (§7 budget wall) |
 | DML int4 decode competitive | **Closed negative** | §12 non-fused GEMM; 8.8 tok/s |
-| Demo video | **Open** | ROADMAP Phase 4/6 |
-| Publication venue | **Open** | GitHub Discussions vs arXiv |
+| Demo video | **Open** | ROADMAP Phase 6 checklist |
+| Publication venue | **Done** | [Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76) |
 | Promote ORT patch to default ship | **Done (1.1.8.0)** | `vendor-dlls-v1` + SHA256SUMS |
 | Upstream fused low-bit DML GEMM | **Deprioritised** | not a local lever |
 

--- a/docs/technical-report.md
+++ b/docs/technical-report.md
@@ -1,6 +1,7 @@
 # xllama — LLM and Diffusion Inference on Xbox Series S: What the Hardware Actually Gives You
 
-**Venere Labs · 2026-07 · v1.0 draft**
+**Venere Labs · 2026-07 · v1.0 draft**  
+**Published:** [GitHub Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76)
 
 xllama is a UWP application that runs local LLM chat and Stable-Diffusion-class
 image generation on a retail Xbox Series S in Dev Mode. This report is the


### PR DESCRIPTION
## Summary

- Enable GitHub Discussions on the repo; publish [Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76) as the technical-report entrypoint (Phase 6 venue decision).
- Link from README, `docs/README.md`, ROADMAP, technical-report header, and project-analysis status matrix.
- Deduplicate Phase 4 demo-video tracking toward Phase 6.

## Test plan

- [x] Discussion #76 loads and links resolve
- [x] Docs-only PR (no code paths)