### PR TITLE
docs: record v1.1.8.0 GitHub Release + pending field smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- **Technical report publication** — GitHub Discussions enabled;
-  [Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76) is the
-  public entrypoint for `docs/technical-report.md` (linked from README + docs index).
+- **GitHub Release [v1.1.8.0](https://github.com/gianlucamazza/xllama/releases/tag/v1.1.8.0)**
+  (2026-07-16) — MSIX `xllama_1.1.8.490_x64.msix` + cert + VCLibs x64 from CI
+  artifact after PatchedOrt promotion. Field console smoke of the combined
+  package **pending** (Device Portal unreachable from the release host);
+  PatchedOrt path was console-validated pre-promotion (2026-07-15).
 
 ## [1.1.8.0] - 2026-07-15
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,8 +10,12 @@ number). First-launch default chat model on unified: **`lfm25-350m`** (~94 tok/s
 no 1–3 h ORT rebuild on every PR). Carries 1.1.7.0: GGUF **KV-reuse** (4.07×),
 **quant auto-upgrade**, **membw**, **SmolLM2-1.7B** on catalogue, Gemma family.
 Full numbers: `docs/benchmarks.md`; architecture: `docs/architecture.md`.
-Console gates: `validate-console.sh all` → **ALL PASS** (2026-07-14; re-smoke
-recommended after first 1.1.8 deploy). See
+Console gates: `validate-console.sh all` → **ALL PASS** (2026-07-14).
+**GitHub Release [v1.1.8.0](https://github.com/gianlucamazza/xllama/releases/tag/v1.1.8.0)**
+published 2026-07-16 (MSIX + cert + VCLibs). Field smoke of the combined 1.1.8
+package was **pending at release** (Device Portal unreachable from the release
+host); re-run `./scripts/install-latest-build.sh` + a short LFM chat when the
+console is online. See
 [`docs/benchmarks.md`](docs/benchmarks.md),
 [`docs/recommended-config.md`](docs/recommended-config.md) and
 [`docs/console-validation-runbook.md`](docs/console-validation-runbook.md).

--- a/docs/install-release.md
+++ b/docs/install-release.md
@@ -55,8 +55,10 @@ Notes:
 ## 3. First launch
 
 Launch xllama from Dev Home (or `./scripts/deploy.sh start-app`). The app
-downloads the default chat model (~417 MB) with a progress bar, then opens the
-chat. See [using-the-app.md](./using-the-app.md) from here.
+downloads the default chat model with a progress bar, then opens the chat.
+On **unified** shipping builds (v1.1.8+) that default is **LFM2.5-350M**
+(~219 MB); older releases used SmolLM2-360M INT4 (~417 MB). See
+[using-the-app.md](./using-the-app.md) from here.
 
 For image generation, the SD-Turbo model (2.4 GB) is downloaded from the
 catalogue on the first **Generate** — mind the Dev Mode disk budget (~2.2–2.5 GB


### PR DESCRIPTION
## Summary

- Document [v1.1.8.0](https://github.com/gianlucamazza/xllama/releases/tag/v1.1.8.0) release (MSIX+cer+VCLibs) and that **field console smoke is still pending** (WDP unreachable 2026-07-16).
- Demo video deferred with checklist; `install-release.md` first-launch default size updated for LFM.

## Test plan

- [x] `gh release view v1.1.8.0` has three assets
- [x] Docs-only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes for GitHub Release v1.1.8.0, including artifact availability and pending console smoke testing.
  * Clarified roadmap validation status and follow-up steps once the console is reachable.
  * Updated first-launch guidance with the new default model for unified builds and its smaller download size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->