### PR TITLE
research(phase7): H4 PASS — Llama-3.2-3B Q3 @14.2 tok/s on console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Phase 7 research** — `docs/phase7-hypotheses.md`: peer-class model hypotheses
+  (H1–H9). **H4 PASS** on console: Llama-3.2-3B-Instruct Q3_K_S decode
+  **14.2 tok/s**, peak 1824 MB (`bench/results/phase7-scale.csv`); near Gemma-4-E2B
+  speed at ~900 MB less RAM. Not yet catalogue-published.
 - **GitHub Release [v1.1.8.0](https://github.com/gianlucamazza/xllama/releases/tag/v1.1.8.0)**
   (2026-07-16) — MSIX + cert + VCLibs x64. **Field smoke same day:** install
   `1.1.8.496` on Series S, first-launch download of `lfm25-350m`, 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **GitHub Release [v1.1.8.0](https://github.com/gianlucamazza/xllama/releases/tag/v1.1.8.0)**
-  (2026-07-16) — MSIX `xllama_1.1.8.490_x64.msix` + cert + VCLibs x64 from CI
-  artifact after PatchedOrt promotion. Field console smoke of the combined
-  package **pending** (Device Portal unreachable from the release host);
-  PatchedOrt path was console-validated pre-promotion (2026-07-15).
+  (2026-07-16) — MSIX + cert + VCLibs x64. **Field smoke same day:** install
+  `1.1.8.496` on Series S, first-launch download of `lfm25-350m`, 
+  `validate-console.sh gguf` → **PASS** (llama.cpp load + short chat).
 
 ## [1.1.8.0] - 2026-07-15
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -374,3 +374,17 @@ Open items only — everything above is measured or shipped.
       the PatchedOrt capability visible in the picker without USB/WDP staging.
 - [ ] (upstream, deprioritised) **Fused low-bit GPU GEMM in DirectML** — §12;
       not a local contribution via #2280
+
+## Phase 7 — Peer-class model research 🔮 OPEN
+
+**Goal:** models with capability (and where possible speed) comparable to peer
+hardware (Zen 2 class / mid GPU), within Series S bandwidth (~13 GB/s) and
+AppContainer limits. Plan: [`docs/phase7-hypotheses.md`](docs/phase7-hypotheses.md).
+
+- [x] **H4 falsification campaign** (2026-07-16) — Llama-3.2-3B-Instruct **Q3_K_S**
+      on console: decode **14.16 tok/s**, prefill 19.5, peak **1824 MB**, load
+      ~17 s (`bench/results/phase7-scale.csv`). **PASS** (usable 3B-class GGUF).
+- [ ] Catalogue entry for Llama-3.2-3B (or Phi-3.5-mini) if product wants it in picker
+- [ ] H1 shortlist (larger LFM / hybrid) + H9 human task suite
+- [ ] H2 MoE candidate only if &lt;~3.5 GB GGUF with arch in pin
+- [ ] H3 speculative decoding spike (eng) — only if H9 says 3B still short of peer 7B

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,10 +12,10 @@ no 1–3 h ORT rebuild on every PR). Carries 1.1.7.0: GGUF **KV-reuse** (4.07×)
 Full numbers: `docs/benchmarks.md`; architecture: `docs/architecture.md`.
 Console gates: `validate-console.sh all` → **ALL PASS** (2026-07-14).
 **GitHub Release [v1.1.8.0](https://github.com/gianlucamazza/xllama/releases/tag/v1.1.8.0)**
-published 2026-07-16 (MSIX + cert + VCLibs). Field smoke of the combined 1.1.8
-package was **pending at release** (Device Portal unreachable from the release
-host); re-run `./scripts/install-latest-build.sh` + a short LFM chat when the
-console is online. See
+published 2026-07-16 (MSIX + cert + VCLibs). **Field smoke 2026-07-16:** deploy
+`xllama_1.1.8.496` → first-launch catalogue download `lfm25-350m` →
+`validate-console.sh gguf` → **PASS** (GGUF load + short chat). Demo video still
+open. See
 [`docs/benchmarks.md`](docs/benchmarks.md),
 [`docs/recommended-config.md`](docs/recommended-config.md) and
 [`docs/console-validation-runbook.md`](docs/console-validation-runbook.md).
@@ -338,8 +338,8 @@ Open items only — everything above is measured or shipped.
       **Checklist:** (1) deploy [v1.1.8.0](https://github.com/gianlucamazza/xllama/releases/tag/v1.1.8.0)
       or CI `xllama-appx`, (2) first-launch LFM download, (3) chat short + long
       (routing), (4) Image Generate one frame, (5) 60–90 s capture via capture
-      card / Game Bar if available. No code blocker. **Deferred 2026-07-16** —
-      console offline during Path A release session; do together with field smoke.
+      card / Game Bar if available. No code blocker. Field smoke (deploy + LFM
+      chat) **done 2026-07-16**; only the capture clip remains.
 - [x] **Publication venue** — GitHub Discussions; **posted**
       [Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76)
       (technical-report entrypoint + SSOT links). arXiv only if a formal citation

--- a/bench/results/phase7-scale.csv
+++ b/bench/results/phase7-scale.csv
@@ -1,0 +1,2 @@
+model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,host,date
+llama32-3b-q3ks,Q3_K_S,cpu,2048,6,19.51,14.16,1824,16936,0,0,xbox-series-s-t6,2026-07-16T07:01:27Z

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,5 +27,6 @@ docs quote a headline and link back:
 | [benchmarks.md](./benchmarks.md)                                 | Consolidated perf for every tested model (decode/prefill/RAM, 3 backends) + comparative charts (`benchmarks-charts.html`)                  |
 | [recommended-config.md](./recommended-config.md)                 | Correct modern settings: models, genai_config, settings.json, build variants, obsolete myths                                               |
 | [project-analysis-2026-07.md](./project-analysis-2026-07.md)     | Project health snapshot (2026-07-15): status matrix, risks, Phase 6 priorities — **not** a perf SSOT                                       |
+| [phase7-hypotheses.md](./phase7-hypotheses.md)                   | Phase 7 research: peer-class model hypotheses (H1–H9), shortlist, campaign results — **not** a perf SSOT                                   |
 
 See also [../CHANGELOG.md](../CHANGELOG.md) for the full pivot history (llama.cpp → ORT GenAI → CPU EP → per-workload routing) and [../diffusion/README.md](../diffusion/README.md) for the SD-Turbo model toolchain.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -35,8 +35,14 @@ Best measured decode configuration per model.
 | Qwen3.5-0.8B | 0.8B   | Q4_K_M | llama.cpp CPU · t6    |          98.1 |         35.1 |         718 | `phase5-gguf`               |
 | SmolLM2-1.7B | 1.7B   | int4   | ORT-GenAI CPU         |          54.9 |         20.6 |        2423 | `phase35-1b-cpu`            |
 | SmolLM2-360M | 360M   | int4   | ORT DML int4          |       152–334 |          8.8 |    999–1525 | `phase2-dml`                |
+| Llama-3.2-3B | 3B     | Q3_K_S | llama.cpp CPU · t6    |          19.5 |     **14.2** |        1824 | `phase7-scale`              |
 
 Notes:
+
+- **Llama-3.2-3B Q3_K_S** (Phase 7 H4, 2026-07-16): dense 3B at **14.2 tok/s** /
+  1824 MB peak — similar speed to Gemma-4-E2B Q3 (15.3) with ~900 MB less RAM.
+  Validates that 3B-class GGUF is interactive on Series S; not yet in the
+  shipping catalogue. See [phase7-hypotheses.md](phase7-hypotheses.md).
 
 - **LFM2.5-350M** is the fastest chat model and the lightest (321 MB RAM) — the
   default chat model on unified builds.

--- a/docs/phase7-hypotheses.md
+++ b/docs/phase7-hypotheses.md
@@ -1,0 +1,159 @@
+# Phase 7 — Hypotheses for peer-class model support
+
+**Research note (2026-07-16).** Not a performance SSOT — numbers live in
+[benchmarks.md](benchmarks.md). Goal: support models with **capability** (and
+where possible throughput) comparable to what peer hardware (Zen 2 class +
+mid-range GPU) typically runs, without pretending Series S has peer DRAM
+bandwidth or fused DML int4.
+
+## Hardware bound (measured)
+
+| Resource | Series S (Dev Mode) | Implication |
+| --- | --- | --- |
+| Useful CPU cores | ~6 (t7/t8 livelock ggml) | Cap llama at t6 |
+| Effective decode BW | ~12.4–13 GB/s | M=1 GEMV ceiling |
+| GPU budget | 3801 MB Game | Prefill/diffusion; not small-model decode |
+| Peak RAM seen | ~2.7 GB GGUF | 3B Q3 class fits |
+
+Naive BW bound (13 GB/s, one weight read/token): **3B Q4 ~8 tok/s**, **7B Q4 ~3–4
+tok/s**. Measured rows already saturate ≤1B (LFM 94, 0.8B 35, 1.7B 21). Peer
+“7B chat” machines win with **more bandwidth**, **GPU decode**, or **fewer
+active parameters** (MoE / extreme quant) — not by violating physics.
+
+## Goals (do not conflate)
+
+| ID | Goal | Operational target |
+| --- | --- | --- |
+| G1 | Capability | Chat quality ≈ casual 3B–7B peer |
+| G2 | Throughput | ≥12–15 tok/s interactive decode |
+| G3 | Prefill/RAG | Low TTFT at 1k+ tokens |
+
+Series S product priority: **G1 ≥ G2** (smart 2–3B at 10–15 tok/s beats dumb
+350M at 94).
+
+## Shipping baseline (SSOT excerpt)
+
+| Model | Decode | Peak | Role |
+| --- | --- | --- | --- |
+| LFM2.5-350M Q4 | **94.2** | 321 MB | default, G2 king |
+| Qwen3.5-0.8B Q4 | 35.1 | 718 MB | mid |
+| SmolLM2-1.7B int4 | 20.6 | 2423 MB | mid |
+| Gemma-4-E2B Q3 | 15.3 | 2742 MB | best heavy quality so far |
+
+Closed negative: DML int4 decode, 1B fp16 DML inference, llama≫ORT BW, AppContainer mmap.
+
+## Hypotheses
+
+### H1 — High-efficiency architectures (LFM / hybrid class)
+
+- **Claim:** At ~20 tok/s bound, a 1–2B efficient arch beats dense 0.8B quality and approaches peer 3B.
+- **PASS:** Quality ≥ E2B and decode ≥20 **or** quality ≫ E2B at ≥12 tok/s.
+- **FAIL:** Another tiny fast model without quality lift.
+- **Status:** Open — LFM 350M already proves efficiency direction; need larger LFM/hybrid if GGUF exists.
+
+### H2 — MoE with ~1–2B active params
+
+- **Claim:** Decode scales with *active* weights; MoE delivers peer quality at mid speed.
+- **PASS:** Peak &lt; 4 GB, decode ≥12, quality &gt; Qwen3.5-0.8B.
+- **FAIL:** Arch missing from UWP static lib / OOM / &lt;8 tok/s.
+- **Status:** Open — pin includes many `*moe*.cpp` + `lfm2moe` via `src/models/*.cpp` wildcard; needs small-enough GGUF candidate.
+
+### H3 — Speculative decoding (draft LFM + target 1.7–3B)
+
+- **Claim:** ≥1.4× perceived tok/s on target without more average bandwidth.
+- **PASS:** ≥1.4× on 1.7B+ with same quality.
+- **FAIL:** Overhead &gt; gain on 6 cores.
+- **Status:** Deferred eng (llama.cpp has tools; not in `LlamaSession` yet).
+
+### H4 — Usable 3B-class GGUF at Q3/Q4
+
+- **Claim:** 3B Q3_K_S runs ≥8 tok/s, peak &lt; 3.5 GB, coherent chat ≥ E2B.
+- **PASS:** Coherent generate + decode ≥8 + peak OK.
+- **FAIL:** EOG/garbage (see E2B IQ2) or OOM/livelock.
+- **Status:** **In campaign** — primary falsifier (low cost, high information).
+
+### H5 — BitNet / 1.58-bit
+
+- **Claim:** 1.5–3B at 1.58-bit → ≥20 tok/s in 400–800 MB.
+- **Status:** Desk — `llama.cpp` has `bitnet.cpp`; ORT GenAI 0.14.1 no stable INT2. Survey before eng.
+
+### H6 — GGUF GPU backend (Vulkan/D3D12) in AppContainer
+
+- **Claim:** At ≥3B, GPU decode beats CPU t6.
+- **Status:** Deferred platform work; only after H4 shows 3B is quality-limited not eng-limited. Small-model GPU decode already falsified for ORT DML.
+
+### H7 — GGUF prefill offload (hybrid)
+
+- **Claim:** TTFT at 1k tokens ≤0.7× pure CPU GGUF.
+- **Status:** Deferred (hard split-session design).
+
+### H8 — Series X GPU budget for 1B fp16 DML
+
+- **Claim:** Higher Game budget avoids 8007000E on 1B fp16 inference.
+- **Status:** Opportunistic if Series X available.
+
+### H9 — Task suite (capability, not tok/s)
+
+- **Claim:** E2B/1.7B + KV-reuse covers casual peer-7B tasks.
+- **Status:** Human eval after H4 winners.
+
+## Do not reopen
+
+GPU decode@360M, llama 2× ORT BW, mmap load win, extdata→1B fp16 GPU, DML int4 config-only.
+
+## Shortlist (desk, 2026-07-16)
+
+| Hypothesis | Candidate | Repo / file | Size | Why |
+| --- | --- | --- | --- | --- |
+| H4 | Llama-3.2-3B-Instruct Q3_K_S | `unsloth/Llama-3.2-3B-Instruct-GGUF` | 1.54 GB | Dense 3B, llama arch, under E2B size |
+| H4 | Llama-3.2-3B-Instruct Q4_K_M | same | 2.02 GB | Quality control if Q3 weak |
+| H4 | Phi-3.5-mini Q3_K_S | `bartowski/Phi-3.5-mini-instruct-GGUF` | 1.68 GB | Strong small instruct class |
+| H1 | Larger LFM / LFM2-MoE if &lt;3 GB | check LiquidAI / unsloth | TBD | Efficiency line |
+| H2 | Small MoE GGUF with arch in tree | e.g. OLMoE/Qwen-MoE tiny | TBD | Only if &lt;~3.5 GB Q3 |
+
+## Console campaign results
+
+Source CSV: `bench/results/phase7-scale.csv` (Xbox Series S, t6, `standard-512.txt`,
+median of 3 runs with run-1 dropped).
+
+| Model | Quant | Decode | Prefill | Peak MB | Load ms | Verdict |
+| --- | --- | --- | --- | --- | --- | --- |
+| Llama-3.2-3B-Instruct (`llama32-3b-q3ks`) | Q3_K_S | **14.16** | 19.51 | **1824** | ~16900 | **H4 PASS** |
+
+Notes:
+
+- Quant column was auto-mislabeled `Q4_K_M` by the bench harness (first-token
+  heuristic); corrected to **Q3_K_S** (on-disk file name).
+- Peak **1824 MB** is ~900 MB under Gemma-4-E2B Q3 (2742 MB) at nearly the same
+  decode (14.2 vs 15.3) — dense 3B is *lighter* than E2B MatFormer at this quant.
+- Naive BW bound for 3B Q4 was ~8 tok/s; Q3_K_S at **14 tok/s** is consistent with
+  fewer weight bytes/token (still bandwidth-class).
+- Headless bench completed full decode rows (not EOG-zero). Interactive
+  `set_model` autopilot for non-catalogue dirs still needs catalogue entry /
+  provision path — provision for campaign was `deploy.sh upload-dir`.
+
+### H4 decision
+
+| Criterion | Result |
+| --- | --- |
+| Decode ≥ 8 tok/s | **14.16** ✅ |
+| Peak &lt; 3.5 GB | **1.82 GB** ✅ |
+| Coherent generate (bench path) | ✅ (non-zero decode tokens) |
+| vs E2B (15.3 tok/s, 2742 MB) | Similar speed, **much less RAM** |
+
+**H4: PASS.** A dense 3B Q3 is a viable “peer-class capability” candidate on Series
+S and should be considered for catalogue (HF direct, like gemma4-e2b).
+
+### Next measured steps
+
+1. Phi-3.5-mini Q3_K_S A/B (quality head-to-head with Llama-3.2-3B).
+2. H9 human task suite: LFM vs E2B vs Llama-3.2-3B.
+3. Optional catalogue entry `llama32-3b` (HF unsloth GGUF).
+4. H3 speculative only if H9 says 3B quality is still short of peer 7B.
+
+## Decision log
+
+| Date | Decision |
+| --- | --- |
+| 2026-07-16 | Open Phase 7 research; prioritize H4 then H1; H3/H6 eng only after H4 data |
+| 2026-07-16 | **H4 PASS** — Llama-3.2-3B Q3_K_S @14.2 tok/s, 1824 MB peak (`phase7-scale.csv`) |


### PR DESCRIPTION
## Summary

Phase 7 research (peer-class model support):

- New **`docs/phase7-hypotheses.md`**: hardware bound, goals G1/G2/G3, falsifiable H1–H9, shortlist.
- **Console H4 campaign:** Llama-3.2-3B-Instruct **Q3_K_S** uploaded + `bench-xbox-ort.sh` (t6, 3 runs):
  - decode **14.16 tok/s**, prefill 19.5, peak **1824 MB**, load ~17 s
  - CSV: `bench/results/phase7-scale.csv`
- **Verdict H4 PASS** — dense 3B is interactive on Series S; comparable to Gemma-4-E2B speed with ~900 MB less RAM.
- Wired into `benchmarks.md`, ROADMAP Phase 7, CHANGELOG Unreleased.

Not shipping a catalogue entry yet (product decision).

## Test plan

- [x] Console bench median row in `phase7-scale.csv`
- [x] Host docs only for the rest