### PR TITLE
feat(catalogue): llama32-3b + Llama-3 chat template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Catalogue `llama32-3b`** — Llama-3.2-3B-Instruct Q3_K_S (~1.54 GB) from
+  Hugging Face unsloth GGUF (optional advanced chat; default remains
+  `lfm25-350m`). Console H4: **14.2 tok/s**, peak 1824 MB.
+- **Llama-3 chat template** — `ChatFormatKind::Llama3` (`<|start_header_id|>` /
+  `<|eot_id|>`) via `chat_format_for` / `model_is_llama`; KV-reuse invariant
+  covered in unit tests.
 - **Phase 7 research** — `docs/phase7-hypotheses.md`: peer-class model hypotheses
   (H1–H9). **H4 PASS** on console: Llama-3.2-3B-Instruct Q3_K_S decode
   **14.2 tok/s**, peak 1824 MB (`bench/results/phase7-scale.csv`); near Gemma-4-E2B
-  speed at ~900 MB less RAM. Not yet catalogue-published.
+  speed at ~900 MB less RAM.
 - **GitHub Release [v1.1.8.0](https://github.com/gianlucamazza/xllama/releases/tag/v1.1.8.0)**
   (2026-07-16) — MSIX + cert + VCLibs x64. **Field smoke same day:** install
-  `1.1.8.496` on Series S, first-launch download of `lfm25-350m`, 
+  `1.1.8.496` on Series S, first-launch download of `lfm25-350m`,
   `validate-console.sh gguf` → **PASS** (llama.cpp load + short chat).
 
 ## [1.1.8.0] - 2026-07-15

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -384,7 +384,10 @@ AppContainer limits. Plan: [`docs/phase7-hypotheses.md`](docs/phase7-hypotheses.
 - [x] **H4 falsification campaign** (2026-07-16) — Llama-3.2-3B-Instruct **Q3_K_S**
       on console: decode **14.16 tok/s**, prefill 19.5, peak **1824 MB**, load
       ~17 s (`bench/results/phase7-scale.csv`). **PASS** (usable 3B-class GGUF).
-- [ ] Catalogue entry for Llama-3.2-3B (or Phi-3.5-mini) if product wants it in picker
+- [x] **Catalogue `llama32-3b`** — HF unsloth Q3_K_S + Llama-3 chat template
+      (`ChatFormatKind::Llama3`). Optional advanced picker entry; default remains
+      `lfm25-350m`. Console in-app download smoke still recommended on first CI package.
 - [ ] H1 shortlist (larger LFM / hybrid) + H9 human task suite
+- [ ] Optional Phi-3.5-mini A/B vs Llama-3.2-3B (quality head-to-head)
 - [ ] H2 MoE candidate only if &lt;~3.5 GB GGUF with arch in pin
 - [ ] H3 speculative decoding spike (eng) — only if H9 says 3B still short of peer 7B

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -41,8 +41,9 @@ Notes:
 
 - **Llama-3.2-3B Q3_K_S** (Phase 7 H4, 2026-07-16): dense 3B at **14.2 tok/s** /
   1824 MB peak — similar speed to Gemma-4-E2B Q3 (15.3) with ~900 MB less RAM.
-  Validates that 3B-class GGUF is interactive on Series S; not yet in the
-  shipping catalogue. See [phase7-hypotheses.md](phase7-hypotheses.md).
+  Catalogue id **`llama32-3b`** (HF direct, optional advanced; default stays
+  LFM). See [phase7-hypotheses.md](phase7-hypotheses.md).
+
 
 - **LFM2.5-350M** is the fastest chat model and the lightest (321 MB RAM) — the
   default chat model on unified builds.

--- a/docs/phase7-hypotheses.md
+++ b/docs/phase7-hypotheses.md
@@ -146,9 +146,9 @@ S and should be considered for catalogue (HF direct, like gemma4-e2b).
 
 ### Next measured steps
 
-1. Phi-3.5-mini Q3_K_S A/B (quality head-to-head with Llama-3.2-3B).
-2. H9 human task suite: LFM vs E2B vs Llama-3.2-3B.
-3. Optional catalogue entry `llama32-3b` (HF unsloth GGUF).
+1. ~~Optional catalogue entry `llama32-3b`~~ — **done** (manifest + Llama-3 template).
+2. Phi-3.5-mini Q3_K_S A/B (quality head-to-head with Llama-3.2-3B).
+3. H9 human task suite: LFM vs E2B vs Llama-3.2-3B.
 4. H3 speculative only if H9 says 3B quality is still short of peer 7B.
 
 ## Decision log
@@ -157,3 +157,4 @@ S and should be considered for catalogue (HF direct, like gemma4-e2b).
 | --- | --- |
 | 2026-07-16 | Open Phase 7 research; prioritize H4 then H1; H3/H6 eng only after H4 data |
 | 2026-07-16 | **H4 PASS** — Llama-3.2-3B Q3_K_S @14.2 tok/s, 1824 MB peak (`phase7-scale.csv`) |
+| 2026-07-16 | Catalogue **`llama32-3b`** (HF Q3_K_S) + `ChatFormatKind::Llama3`; default stays LFM |

--- a/include/xllama/chat_prompt.h
+++ b/include/xllama/chat_prompt.h
@@ -15,6 +15,10 @@ bool model_is_qwen(const std::string& model_id);
 // (substring "gemma", case-insensitive).
 bool model_is_gemma(const std::string& model_id);
 
+// True for Llama / Llama-3.x catalogue ids or filenames (substring "llama",
+// case-insensitive). Used to select the Llama-3 instruct header template.
+bool model_is_llama(const std::string& model_id);
+
 // Qwen3.x no-think generation prefill (matches Qwen3.5 Jinja with enable_thinking=false).
 // Empty when the model is not Qwen.
 std::string qwen_no_think_gen_suffix(const std::string& model_id);
@@ -33,15 +37,15 @@ bool apply_stop_sequences(std::string& output, const std::vector<std::string>& s
 // ---------------------------------------------------------------------------
 // Per-architecture chat template
 //
-// Data-driven, backend-agnostic. The two supported formats differ only in
-// delimiters, the assistant role label, how the system prompt is placed, the
-// stop sequence and a per-model generation suffix. Built via chat_format_for().
+// Data-driven, backend-agnostic. Supported formats differ in delimiters, the
+// assistant role label, how the system prompt is placed, the stop sequence and
+// a per-model generation suffix. Built via chat_format_for().
 // ---------------------------------------------------------------------------
 
-enum class ChatFormatKind { ChatML, Gemma };
+enum class ChatFormatKind { ChatML, Gemma, Llama3 };
 
 // How the system prompt is emitted.
-// - DedicatedTurn: its own turn (ChatML: <|im_start|>system ... <|im_end|>).
+// - DedicatedTurn: its own turn (ChatML / Llama-3 system role).
 // - MergeIntoFirstUser: prepended to the first user turn (Gemma has no system role).
 enum class SystemStyle { DedicatedTurn, MergeIntoFirstUser };
 
@@ -55,15 +59,17 @@ struct ChatFormat {
     ChatFormatKind kind = ChatFormatKind::ChatML;
 
     // Delimiters / role labels.
-    std::string turn_open;     // "<|im_start|>"  | "<start_of_turn>"
-    std::string turn_close;    // "<|im_end|>\n"  | "<end_of_turn>\n"
+    // Layout: turn_open + role_tag + role_sep + content + turn_close
+    std::string turn_open;     // "<|im_start|>" | "<start_of_turn>" | "<|start_header_id|>"
+    std::string turn_close;    // "<|im_end|>\n" | "<end_of_turn>\n" | "<|eot_id|>"
+    std::string role_sep;      // "\n" | "\n" | "<|end_header_id|>\n\n"
     std::string user_tag;      // "user"
-    std::string assistant_tag; // "assistant"     | "model"
-    std::string system_tag;    // "system"        | "" (Gemma: unused)
-    std::string system_sep;    // ""              | "\n\n" (merge separator)
+    std::string assistant_tag; // "assistant" | "model"
+    std::string system_tag;    // "system"    | "" (Gemma: unused)
+    std::string system_sep;    // ""          | "\n\n" (merge separator)
     SystemStyle system_style = SystemStyle::DedicatedTurn;
 
-    std::vector<std::string> stop_sequences; // {"<|im_end|>"} | {"<end_of_turn>"}
+    std::vector<std::string> stop_sequences; // stop token(s); may be a prefix of turn_close
     std::string gen_suffix;                  // Qwen no-think prefill; else ""
 
     // Full multi-turn prompt ending with the assistant generation header +

--- a/src/bridge/chat_prompt.cpp
+++ b/src/bridge/chat_prompt.cpp
@@ -45,6 +45,10 @@ bool model_is_gemma(const std::string& model_id) {
     return to_lower(model_id).find("gemma") != std::string::npos;
 }
 
+bool model_is_llama(const std::string& model_id) {
+    return to_lower(model_id).find("llama") != std::string::npos;
+}
+
 std::string qwen_no_think_gen_suffix(const std::string& model_id) {
     if (!model_is_qwen(model_id))
         return {};
@@ -74,24 +78,39 @@ bool apply_stop_sequences(std::string& output, const std::vector<std::string>& s
 
 ChatFormat chat_format_for(const std::string& model_id) {
     ChatFormat f;
-    // Gemma is checked before the ChatML default; the Qwen no-think suffix is
-    // resolved inside the ChatML branch. "gemma" does not collide with
-    // smollm2/lfm2/qwen ids.
+    // Gemma and Llama-3 are checked before the ChatML default. Substrings do not
+    // collide with smollm2 / lfm2 / qwen ids. BOS is added by the tokenizer
+    // (add_bos) for Gemma and Llama-3 GGUF — not emitted in the template string.
     if (model_is_gemma(model_id)) {
         f.kind = ChatFormatKind::Gemma;
         f.turn_open = "<start_of_turn>";
         f.turn_close = "<end_of_turn>\n";
+        f.role_sep = "\n";
         f.user_tag = "user";
         f.assistant_tag = "model";
         f.system_tag = "";
         f.system_sep = "\n\n";
         f.system_style = SystemStyle::MergeIntoFirstUser;
         f.stop_sequences = {"<end_of_turn>"};
-        f.gen_suffix = {}; // Gemma has no think prefill; <bos> is added by add_bos.
+        f.gen_suffix = {};
+    } else if (model_is_llama(model_id)) {
+        // Meta Llama-3 / 3.1 / 3.2 instruct template.
+        f.kind = ChatFormatKind::Llama3;
+        f.turn_open = "<|start_header_id|>";
+        f.turn_close = "<|eot_id|>";
+        f.role_sep = "<|end_header_id|>\n\n";
+        f.user_tag = "user";
+        f.assistant_tag = "assistant";
+        f.system_tag = "system";
+        f.system_sep = "";
+        f.system_style = SystemStyle::DedicatedTurn;
+        f.stop_sequences = {"<|eot_id|>"};
+        f.gen_suffix = {};
     } else {
         f.kind = ChatFormatKind::ChatML;
         f.turn_open = "<|im_start|>";
         f.turn_close = "<|im_end|>\n";
+        f.role_sep = "\n";
         f.user_tag = "user";
         f.assistant_tag = "assistant";
         f.system_tag = "system";
@@ -108,10 +127,10 @@ std::string ChatFormat::render_prompt(const std::string& system,
                                       const std::string& final_user) const {
     std::string p;
 
-    // System: dedicated turn (ChatML, emitted unconditionally) or merged into
-    // the first user turn (Gemma).
+    // System: dedicated turn (ChatML / Llama-3, emitted unconditionally) or
+    // merged into the first user turn (Gemma).
     if (system_style == SystemStyle::DedicatedTurn)
-        p += turn_open + system_tag + "\n" + system + turn_close;
+        p += turn_open + system_tag + role_sep + system + turn_close;
 
     bool sys_pending = (system_style == SystemStyle::MergeIntoFirstUser) && !system.empty();
     auto user_content = [&](const std::string& u) -> std::string {
@@ -123,24 +142,35 @@ std::string ChatFormat::render_prompt(const std::string& system,
     };
 
     for (const ChatTurn& t : history) {
-        p += turn_open + user_tag + "\n" + user_content(t.user) + turn_close;
+        p += turn_open + user_tag + role_sep + user_content(t.user) + turn_close;
         // History assistant headers never carry gen_suffix (suffix only on the
         // trailing header below), matching the legacy hand-built prompt.
-        p += turn_open + assistant_tag + "\n" + t.assistant + turn_close;
+        p += turn_open + assistant_tag + role_sep + t.assistant + turn_close;
     }
 
-    p += turn_open + user_tag + "\n" + user_content(final_user) + turn_close;
-    p += turn_open + assistant_tag + "\n" + gen_suffix;
+    p += turn_open + user_tag + role_sep + user_content(final_user) + turn_close;
+    p += turn_open + assistant_tag + role_sep + gen_suffix;
     return p;
 }
 
 std::string ChatFormat::render_delta(const std::string& user, bool prev_ended_with_stop) const {
     // The reused KV already holds the previous assistant tokens. If generation
-    // stopped on the stop token the turn is already closed (only a newline is
-    // needed); otherwise close it with turn_close.
-    std::string d = prev_ended_with_stop ? std::string("\n") : turn_close;
-    d += turn_open + user_tag + "\n" + user + turn_close;
-    d += turn_open + assistant_tag + "\n" + gen_suffix;
+    // stopped on the stop token, that token is in the KV — emit only any trailing
+    // glue of turn_close beyond the stop (ChatML/Gemma: "\n"; Llama-3: empty).
+    // Otherwise close the turn with the full turn_close.
+    std::string d;
+    if (prev_ended_with_stop) {
+        if (!stop_sequences.empty() && !stop_sequences.front().empty() &&
+            turn_close.compare(0, stop_sequences.front().size(), stop_sequences.front()) == 0) {
+            d = turn_close.substr(stop_sequences.front().size());
+        } else {
+            d = "\n"; // defensive fallback for misconfigured formats
+        }
+    } else {
+        d = turn_close;
+    }
+    d += turn_open + user_tag + role_sep + user + turn_close;
+    d += turn_open + assistant_tag + role_sep + gen_suffix;
     return d;
 }
 

--- a/tests/test_chat_prompt.cpp
+++ b/tests/test_chat_prompt.cpp
@@ -70,16 +70,26 @@ TEST_CASE("gemma detection") {
     CHECK_FALSE(model_is_gemma("lfm25-350m"));
 }
 
+TEST_CASE("llama detection") {
+    CHECK(model_is_llama("llama32-3b"));
+    CHECK(model_is_llama("Llama-3.2-3B-Instruct-Q3_K_S.gguf"));
+    CHECK_FALSE(model_is_llama("smollm2-360m-cpu-int4"));
+    CHECK_FALSE(model_is_llama("lfm25-350m"));
+    CHECK_FALSE(model_is_llama("gemma3-270m"));
+}
+
 TEST_CASE("chat format selection") {
     CHECK(chat_format_for("smollm2-360m-cpu-int4").kind == ChatFormatKind::ChatML);
     CHECK(chat_format_for("lfm25-350m").kind == ChatFormatKind::ChatML);
     CHECK(chat_format_for("gemma3-270m").kind == ChatFormatKind::Gemma);
+    CHECK(chat_format_for("llama32-3b").kind == ChatFormatKind::Llama3);
 
     const ChatFormat qwen = chat_format_for("qwen35-0.8b");
     CHECK(qwen.kind == ChatFormatKind::ChatML);
     CHECK_FALSE(qwen.gen_suffix.empty()); // Qwen no-think prefill
 
     CHECK(chat_format_for("smollm2-360m-cpu-int4").gen_suffix.empty());
+    CHECK(chat_format_for("llama32-3b").gen_suffix.empty());
 }
 
 TEST_CASE("chat format stop sequences") {
@@ -87,6 +97,8 @@ TEST_CASE("chat format stop sequences") {
           std::vector<std::string>{"<|im_end|>"});
     CHECK(chat_format_for("gemma3-270m").stop_sequences ==
           std::vector<std::string>{"<end_of_turn>"});
+    CHECK(chat_format_for("llama32-3b").stop_sequences ==
+          std::vector<std::string>{"<|eot_id|>"});
 }
 
 TEST_CASE("chatml render is byte-exact with the legacy hand-built prompt") {
@@ -141,7 +153,7 @@ TEST_CASE("gemma render with empty system leaves the first user turn unprefixed"
           "<start_of_turn>user\nciao<end_of_turn>\n<start_of_turn>model\n");
 }
 
-TEST_CASE("render_delta for both formats and prev_ended_with_stop") {
+TEST_CASE("render_delta for chatml, gemma, llama3 and prev_ended_with_stop") {
     const ChatFormat cm = chat_format_for("smollm2-360m-cpu-int4");
     CHECK(cm.render_delta("q", /*stop=*/true) ==
           "\n<|im_start|>user\nq<|im_end|>\n<|im_start|>assistant\n");
@@ -153,12 +165,33 @@ TEST_CASE("render_delta for both formats and prev_ended_with_stop") {
           "\n<start_of_turn>user\nq<end_of_turn>\n<start_of_turn>model\n");
     CHECK(gm.render_delta("q", /*stop=*/false) ==
           "<end_of_turn>\n<start_of_turn>user\nq<end_of_turn>\n<start_of_turn>model\n");
+
+    // Llama-3: stop == turn_close, so post-stop glue is empty (no extra newline).
+    const ChatFormat lm = chat_format_for("llama32-3b");
+    CHECK(lm.render_delta("q", /*stop=*/true) ==
+          "<|start_header_id|>user<|end_header_id|>\n\nq<|eot_id|>"
+          "<|start_header_id|>assistant<|end_header_id|>\n\n");
+    CHECK(lm.render_delta("q", /*stop=*/false) ==
+          "<|eot_id|><|start_header_id|>user<|end_header_id|>\n\nq<|eot_id|>"
+          "<|start_header_id|>assistant<|end_header_id|>\n\n");
+}
+
+TEST_CASE("llama3 render matches Meta instruct header layout") {
+    const ChatFormat f = chat_format_for("llama32-3b");
+    const std::string p = f.render_prompt("Be concise.", {{"hi", "hello"}}, "how are you?");
+    CHECK(p == "<|start_header_id|>system<|end_header_id|>\n\nBe concise.<|eot_id|>"
+               "<|start_header_id|>user<|end_header_id|>\n\nhi<|eot_id|>"
+               "<|start_header_id|>assistant<|end_header_id|>\n\nhello<|eot_id|>"
+               "<|start_header_id|>user<|end_header_id|>\n\nhow are you?<|eot_id|>"
+               "<|start_header_id|>assistant<|end_header_id|>\n\n");
+    CHECK(p.find("<|begin_of_text|>") == std::string::npos); // BOS via tokenizer
 }
 
 TEST_CASE("postprocess_output strips empty think for chatml, passthrough otherwise") {
     const std::string block = std::string("<think>") + "\n\n" + "</think>";
     CHECK(chat_format_for("qwen35-0.8b").postprocess_output(block + "\n\nCiao!") == "Ciao!");
     CHECK(chat_format_for("gemma3-270m").postprocess_output("plain gemma") == "plain gemma");
+    CHECK(chat_format_for("llama32-3b").postprocess_output("plain llama") == "plain llama");
 }
 
 // The core KV-reuse safety net: the string a reused KV holds after a turn — the
@@ -191,7 +224,8 @@ static void check_kv_reuse_invariant(const ChatFormat& f) {
     CHECK(base + raw_out + f.render_delta(next_user, /*prev_ended_with_stop=*/false) == cold);
 }
 
-TEST_CASE("kv-reuse invariant holds for chatml and gemma") {
+TEST_CASE("kv-reuse invariant holds for chatml, gemma, and llama3") {
     check_kv_reuse_invariant(chat_format_for("smollm2-360m-cpu-int4"));
     check_kv_reuse_invariant(chat_format_for("gemma3-270m"));
+    check_kv_reuse_invariant(chat_format_for("llama32-3b"));
 }

--- a/tests/test_chat_prompt.cpp
+++ b/tests/test_chat_prompt.cpp
@@ -97,8 +97,7 @@ TEST_CASE("chat format stop sequences") {
           std::vector<std::string>{"<|im_end|>"});
     CHECK(chat_format_for("gemma3-270m").stop_sequences ==
           std::vector<std::string>{"<end_of_turn>"});
-    CHECK(chat_format_for("llama32-3b").stop_sequences ==
-          std::vector<std::string>{"<|eot_id|>"});
+    CHECK(chat_format_for("llama32-3b").stop_sequences == std::vector<std::string>{"<|eot_id|>"});
 }
 
 TEST_CASE("chatml render is byte-exact with the legacy hand-built prompt") {

--- a/uwp/models/manifest.json
+++ b/uwp/models/manifest.json
@@ -135,6 +135,19 @@
       ]
     },
     {
+      "_comment": "Llama-3.2-3B-Instruct Q3_K_S — Phase 7 H4 PASS (2026-07-16): decode 14.16 tok/s, peak 1824 MB on Series S (phase7-scale.csv). Optional heavy chat (not the shipping default — keep lfm25-350m). Direct from HF unsloth GGUF; Meta Llama Community License applies — do not mirror onto models-v1 without license review. Chat template: Llama-3 headers via chat_format_for (kind:gguf, CPU-only, KV-reuse, routing disabled).",
+      "name": "llama32-3b",
+      "display": "Llama 3.2 3B (GGUF · CPU · 1.54 GB, advanced)",
+      "kind": "gguf",
+      "hf_base_url": "https://huggingface.co/unsloth/Llama-3.2-3B-Instruct-GGUF/resolve/main",
+      "files": [
+        {
+          "filename": "Llama-3.2-3B-Instruct-Q3_K_S.gguf",
+          "approx_bytes": 1542848960
+        }
+      ]
+    },
+    {
       "name": "sd-turbo-fp16",
       "display": "SD-Turbo (image, GPU fp16)",
       "kind": "diffusion",


### PR DESCRIPTION
## Summary

- Catalogue entry **`llama32-3b`**: Llama-3.2-3B-Instruct **Q3_K_S** (~1.54 GB) via HF unsloth (same pattern as `gemma4-e2b`).
- **`ChatFormatKind::Llama3`**: Meta instruct template (`<|start_header_id|>` / `<|eot_id|>`) so interactive chat is not ChatML-misformatted.
- Docs/ROADMAP/CHANGELOG: H4 productized; default remains **`lfm25-350m`**.

## Context

Phase 7 H4 PASS (#81): decode **14.16 tok/s**, peak **1824 MB** on Series S. This PR makes the model selectable in-app without WDP upload-dir.

## Test plan

- [x] `ctest --test-dir build/linux-test` (chat_prompt + full suite)
- [ ] CI `build-uwp` unified green
- [ ] Console (optional first package): picker download `llama32-3b` → load → short chat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the optional **Llama 3.2 3B** model (`llama32-3b`) to the model catalogue, available for direct Hugging Face download.
  - Added support for Llama 3 chat formatting, including correct prompts, turn handling, stop sequences, and output behavior.
  - The default model remains **LFM 350M**; Llama 3.2 3B is available through the advanced model picker.

- **Documentation**
  - Updated release notes, roadmap, benchmark notes, and research documentation to reflect the new model and chat support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->