### PR TITLE
feat(uwp): LAN HTTP endpoint (OpenAI-compat) on xllama::Session

### DIFF
--- a/docs/api-endpoint.md
+++ b/docs/api-endpoint.md
@@ -18,26 +18,46 @@ consumed**: the server is persistent and coexists with the live XAML chat UI. It
 from `App::OnLaunched` on a detached MTA thread and stays bound for the app lifetime.
 
 - **Port:** `LocalState\api-port.txt` if present, else **11434** (Ollama's default port).
+  Xbox silently drops traffic for ports in **[57344, 65535]** and reserves **11443** for the
+  Device Portal, so the server only honors an override in the bindable app range
+  **[1025, 49151]** (and not 11443); anything else falls back to 11434 with a log line.
 - **Model:** taken from the request's `"model"` field; if absent, falls back to
   `LocalState\model.txt`. The `Session` is created lazily on the first request and reused;
   it is re-created only when a request asks for a different model.
 
-The endpoint dies when the app is suspended/closed (UWP PLM — no always-on system service).
-That is accepted: this is research on Dev Mode, not a hosted service.
+**Foreground only.** The endpoint dies when the app leaves the foreground (UWP Process
+Lifetime Management — no always-on system service). On Xbox this is stricter than on PC: if
+the package is game-classified (Device Portal _"Treat UWP apps as games by default"_) it is
+**suspended and terminated** in the background, and `ExtendedExecutionSession` does not keep
+a listener alive. Keep the app foregrounded on the console while using the endpoint. Accepted:
+this is Dev Mode research, not a hosted service.
+
+> Verified against learn.microsoft.com (2024-2026): `privateNetworkClientServer` +
+> `StreamSocketListener` is the documented path for LAN inbound; network isolation blocks
+> only _same-host_ sockets, so no `CheckNetIsolation` loopback exemption is needed for
+> requests coming **from another LAN device** (only for a localhost client on the console).
 
 ## Protocol (v1)
 
-| Method | Path                   | Behaviour                                                            |
-| ------ | ---------------------- | -------------------------------------------------------------------- |
-| `GET`  | `/` or `/health`       | `200 {"status":"ok","service":"xllama"}` — the spike/liveness probe. |
-| `POST` | `/v1/chat/completions` | OpenAI-compatible chat completion, **non-streaming**.                |
+| Method    | Path                   | Behaviour                                                             |
+| --------- | ---------------------- | --------------------------------------------------------------------- |
+| `GET`     | `/` or `/health`       | `200 {"status":"ok","service":"xllama"}` — the spike/liveness probe.  |
+| `GET`     | `/v1/models`           | OpenAI model discovery — lists the current/served model.              |
+| `GET`     | `/api/tags`            | Ollama model discovery — same model, Ollama shape.                    |
+| `POST`    | `/v1/chat/completions` | OpenAI-compatible chat completion, **non-streaming**.                 |
+| `OPTIONS` | _any_                  | CORS preflight (`204` + `Allow-Methods/Headers`) for browser clients. |
 
 Request body (subset): `model`, `messages[]` (`role` ∈ system/user/assistant, `content`),
-optional `max_tokens` (default 512), `temperature`, `top_p`. `messages[]` is mapped to
+optional `max_completion_tokens` / `max_tokens` (default 512; the former wins — `max_tokens`
+is the deprecated OpenAI alias), `temperature`, `top_p`. Unknown fields (`stream`, `n`,
+`stop`, penalties, `tools`, …) are ignored, not rejected. `messages[]` is mapped to
 `ChatFormat::render_prompt(system, history, final_user)` (`include/xllama/chat_prompt.h`);
-`chat_format_for(model)` selects the template and stop sequences. The reply carries
-`choices[0].message.content`, `finish_reason` (`stop`/`length`) and a `usage` block from
-`InferenceResult` (`n_p_eval` / `n_eval`).
+`chat_format_for(model)` selects the template and stop sequences.
+
+The reply follows the OpenAI shape: `id` (`chatcmpl-…`), `object: chat.completion`,
+`created`, `model`, `choices[0]` (`message`, `finish_reason` `stop`/`length`, and
+`logprobs: null` — omitting it breaks openai-python/LangChain Pydantic validation), and a
+`usage` block from `InferenceResult` (`n_p_eval` / `n_eval`).
 
 `stream: true` is **not** implemented in v1 (always returns the full completion). The
 `GenerateParams::on_token` hook is the seam for adding SSE later.
@@ -60,8 +80,10 @@ served gets **HTTP 503** `{"error":{"message":"busy"}}` — Ollama single-slot s
 
 ## Validation
 
-See `scripts/validate-api.sh`. Spike gate first (`GET /` → 200 proves the bind survives the
-Series S firewall/PLM), then a chat round-trip:
+See `scripts/validate-api.sh` (`spike|chat|all`). Run it **from another host on the LAN**,
+not from a client on the console itself — cross-device inbound needs no loopback exemption,
+but a same-host localhost client would (`CheckNetIsolation`). Spike gate first (`GET /` → 200
+proves the bind survives the Series S firewall/PLM), then a chat round-trip:
 
 ```bash
 curl -s http://<ip-xbox>:11434/v1/chat/completions \

--- a/docs/api-endpoint.md
+++ b/docs/api-endpoint.md
@@ -1,0 +1,70 @@
+# LAN HTTP endpoint (OpenAI-compatible)
+
+**Status:** v1 — spike + non-streaming chat. Opt-in, **default OFF**. Dev Mode / LAN
+research only. Not for the Store, not for public inbound.
+
+xllama can expose its inference core (`xllama::Session`) as an HTTP endpoint on the local
+network, so a PC on the same LAN can run inference on the console:
+`http://<ip-xbox>:<port>/v1/chat/completions`. It is **another front-end on the same
+`Session`** used by the chat UI, bench and CLI — not a separate inference path. Code lives
+in `uwp/api-server.{h,cpp}` (WinRT `StreamSocketListener`), entirely under `#ifdef
+XLLAMA_UWP`; the Linux/CLI build is unaffected.
+
+## Enabling it
+
+Drop an empty `api.flag` in the app's `LocalState` (via Device Portal / WDP, same channel
+as the other flags). Unlike the headless `bench.flag`/`diffuse.flag`, `api.flag` is **not
+consumed**: the server is persistent and coexists with the live XAML chat UI. It starts
+from `App::OnLaunched` on a detached MTA thread and stays bound for the app lifetime.
+
+- **Port:** `LocalState\api-port.txt` if present, else **11434** (Ollama's default port).
+- **Model:** taken from the request's `"model"` field; if absent, falls back to
+  `LocalState\model.txt`. The `Session` is created lazily on the first request and reused;
+  it is re-created only when a request asks for a different model.
+
+The endpoint dies when the app is suspended/closed (UWP PLM — no always-on system service).
+That is accepted: this is research on Dev Mode, not a hosted service.
+
+## Protocol (v1)
+
+| Method | Path                   | Behaviour                                                            |
+| ------ | ---------------------- | -------------------------------------------------------------------- |
+| `GET`  | `/` or `/health`       | `200 {"status":"ok","service":"xllama"}` — the spike/liveness probe. |
+| `POST` | `/v1/chat/completions` | OpenAI-compatible chat completion, **non-streaming**.                |
+
+Request body (subset): `model`, `messages[]` (`role` ∈ system/user/assistant, `content`),
+optional `max_tokens` (default 512), `temperature`, `top_p`. `messages[]` is mapped to
+`ChatFormat::render_prompt(system, history, final_user)` (`include/xllama/chat_prompt.h`);
+`chat_format_for(model)` selects the template and stop sequences. The reply carries
+`choices[0].message.content`, `finish_reason` (`stop`/`length`) and a `usage` block from
+`InferenceResult` (`n_p_eval` / `n_eval`).
+
+`stream: true` is **not** implemented in v1 (always returns the full completion). The
+`GenerateParams::on_token` hook is the seam for adding SSE later.
+
+## Concurrency
+
+`Session::generate()` is single-slot / non-concurrent. The server holds one shared
+`Session` behind a `std::mutex` with `try_lock`: a request arriving while another is being
+served gets **HTTP 503** `{"error":{"message":"busy"}}` — Ollama single-slot semantics.
+
+## Not in scope / do not do
+
+- No `internetClientServer` / public inbound — `privateNetworkClientServer` (already in the
+  manifest) covers LAN only.
+- No `llama.cpp/tools/server` or cpp-httplib imported into the MSIX.
+- The endpoint is **unauthenticated** — only expose it on a trusted LAN.
+- Memory note: the server's `Session` is independent of the UI's. On large models (e.g. the
+  3B H4 line, ~1.8 GB) two loaded copies may not fit; the follow-up is to share the
+  controller's `m_session` behind the same mutex.
+
+## Validation
+
+See `scripts/validate-api.sh`. Spike gate first (`GET /` → 200 proves the bind survives the
+Series S firewall/PLM), then a chat round-trip:
+
+```bash
+curl -s http://<ip-xbox>:11434/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"<catalogue-id>","messages":[{"role":"user","content":"Say hi"}]}'
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,6 +130,18 @@ compositor in-process (unlike ORT GenAI's DML init — see `uwp-constraints.md �
 Optional TAESD tiny VAE shortens the decode stage. Triggered from the Image dialog
 or the headless `diffuse.flag`.
 
+## LAN HTTP endpoint (OpenAI-compat)
+
+Optional, **default OFF**: a `StreamSocketListener` in `uwp/api-server.cpp` exposes the
+same `xllama::Session` as an OpenAI-compatible endpoint on the LAN
+(`POST /v1/chat/completions`, non-streaming). Started from `App::OnLaunched` on a detached
+MTA thread when `LocalState\api.flag` is present — unlike the headless bench/diffuse flags,
+`api.flag` is **not consumed** and the server coexists with the live chat UI. Port 11434
+(override `api-port.txt`); single-slot with a `try_lock` → HTTP 503 when busy. Capability
+`privateNetworkClientServer` (already in `AppxManifest.xml`) covers LAN inbound; no public
+inbound. Full contract + validation in [api-endpoint.md](api-endpoint.md)
+(`scripts/validate-api.sh`).
+
 ## Build variants and versioning
 
 CI (`build-uwp.yml`) produces `xllama-appx` (**unified**: ORT + llama.cpp +

--- a/scripts/validate-api.sh
+++ b/scripts/validate-api.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# validate-api.sh — deploy api.flag, restart the app, and validate the LAN HTTP
+# endpoint (OpenAI-compat) from this host over the network. Deterministic
+# PASS/FAIL, no human at the pad. See docs/api-endpoint.md.
+#
+# Usage:
+#   source ~/.config/xllama/xbox-env
+#   ./scripts/validate-api.sh <spike|chat|all>
+#
+#   spike  bind gate only: GET / -> HTTP 200 (proves the StreamSocketListener
+#          survives the Series S firewall/PLM). No inference.
+#   chat   POST /v1/chat/completions -> non-empty assistant content + a 503-busy
+#          check (two concurrent requests). Implies the spike gate first.
+#
+# Requires: an installed xllama build with the endpoint, a chat model already in
+# LocalState (set MODEL, or seed LocalState\model.txt), and XBOX_IP/USER/PASS.
+# The app must NOT be running a headless flag (bench/diffuse) — those exit the
+# process and never bind the socket.
+
+set -euo pipefail
+
+: "${XBOX_IP:?XBOX_IP not set — run: source ~/.config/xllama/xbox-env}"
+: "${XBOX_USER:?XBOX_USER not set}"
+: "${XBOX_PASS:?XBOX_PASS not set}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY="${SCRIPT_DIR}/deploy.sh"
+BASE_URL="https://${XBOX_IP}:11443"
+CURL_AUTH=(--basic -u "${XBOX_USER}:${XBOX_PASS}" -k -sS)
+
+PORT="${API_PORT:-11434}"
+MODEL="${MODEL:-lfm25-350m}"
+API_URL="http://${XBOX_IP}:${PORT}"
+
+CSRF_TOKEN=$(curl "${CURL_AUTH[@]}" "${BASE_URL}/" -o /dev/null -D - 2>/dev/null |
+	sed -n 's/.*[Cc][Ss][Rr][Ff]-[Tt]oken=\([^;[:space:]]*\).*/\1/p' |
+	tr -d '\r' | head -n1)
+[[ -z "$CSRF_TOKEN" ]] && echo "Warning: no CSRF token — POST/DELETE may fail" >&2
+
+PFN=$("${DEPLOY}" pfn 2>/dev/null)
+[[ -z "$PFN" ]] && {
+	echo "Error: xllama not found — deploy it first" >&2
+	exit 1
+}
+
+TMPDIR_LOCAL=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_LOCAL"' EXIT
+
+# --- WDP helpers (same idioms as validate-console.sh) ----------------------
+
+upload_file() {
+	local local_path="$1" remote_name="${2:-}"
+	local form_entry
+	if [[ -n "$remote_name" ]]; then
+		form_entry="${local_path};filename=${remote_name};type=application/octet-stream"
+	else
+		form_entry="${local_path};type=application/octet-stream"
+	fi
+	curl "${CURL_AUTH[@]}" -H "X-CSRF-Token:${CSRF_TOKEN}" -X POST \
+		-F "file=@${form_entry}" \
+		"${BASE_URL}/api/filesystem/apps/file?knownfolderid=LocalAppData&packagefullname=${PFN}&path=%5CLocalState" \
+		>/dev/null
+}
+
+delete_file() {
+	curl "${CURL_AUTH[@]}" -H "X-CSRF-Token:${CSRF_TOKEN}" -X DELETE \
+		"${BASE_URL}/api/filesystem/apps/file?knownfolderid=LocalAppData&packagefullname=${PFN}&path=%5CLocalState&filename=$1" \
+		>/dev/null 2>&1 || true
+}
+
+restart_app() {
+	curl "${CURL_AUTH[@]}" -H "X-CSRF-Token:${CSRF_TOKEN}" -X DELETE \
+		"${BASE_URL}/api/taskmanager/app?package=${PFN}" >/dev/null 2>&1 || true
+	sleep 2
+	local pfamily aumid
+	# shellcheck disable=SC2001
+	pfamily=$(echo "$PFN" | sed 's/_[0-9][0-9.]*_[^_]*__/_/')
+	aumid=$(printf '%s!xllama' "$pfamily" | base64 -w0)
+	curl "${CURL_AUTH[@]}" -H "X-CSRF-Token:${CSRF_TOKEN}" -X POST -d "" \
+		"${BASE_URL}/api/taskmanager/app?appid=${aumid}" >/dev/null 2>&1 || true
+}
+
+# Deploy api.flag + model.txt and (re)launch so the endpoint comes up.
+start_endpoint() {
+	printf 'go' >"${TMPDIR_LOCAL}/api.flag"
+	printf '%s' "$MODEL" >"${TMPDIR_LOCAL}/model.txt"
+	[[ "$PORT" != "11434" ]] && printf '%s' "$PORT" >"${TMPDIR_LOCAL}/api-port.txt"
+	delete_file "bench.flag" # a stale headless flag would exit before binding
+	delete_file "diffuse.flag"
+	upload_file "${TMPDIR_LOCAL}/api.flag"
+	upload_file "${TMPDIR_LOCAL}/model.txt"
+	[[ "$PORT" != "11434" ]] && upload_file "${TMPDIR_LOCAL}/api-port.txt"
+	restart_app
+}
+
+# Poll GET / until it returns 200 or times out.
+wait_endpoint() {
+	local timeout_s="${1:-120}" elapsed=0 code
+	echo "  Waiting for ${API_URL}/ (timeout ${timeout_s}s)..." >&2
+	while ((elapsed < timeout_s)); do
+		code=$(curl -sS -m 4 -o /dev/null -w "%{http_code}" "${API_URL}/" 2>/dev/null || echo "000")
+		if [[ "$code" == "200" ]]; then
+			echo "  Endpoint up after ${elapsed}s." >&2
+			return 0
+		fi
+		sleep 5
+		((elapsed += 5))
+	done
+	echo "  Timeout: endpoint never returned 200 (last code ${code})." >&2
+	return 1
+}
+
+# --- spike gate ------------------------------------------------------------
+
+validate_spike() {
+	echo "=== spike: LAN bind + HTTP 200 ==="
+	start_endpoint
+	if ! wait_endpoint 120; then
+		echo "  FAIL: no 200 from ${API_URL}/ — bind blocked or app not serving"
+		echo "spike: FAIL"
+		return 1
+	fi
+	local body
+	body=$(curl -sS -m 5 "${API_URL}/" || true)
+	echo "  GET / -> ${body}"
+	if grep -q '"status":"ok"' <<<"$body"; then
+		echo "spike: PASS"
+		return 0
+	fi
+	echo "  FAIL: unexpected health body"
+	echo "spike: FAIL"
+	return 1
+}
+
+# --- chat round-trip -------------------------------------------------------
+
+validate_chat() {
+	echo "=== chat: /v1/chat/completions ==="
+	local req resp verdict=0
+	req=$(printf '{"model":"%s","messages":[{"role":"user","content":"Say hello in one short sentence."}],"max_tokens":64}' "$MODEL")
+	resp=$(curl -sS -m 180 -H 'Content-Type: application/json' -d "$req" \
+		"${API_URL}/v1/chat/completions" || true)
+	local content
+	content=$(
+		python3 - <<PY
+import json, sys
+try:
+    d = json.loads('''$resp''')
+    print(d.get("choices", [{}])[0].get("message", {}).get("content", ""))
+except Exception:
+    print("")
+PY
+	)
+	if [[ -n "$content" ]]; then
+		echo "  ok: assistant replied: ${content:0:80}"
+	else
+		echo "  FAIL: empty/invalid completion. Raw: ${resp:0:200}"
+		verdict=1
+	fi
+
+	# 503-busy: fire two concurrent requests; at least one should be 503 while the
+	# single slot is occupied (best-effort — a very fast model may serialize both).
+	echo "  checking single-slot 503 (two concurrent requests)..."
+	local c1 c2
+	curl -sS -m 180 -o /dev/null -w "%{http_code}" -H 'Content-Type: application/json' \
+		-d "$req" "${API_URL}/v1/chat/completions" >"${TMPDIR_LOCAL}/c1" 2>/dev/null &
+	curl -sS -m 180 -o /dev/null -w "%{http_code}" -H 'Content-Type: application/json' \
+		-d "$req" "${API_URL}/v1/chat/completions" >"${TMPDIR_LOCAL}/c2" 2>/dev/null &
+	wait
+	c1=$(cat "${TMPDIR_LOCAL}/c1" 2>/dev/null || echo "000")
+	c2=$(cat "${TMPDIR_LOCAL}/c2" 2>/dev/null || echo "000")
+	echo "  concurrent codes: ${c1} ${c2}"
+	if [[ "$c1" == "503" || "$c2" == "503" ]]; then
+		echo "  ok: single-slot 503 observed"
+	else
+		echo "  note: no 503 seen (both ${c1}/${c2}) — acceptable if the model served fast"
+	fi
+
+	[[ $verdict -eq 0 ]] && echo "chat: PASS" || echo "chat: FAIL"
+	return $verdict
+}
+
+# --- dispatch --------------------------------------------------------------
+
+CMD="${1:-}"
+case "$CMD" in
+spike) validate_spike ;;
+chat)
+	validate_spike || exit 1
+	validate_chat
+	;;
+all)
+	rc=0
+	validate_spike || {
+		echo "=== summary ==="
+		echo "SPIKE FAILED — stopping before chat"
+		exit 1
+	}
+	validate_chat || rc=1
+	echo
+	echo "=== summary ==="
+	[[ $rc -eq 0 ]] && echo "ALL PASS" || echo "SOME FAILED (exit ${rc})"
+	exit $rc
+	;;
+*)
+	echo "Usage: $0 <spike|chat|all>" >&2
+	exit 1
+	;;
+esac

--- a/uwp/App.cpp
+++ b/uwp/App.cpp
@@ -8,6 +8,7 @@
 #include "pch.h"
 #include "App.h"
 #include "MainPage.h"
+#include "api-server.h"
 #include "inference-bridge.h"
 #include "xllama/platform.h"
 // clang-format on
@@ -134,6 +135,20 @@ void App::OnLaunched(LaunchActivatedEventArgs const&) {
         // controller from a background thread — see MainPage.cpp.
         if (m_controller)
             m_controller->StartAutopilotIfRequested();
+
+        // LAN HTTP endpoint (OpenAI-compat), opt-in and default OFF: started
+        // only when LocalState\api.flag exists. The flag is NOT consumed — the
+        // server is persistent and coexists with the live XAML chat UI, unlike
+        // the headless bench/diffuse flags. Runs on a detached MTA thread; the
+        // StreamSocketListener stays bound for the app lifetime. See
+        // api-server.cpp.
+        if (!flag_path_if_present(L"api.flag").empty()) {
+            log_write("[xllama] api.flag detected -> starting LAN HTTP endpoint\n");
+            std::thread([] {
+                winrt::init_apartment(); // MTA: WinRT sockets + ApplicationData
+                ::xllama::api::run_server();
+            }).detach();
+        }
     } catch (winrt::hresult_error const& e) {
         char buf[512];
         snprintf(buf, sizeof(buf), "[xllama] OnLaunched hresult 0x%08X: %ls\n",

--- a/uwp/api-server.cpp
+++ b/uwp/api-server.cpp
@@ -1,0 +1,373 @@
+// Copyright (c) 2024 Venere Labs
+// SPDX-License-Identifier: MIT
+//
+// LAN HTTP endpoint (OpenAI-compatible) — implementation. UWP-only.
+// A new front-end on xllama::Session: it does no inference of its own, it maps
+// JSON <-> Session/chat_prompt. See api-server.h.
+
+#include "api-server.h"
+
+#ifdef XLLAMA_UWP
+
+// clang-format off
+// pch.h must be first: it includes <unknwn.h> before winrt/base.h (COM IUnknown
+// guard). Sockets + Json are the WinRT namespaces pch.h does not already pull in.
+#include "pch.h"
+#include <winrt/Windows.Data.Json.h>
+#include <winrt/Windows.Networking.Sockets.h>
+// clang-format on
+
+    #include "xllama/chat_prompt.h"
+    #include "xllama/path_utils.h"
+    #include "xllama/platform.h"
+    #include "xllama/session.h"
+
+    #include <cctype>
+    #include <cstdio>
+    #include <ctime>
+    #include <future>
+    #include <memory>
+    #include <mutex>
+    #include <string>
+    #include <vector>
+
+namespace xllama::api {
+namespace {
+
+using namespace winrt::Windows::Networking::Sockets;
+using namespace winrt::Windows::Storage::Streams;
+using namespace winrt::Windows::Data::Json;
+
+// ---------------------------------------------------------------------------
+// Shared single-slot inference state
+//
+// The server owns ONE Session, created lazily on the first request and reused.
+// g_mtx serializes both (re)creation and generate(): xllama::Session::generate()
+// is not concurrent (session.h:74). A request that finds the slot busy gets 503.
+// ---------------------------------------------------------------------------
+std::mutex g_mtx;
+std::unique_ptr<::xllama::Session> g_session;
+std::string g_model; // model id currently loaded into g_session
+
+// Keep the listener alive for the process lifetime (callbacks fire on the WinRT
+// thread pool, not on run_server's thread).
+StreamSocketListener g_listener{nullptr};
+
+constexpr int kDefaultPort = 11434; // Ollama default port, familiar to clients
+
+// Read and trim a small LocalState text file; empty string if absent.
+std::string read_local_text(const char* name) {
+    std::string out;
+    const std::string p = ::xllama::resolve_local_path(name);
+    FILE* f = _wfopen(winrt::to_hstring(p).c_str(), L"r");
+    if (!f)
+        return out;
+    char buf[512];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof(buf), f)) > 0)
+        out.append(buf, n);
+    fclose(f);
+    while (!out.empty() && (out.back() == '\n' || out.back() == '\r' || out.back() == ' '))
+        out.pop_back();
+    return out;
+}
+
+int listen_port() {
+    const std::string s = read_local_text("api-port.txt");
+    if (!s.empty()) {
+        const int p = std::atoi(s.c_str());
+        if (p > 0 && p < 65536)
+            return p;
+    }
+    return kDefaultPort;
+}
+
+// ---------------------------------------------------------------------------
+// Minimal HTTP request read
+// ---------------------------------------------------------------------------
+struct HttpRequest {
+    std::string method;
+    std::string path;
+    std::string body;
+    bool ok = false;
+};
+
+std::string to_lower(std::string s) {
+    for (char& c : s)
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    return s;
+}
+
+// Reads request line + headers + Content-Length body from the socket. Blocking
+// (LoadAsync().get()); called on a thread-pool thread, never the UI thread.
+HttpRequest read_request(StreamSocket const& socket) {
+    HttpRequest req;
+    DataReader reader(socket.InputStream());
+    reader.InputStreamOptions(InputStreamOptions::Partial);
+
+    std::string data;
+    size_t header_end = std::string::npos;
+    // Pull chunks until the header terminator appears (cap to avoid abuse).
+    while (header_end == std::string::npos && data.size() < 64 * 1024) {
+        const uint32_t got = reader.LoadAsync(4096).get();
+        if (got == 0)
+            break;
+        for (uint32_t i = 0; i < got; ++i)
+            data.push_back(static_cast<char>(reader.ReadByte()));
+        header_end = data.find("\r\n\r\n");
+    }
+    if (header_end == std::string::npos)
+        return req;
+
+    // Request line: METHOD SP PATH SP HTTP/x.y
+    const size_t line_end = data.find("\r\n");
+    const std::string line = data.substr(0, line_end);
+    const size_t sp1 = line.find(' ');
+    const size_t sp2 = (sp1 == std::string::npos) ? std::string::npos : line.find(' ', sp1 + 1);
+    if (sp1 == std::string::npos || sp2 == std::string::npos)
+        return req;
+    req.method = line.substr(0, sp1);
+    req.path = line.substr(sp1 + 1, sp2 - sp1 - 1);
+
+    // Content-Length (case-insensitive header scan).
+    size_t content_length = 0;
+    {
+        const std::string headers = to_lower(data.substr(line_end + 2, header_end - line_end - 2));
+        const size_t cl = headers.find("content-length:");
+        if (cl != std::string::npos) {
+            content_length = static_cast<size_t>(std::atoll(headers.c_str() + cl + 15));
+            if (content_length > 8 * 1024 * 1024)
+                content_length = 8 * 1024 * 1024; // hard cap
+        }
+    }
+
+    const size_t body_start = header_end + 4;
+    while (data.size() - body_start < content_length) {
+        const uint32_t got = reader.LoadAsync(4096).get();
+        if (got == 0)
+            break;
+        for (uint32_t i = 0; i < got; ++i)
+            data.push_back(static_cast<char>(reader.ReadByte()));
+    }
+    req.body = data.substr(body_start, content_length);
+    req.ok = true;
+    return req;
+}
+
+void write_response(StreamSocket const& socket, const char* status, const std::string& json) {
+    std::string out = "HTTP/1.1 ";
+    out += status;
+    out += "\r\nContent-Type: application/json\r\nContent-Length: ";
+    out += std::to_string(json.size());
+    out += "\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n";
+    out += json;
+
+    DataWriter writer(socket.OutputStream());
+    writer.UnicodeEncoding(UnicodeEncoding::Utf8);
+    writer.WriteString(winrt::to_hstring(out));
+    writer.StoreAsync().get();
+    writer.FlushAsync().get();
+    writer.DetachStream();
+}
+
+std::string error_json(const std::string& msg) {
+    JsonObject err;
+    err.Insert(L"message", JsonValue::CreateStringValue(winrt::to_hstring(msg)));
+    err.Insert(L"type", JsonValue::CreateStringValue(L"xllama_error"));
+    JsonObject root;
+    root.Insert(L"error", err);
+    return winrt::to_string(root.Stringify());
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI /v1/chat/completions
+// ---------------------------------------------------------------------------
+
+// Turn the OpenAI messages[] into (system, history, final_user) for render_prompt.
+void split_messages(JsonArray const& messages, std::string& system,
+                    std::vector<::xllama::ChatTurn>& history, std::string& final_user) {
+    std::string cur_user;
+    bool have_user = false;
+    for (uint32_t i = 0; i < messages.Size(); ++i) {
+        const JsonObject m = messages.GetObjectAt(i);
+        const std::string role = winrt::to_string(m.GetNamedString(L"role", L""));
+        const std::string content = winrt::to_string(m.GetNamedString(L"content", L""));
+        if (role == "system") {
+            if (!system.empty())
+                system += "\n";
+            system += content;
+        } else if (role == "user") {
+            if (have_user) // consecutive user turns: close the previous unanswered
+                history.push_back({cur_user, ""});
+            cur_user = content;
+            have_user = true;
+        } else if (role == "assistant") {
+            if (have_user) {
+                history.push_back({cur_user, content});
+                have_user = false;
+            }
+        }
+    }
+    if (have_user)
+        final_user = cur_user; // trailing user turn is the one we answer
+}
+
+// Handles one chat request under g_mtx (already locked by the caller).
+std::string handle_chat_locked(const std::string& body, const char*& status) {
+    JsonObject root{nullptr};
+    if (!JsonObject::TryParse(winrt::to_hstring(body), root) || root == nullptr) {
+        status = "400 Bad Request";
+        return error_json("invalid JSON body");
+    }
+
+    std::string model = winrt::to_string(root.GetNamedString(L"model", L""));
+    if (model.empty())
+        model = read_local_text("model.txt"); // field-test fallback
+    if (model.empty()) {
+        status = "400 Bad Request";
+        return error_json("missing 'model' (and no LocalState\\model.txt fallback)");
+    }
+
+    if (!root.HasKey(L"messages")) {
+        status = "400 Bad Request";
+        return error_json("missing 'messages'");
+    }
+    std::string system, final_user;
+    std::vector<::xllama::ChatTurn> history;
+    split_messages(root.GetNamedArray(L"messages"), system, history, final_user);
+
+    // Lazily (re)create the Session when the requested model differs.
+    if (!g_session || g_model != model) {
+        std::string err;
+        ::xllama::SessionParams sp;
+        sp.model_path = model;
+        sp.n_ctx = 2048;
+        g_session = ::xllama::Session::create(sp, &err);
+        g_model = model;
+        if (!g_session) {
+            g_model.clear();
+            status = "500 Internal Server Error";
+            return error_json("session create failed: " + err);
+        }
+    }
+
+    const ::xllama::ChatFormat fmt = ::xllama::chat_format_for(model);
+    ::xllama::GenerateParams gp;
+    gp.prompt = fmt.render_prompt(system, history, final_user);
+    gp.stop_sequences = fmt.stop_sequences;
+    gp.reuse_kv = false; // OpenAI chat is stateless: messages[] carry full history
+    gp.n_predict =
+        root.HasKey(L"max_tokens") ? static_cast<int>(root.GetNamedNumber(L"max_tokens")) : 512;
+    if (root.HasKey(L"temperature"))
+        gp.temperature = static_cast<float>(root.GetNamedNumber(L"temperature"));
+    if (root.HasKey(L"top_p"))
+        gp.top_p = static_cast<float>(root.GetNamedNumber(L"top_p"));
+
+    const ::xllama::InferenceResult r = g_session->generate(gp);
+    if (!r.success) {
+        status = "500 Internal Server Error";
+        return error_json("generation failed: " + r.error_msg);
+    }
+    const std::string content = fmt.postprocess_output(r.output_text);
+
+    JsonObject message;
+    message.Insert(L"role", JsonValue::CreateStringValue(L"assistant"));
+    message.Insert(L"content", JsonValue::CreateStringValue(winrt::to_hstring(content)));
+    JsonObject choice;
+    choice.Insert(L"index", JsonValue::CreateNumberValue(0));
+    choice.Insert(L"message", message);
+    choice.Insert(L"finish_reason",
+                  JsonValue::CreateStringValue(r.ended_with_stop ? L"stop" : L"length"));
+    JsonArray choices;
+    choices.Append(choice);
+
+    JsonObject usage;
+    usage.Insert(L"prompt_tokens", JsonValue::CreateNumberValue(r.n_p_eval));
+    usage.Insert(L"completion_tokens", JsonValue::CreateNumberValue(r.n_eval));
+    usage.Insert(L"total_tokens", JsonValue::CreateNumberValue(r.n_p_eval + r.n_eval));
+
+    JsonObject resp;
+    resp.Insert(L"id", JsonValue::CreateStringValue(L"chatcmpl-xllama"));
+    resp.Insert(L"object", JsonValue::CreateStringValue(L"chat.completion"));
+    resp.Insert(L"created", JsonValue::CreateNumberValue(static_cast<double>(time(nullptr))));
+    resp.Insert(L"model", JsonValue::CreateStringValue(winrt::to_hstring(model)));
+    resp.Insert(L"choices", choices);
+    resp.Insert(L"usage", usage);
+    status = "200 OK";
+    return winrt::to_string(resp.Stringify());
+}
+
+void handle_connection(StreamSocket const& socket) {
+    try {
+        const HttpRequest req = read_request(socket);
+        if (!req.ok) {
+            write_response(socket, "400 Bad Request", error_json("malformed request"));
+            return;
+        }
+
+        // Health probe (also the spike gate: curl http://<ip>:<port>/ -> 200).
+        if (req.method == "GET" && (req.path == "/" || req.path == "/health")) {
+            write_response(socket, "200 OK", "{\"status\":\"ok\",\"service\":\"xllama\"}");
+            return;
+        }
+
+        if (req.method == "POST" && req.path == "/v1/chat/completions") {
+            std::unique_lock<std::mutex> lk(g_mtx, std::try_to_lock);
+            if (!lk.owns_lock()) {
+                write_response(socket, "503 Service Unavailable", error_json("busy"));
+                return;
+            }
+            const char* status = "200 OK";
+            const std::string json = handle_chat_locked(req.body, status);
+            write_response(socket, status, json);
+            return;
+        }
+
+        write_response(socket, "404 Not Found", error_json("no such endpoint"));
+    } catch (winrt::hresult_error const& e) {
+        char buf[256];
+        snprintf(buf, sizeof(buf), "[xllama] api: connection hresult 0x%08X\n",
+                 static_cast<unsigned>(e.code().value));
+        ::xllama::log_output(buf);
+    } catch (const std::exception& e) {
+        ::xllama::log_output(std::string("[xllama] api: connection error: ") + e.what() + "\n");
+    } catch (...) {
+        ::xllama::log_output("[xllama] api: connection unknown error\n");
+    }
+}
+
+} // namespace
+
+void run_server() {
+    try {
+        const int port = listen_port();
+        g_listener = StreamSocketListener();
+        g_listener.ConnectionReceived([](StreamSocketListener const&,
+                                         StreamSocketListenerConnectionReceivedEventArgs const& a) {
+            handle_connection(a.Socket());
+        });
+        g_listener.BindServiceNameAsync(winrt::to_hstring(std::to_string(port))).get();
+        ::xllama::log_output("[xllama] api: listening on 0.0.0.0:" + std::to_string(port) +
+                             " (OpenAI-compat /v1/chat/completions)\n");
+
+        // Block forever: the listener stays bound for the app lifetime.
+        std::promise<void>().get_future().wait();
+    } catch (winrt::hresult_error const& e) {
+        char buf[256];
+        snprintf(buf, sizeof(buf), "[xllama] api: listener bind failed 0x%08X\n",
+                 static_cast<unsigned>(e.code().value));
+        ::xllama::log_output(buf);
+    } catch (const std::exception& e) {
+        ::xllama::log_output(std::string("[xllama] api: fatal: ") + e.what() + "\n");
+    }
+}
+
+} // namespace xllama::api
+
+#else // !XLLAMA_UWP
+
+namespace xllama::api {
+void run_server() {}
+} // namespace xllama::api
+
+#endif // XLLAMA_UWP

--- a/uwp/api-server.cpp
+++ b/uwp/api-server.cpp
@@ -72,12 +72,22 @@ std::string read_local_text(const char* name) {
     return out;
 }
 
+// Xbox blocks binding ports in [57344, 65535] (traffic is silently dropped, per
+// the UWP-on-Xbox known-issues doc); 11443 is the Device Portal. Reject those so
+// an api-port.txt typo fails loudly to the default rather than binding a dead
+// port. Valid app range is [1025, 49151].
+bool port_bindable(int p) {
+    return p >= 1025 && p <= 49151 && p != 11443;
+}
+
 int listen_port() {
     const std::string s = read_local_text("api-port.txt");
     if (!s.empty()) {
         const int p = std::atoi(s.c_str());
-        if (p > 0 && p < 65536)
+        if (port_bindable(p))
             return p;
+        ::xllama::log_output("[xllama] api: api-port.txt=" + s +
+                             " out of bindable range [1025,49151]\\11443; using default\n");
     }
     return kDefaultPort;
 }
@@ -154,20 +164,37 @@ HttpRequest read_request(StreamSocket const& socket) {
     return req;
 }
 
-void write_response(StreamSocket const& socket, const char* status, const std::string& json) {
-    std::string out = "HTTP/1.1 ";
-    out += status;
-    out += "\r\nContent-Type: application/json\r\nContent-Length: ";
-    out += std::to_string(json.size());
-    out += "\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n";
-    out += json;
-
+void write_raw(StreamSocket const& socket, const std::string& out) {
     DataWriter writer(socket.OutputStream());
     writer.UnicodeEncoding(UnicodeEncoding::Utf8);
     writer.WriteString(winrt::to_hstring(out));
     writer.StoreAsync().get();
     writer.FlushAsync().get();
     writer.DetachStream();
+}
+
+void write_response(StreamSocket const& socket, const char* status, const std::string& json) {
+    std::string out = "HTTP/1.1 ";
+    out += status;
+    out += "\r\nContent-Type: application/json\r\nContent-Length: ";
+    out += std::to_string(json.size());
+    // Allow-Origin alone is not enough for browser clients: they send a custom
+    // Authorization header + application/json, which triggers a CORS preflight
+    // (handled separately in handle_connection).
+    out += "\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n";
+    out += json;
+    write_raw(socket, out);
+}
+
+// CORS preflight: browsers OPTIONS non-simple requests before the real POST.
+void write_cors_preflight(StreamSocket const& socket) {
+    write_raw(socket, "HTTP/1.1 204 No Content\r\n"
+                      "Access-Control-Allow-Origin: *\r\n"
+                      "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n"
+                      "Access-Control-Allow-Headers: Authorization, Content-Type\r\n"
+                      "Access-Control-Allow-Private-Network: true\r\n"
+                      "Access-Control-Max-Age: 86400\r\n"
+                      "Content-Length: 0\r\nConnection: close\r\n\r\n");
 }
 
 std::string error_json(const std::string& msg) {
@@ -256,8 +283,12 @@ std::string handle_chat_locked(const std::string& body, const char*& status) {
     gp.prompt = fmt.render_prompt(system, history, final_user);
     gp.stop_sequences = fmt.stop_sequences;
     gp.reuse_kv = false; // OpenAI chat is stateless: messages[] carry full history
-    gp.n_predict =
-        root.HasKey(L"max_tokens") ? static_cast<int>(root.GetNamedNumber(L"max_tokens")) : 512;
+    // max_tokens is deprecated in favour of max_completion_tokens; accept both.
+    gp.n_predict = 512;
+    if (root.HasKey(L"max_completion_tokens"))
+        gp.n_predict = static_cast<int>(root.GetNamedNumber(L"max_completion_tokens"));
+    else if (root.HasKey(L"max_tokens"))
+        gp.n_predict = static_cast<int>(root.GetNamedNumber(L"max_tokens"));
     if (root.HasKey(L"temperature"))
         gp.temperature = static_cast<float>(root.GetNamedNumber(L"temperature"));
     if (root.HasKey(L"top_p"))
@@ -276,6 +307,9 @@ std::string handle_chat_locked(const std::string& body, const char*& status) {
     JsonObject choice;
     choice.Insert(L"index", JsonValue::CreateNumberValue(0));
     choice.Insert(L"message", message);
+    // openai-python / LangChain deserialize into Pydantic models and choke when
+    // logprobs is absent; emit it explicitly as null.
+    choice.Insert(L"logprobs", JsonValue::CreateNullValue());
     choice.Insert(L"finish_reason",
                   JsonValue::CreateStringValue(r.ended_with_stop ? L"stop" : L"length"));
     JsonArray choices;
@@ -297,6 +331,50 @@ std::string handle_chat_locked(const std::string& body, const char*& status) {
     return winrt::to_string(resp.Stringify());
 }
 
+// The single model the server can currently serve: the loaded one, else the
+// LocalState\model.txt hint. Empty id if neither is set. g_model is mutated
+// under g_mtx by chat requests; read it only if we can take the lock, else fall
+// back to the file hint (which touches no shared state) to avoid a data race.
+std::string current_model_id() {
+    std::unique_lock<std::mutex> lk(g_mtx, std::try_to_lock);
+    if (lk.owns_lock() && !g_model.empty())
+        return g_model;
+    return read_local_text("model.txt");
+}
+
+// OpenAI GET /v1/models — {"object":"list","data":[{id,object,created,owned_by}]}.
+std::string models_json() {
+    JsonArray data;
+    const std::string id = current_model_id();
+    if (!id.empty()) {
+        JsonObject m;
+        m.Insert(L"id", JsonValue::CreateStringValue(winrt::to_hstring(id)));
+        m.Insert(L"object", JsonValue::CreateStringValue(L"model"));
+        m.Insert(L"created", JsonValue::CreateNumberValue(static_cast<double>(time(nullptr))));
+        m.Insert(L"owned_by", JsonValue::CreateStringValue(L"xllama"));
+        data.Append(m);
+    }
+    JsonObject root;
+    root.Insert(L"object", JsonValue::CreateStringValue(L"list"));
+    root.Insert(L"data", data);
+    return winrt::to_string(root.Stringify());
+}
+
+// Ollama GET /api/tags — {"models":[{name,model}]} for Ollama-probing clients.
+std::string tags_json() {
+    JsonArray models;
+    const std::string id = current_model_id();
+    if (!id.empty()) {
+        JsonObject m;
+        m.Insert(L"name", JsonValue::CreateStringValue(winrt::to_hstring(id)));
+        m.Insert(L"model", JsonValue::CreateStringValue(winrt::to_hstring(id)));
+        models.Append(m);
+    }
+    JsonObject root;
+    root.Insert(L"models", models);
+    return winrt::to_string(root.Stringify());
+}
+
 void handle_connection(StreamSocket const& socket) {
     try {
         const HttpRequest req = read_request(socket);
@@ -305,9 +383,26 @@ void handle_connection(StreamSocket const& socket) {
             return;
         }
 
+        // CORS preflight for browser clients (Continue.dev webview, web UIs).
+        if (req.method == "OPTIONS") {
+            write_cors_preflight(socket);
+            return;
+        }
+
         // Health probe (also the spike gate: curl http://<ip>:<port>/ -> 200).
         if (req.method == "GET" && (req.path == "/" || req.path == "/health")) {
             write_response(socket, "200 OK", "{\"status\":\"ok\",\"service\":\"xllama\"}");
+            return;
+        }
+
+        // Model discovery: clients probe /v1/models (OpenAI SDK) and /api/tags
+        // (Ollama-aware) before completing.
+        if (req.method == "GET" && req.path == "/v1/models") {
+            write_response(socket, "200 OK", models_json());
+            return;
+        }
+        if (req.method == "GET" && req.path == "/api/tags") {
+            write_response(socket, "200 OK", tags_json());
             return;
         }
 

--- a/uwp/api-server.h
+++ b/uwp/api-server.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 Venere Labs
+// SPDX-License-Identifier: MIT
+//
+// LAN HTTP endpoint (OpenAI-compatible) exposing xllama::Session on the local
+// network. Opt-in, default OFF: started only when LocalState\api.flag exists.
+// UWP-only (WinRT StreamSocketListener); no-op on other targets. See
+// docs/api-endpoint.md and the plan in the PR description.
+
+#pragma once
+
+namespace xllama::api {
+
+// Start the LAN HTTP listener and serve until the process exits. Intended to be
+// called on a detached MTA background thread from App::OnLaunched when
+// LocalState\api.flag is present. Blocks its thread; the StreamSocketListener is
+// kept alive for the app lifetime and coexists with the live XAML chat UI.
+//
+// Port: LocalState\api-port.txt if present, else 11434 (Ollama default port).
+// Protocol subset (v1): POST /v1/chat/completions (non-streaming), GET / health.
+// Concurrency: a single shared Session serialized by a mutex; concurrent
+// requests get HTTP 503 (Ollama single-slot semantics).
+void run_server();
+
+} // namespace xllama::api

--- a/uwp/xllama.vcxproj
+++ b/uwp/xllama.vcxproj
@@ -306,6 +306,7 @@
   <!-- xllama UWP app -->
   <ItemGroup>
     <ClCompile Include="App.cpp" />
+    <ClCompile Include="api-server.cpp" />
     <ClCompile Include="chat-history.cpp" />
     <ClCompile Include="MainPage.cpp" />
     <ClCompile Include="model-downloader.cpp" />

--- a/uwp/xllama.vcxproj.filters
+++ b/uwp/xllama.vcxproj.filters
@@ -28,6 +28,9 @@
     <ClCompile Include="App.cpp">
       <Filter>xllama</Filter>
     </ClCompile>
+    <ClCompile Include="api-server.cpp">
+      <Filter>xllama</Filter>
+    </ClCompile>
     <ClCompile Include="MainPage.cpp">
       <Filter>xllama</Filter>
     </ClCompile>
@@ -200,6 +203,9 @@
 
   <ItemGroup>
     <ClInclude Include="App.h">
+      <Filter>xllama</Filter>
+    </ClInclude>
+    <ClInclude Include="api-server.h">
       <Filter>xllama</Filter>
     </ClInclude>
     <ClInclude Include="MainPage.h">


### PR DESCRIPTION
## What & why

Optional, **default-OFF** LAN HTTP endpoint that exposes the existing single-slot
`xllama::Session` as an **OpenAI-compatible** API on the local network — a new
front-end on the core (like the UI, bench and CLI), *not* a fork of inference.
Lets a PC on the same LAN run inference on the console:
`http://<ip-xbox>:11434/v1/chat/completions`. LAN-only Dev Mode research; no
public inbound, not the Store.

Scope this iteration (agreed up front): **spike + non-streaming chat**. Streaming
SSE deferred — the `GenerateParams::on_token` seam is ready for it.

## What's in it

- `uwp/api-server.{h,cpp}` — WinRT `StreamSocketListener` (net-new; no server
  socket existed), minimal HTTP parse, `Windows::Data::Json` mapping of
  `messages[]` → `ChatFormat::render_prompt` → `Session::generate`.
  - `GET /` `/health` (spike/liveness gate) + `POST /v1/chat/completions`.
  - **Single-slot**: one shared `Session` behind a `try_lock` mutex → **HTTP 503**
    when busy (Ollama single-slot semantics). `reuse_kv=false` (OpenAI chat is
    stateless; `messages[]` carry the full history).
  - Port 11434 (Ollama default; `api-port.txt` override). Model from request
    `"model"` or `LocalState\model.txt` fallback; `Session` created lazily and
    reused, re-created only on model change.
- `uwp/App.cpp` — start on a detached MTA thread from `OnLaunched` when
  `LocalState\api.flag` exists. Unlike the headless bench/diffuse flags, the flag
  is **not consumed** — the server is persistent and coexists with the live XAML
  chat UI (same threading pattern as `StartAutopilotIfRequested`).
- `vcxproj` / `.filters` — add `api-server` to the **UWP target only**.
- Capability `privateNetworkClientServer` is **already** in `AppxManifest.xml` —
  no manifest change; no `internetClientServer` (no public inbound).
- Docs: `docs/api-endpoint.md` + section in `architecture.md`.
- `scripts/validate-api.sh` (`spike|chat|all`) — deploys `api.flag` via WDP,
  restarts, then validates the endpoint over the network with PASS/FAIL.

## How verified

- [x] `clang-format` clean (new/modified files formatted)
- [x] Linux/CLI build untouched — CMake does not reference `uwp/`; the
      `#ifdef XLLAMA_UWP` `#else` branch is a no-op, syntax-checked with
      `g++ -std=c++17 -fsyntax-only`
- [x] `shellcheck scripts/validate-api.sh` clean
- [ ] On-console (Xbox) validated — **pending**: needs a UWP build deployed, then
      `scripts/validate-api.sh all`
- [x] Docs updated (`docs/api-endpoint.md`, `docs/architecture.md`)

## Notes

- **UWP code is not built locally** — it compiles only on the Windows CI
  (`build-uwp`). The real residual risk is empirical: whether the
  `StreamSocketListener` bind survives the Series S firewall/PLM. That is exactly
  what `validate-api.sh spike` (`GET /` → 200) gates before investing further.
- **Memory**: the server's `Session` is independent of the UI's. Fine on the
  350M default; on the 3B H4 line (~1.8 GB) two loaded copies may not fit —
  follow-up is to share the controller's `m_session` behind the same mutex.
- Endpoint is **unauthenticated**; only expose on a trusted LAN.
- The `llama.cpp` submodule pointer change in the working tree was pre-existing
  and intentionally left out of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)