### PR TITLE
fix: root-cause fixes from the on-device live test (5 bugs)

### DIFF
--- a/scripts/validate-api.sh
+++ b/scripts/validate-api.sh
@@ -137,19 +137,25 @@ validate_spike() {
 validate_chat() {
 	echo "=== chat: /v1/chat/completions ==="
 	local req resp verdict=0
-	req=$(printf '{"model":"%s","messages":[{"role":"user","content":"Say hello in one short sentence."}],"max_tokens":64}' "$MODEL")
+	# temperature 0 + fixed seed: deterministic PASS/FAIL. At the default
+	# temperature a 350M model occasionally samples a role hallucination
+	# ("User\n\n<|end|>"), turning the gate into a coin flip.
+	req=$(printf '{"model":"%s","messages":[{"role":"user","content":"Say hello in one short sentence."}],"max_tokens":64,"temperature":0,"seed":42}' "$MODEL")
 	resp=$(curl -sS -m 180 -H 'Content-Type: application/json' -d "$req" \
 		"${API_URL}/v1/chat/completions" || true)
 	local content
+	# Parse via stdin: interpolating $resp into a python heredoc broke on any
+	# multi-line content (the JSON "\n" became a real newline inside ''' '''),
+	# mislabeling valid completions as empty.
 	content=$(
-		python3 - <<PY
+		printf '%s' "$resp" | python3 -c '
 import json, sys
 try:
-    d = json.loads('''$resp''')
+    d = json.load(sys.stdin)
     print(d.get("choices", [{}])[0].get("message", {}).get("content", ""))
 except Exception:
     print("")
-PY
+'
 	)
 	if [[ -n "$content" ]]; then
 		echo "  ok: assistant replied: ${content:0:80}"

--- a/scripts/validate-api.sh
+++ b/scripts/validate-api.sh
@@ -157,11 +157,16 @@ except Exception:
     print("")
 '
 	)
-	if [[ -n "$content" ]]; then
-		echo "  ok: assistant replied: ${content:0:80}"
-	else
+	if [[ -z "$content" ]]; then
 		echo "  FAIL: empty/invalid completion. Raw: ${resp:0:200}"
 		verdict=1
+	elif [[ "$content" == *"<|"* ]]; then
+		# Template-token leak ("User\n\n<|end|>" etc.): the model echoed turn
+		# markers instead of answering — a real reply never contains "<|".
+		echo "  FAIL: template leak in reply: ${content:0:80}"
+		verdict=1
+	else
+		echo "  ok: assistant replied: ${content:0:80}"
 	fi
 
 	# 503-busy: fire two concurrent requests; at least one should be 503 while the

--- a/scripts/validate-logit-parity.sh
+++ b/scripts/validate-logit-parity.sh
@@ -139,7 +139,14 @@ fi
 download_file "logits.bin.json" "${TMPDIR_LOCAL}/logits.bin.json" || true
 
 echo "=== compare ==="
-if python3 "$COMPARE" "$GOLDEN" "${TMPDIR_LOCAL}/logits.bin"; then
+# Cross-quant thresholds: the golden is Q4_K_M GGUF while the device model is a
+# different quantization (int4/fp16 ONNX), so exact numerics differ by design.
+# The decisive gates are rank-based: top-1 must match and top-10 overlap ≥ 0.8.
+# Calibrated on-device: a healthy conversion (smollm2 cpu-int4) scores
+# NMSE ~0.094 / max-abs ~6.3 / top10 0.9; a broken one (dml-fp16 predicting
+# " the") scores NMSE ~0.98 / max-abs ~17 / top10 0.3.
+if python3 "$COMPARE" "$GOLDEN" "${TMPDIR_LOCAL}/logits.bin" \
+	--max-abs-diff "${MAX_ABS_DIFF:-8.0}" --nmse "${NMSE_THR:-0.2}"; then
 	echo "logit-parity: PASS"
 	exit 0
 else

--- a/src/bridge/chat_prompt.cpp
+++ b/src/bridge/chat_prompt.cpp
@@ -35,22 +35,32 @@ bool starts_with(const std::string& s, const std::string& prefix) {
     return s.size() >= prefix.size() && s.compare(0, prefix.size(), prefix) == 0;
 }
 
+// Callers pass catalogue ids ("lfm25-350m"), filenames, or FULL paths (CLI -m).
+// Substring-match only the last path component: directory names must not select
+// a template — a repo/cache dir literally named "xllama" contains "llama" and
+// silently forced the Llama-3 template onto every model under it (LFM2.5 then
+// echoes <|eot_id|> as text instead of answering).
+std::string model_basename(const std::string& model_id) {
+    const size_t sep = model_id.find_last_of("/\\");
+    return sep == std::string::npos ? model_id : model_id.substr(sep + 1);
+}
+
 } // namespace
 
 bool model_is_qwen(const std::string& model_id) {
-    return to_lower(model_id).find("qwen") != std::string::npos;
+    return to_lower(model_basename(model_id)).find("qwen") != std::string::npos;
 }
 
 bool model_is_gemma(const std::string& model_id) {
-    return to_lower(model_id).find("gemma") != std::string::npos;
+    return to_lower(model_basename(model_id)).find("gemma") != std::string::npos;
 }
 
 bool model_is_llama(const std::string& model_id) {
-    return to_lower(model_id).find("llama") != std::string::npos;
+    return to_lower(model_basename(model_id)).find("llama") != std::string::npos;
 }
 
 bool model_is_phi(const std::string& model_id) {
-    return to_lower(model_id).find("phi") != std::string::npos;
+    return to_lower(model_basename(model_id)).find("phi") != std::string::npos;
 }
 
 std::string qwen_no_think_gen_suffix(const std::string& model_id) {

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -7,6 +7,7 @@
 #include "xllama/path_utils.h"
 #include "xllama/platform.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
@@ -171,8 +172,12 @@ InferenceResult run_inference_ort(const InferenceParams& params) {
         oga_check(OgaTokenizerEncode(tok.get(), params.prompt.c_str(), seqs.get()),
                   "OgaTokenizerEncode");
         size_t n_prompt_tok = OgaSequencesGetSequenceCount(seqs.get(), 0);
+        // Size max_length from the ACTUAL prompt, clamped to the context: the old
+        // fixed "n_predict + 512" headroom underflowed on long prompts (a 959-tok
+        // routed turn exceeded max_length 768 before generating a single token).
+        const int max_len =
+            std::min(params.n_ctx, static_cast<int>(n_prompt_tok) + params.n_predict);
         {
-            int max_len = params.n_predict + 512;
             char pbuf[128];
             snprintf(pbuf, sizeof(pbuf), "[xllama] prompt=%zu tok, max_length=%d (new≤%d)\n",
                      n_prompt_tok, max_len, max_len - static_cast<int>(n_prompt_tok));
@@ -184,7 +189,7 @@ InferenceResult run_inference_ort(const InferenceParams& params) {
         oga_check(OgaCreateGeneratorParams(model.get(), &raw_params), "OgaCreateGeneratorParams");
         OgaGeneratorParamsPtr gparams(raw_params);
         oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "max_length",
-                                                    static_cast<double>(params.n_predict + 512)),
+                                                    static_cast<double>(max_len)),
                   "SetSearchNumber max_length");
         oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "temperature",
                                                     static_cast<double>(params.temperature)),
@@ -215,14 +220,21 @@ InferenceResult run_inference_ort(const InferenceParams& params) {
         // ORT GenAI ≥ 0.7: feed input sequences to generator (not to params)
         oga_check(OgaGenerator_AppendTokenSequences(gen.get(), seqs.get()), "AppendTokenSequences");
 
-        // Logit-parity dump: capture the last prompt-token logits. GetLogits
-        // returns a CPU copy of "only the last token logits even in prompt
-        // processing", but in ORT GenAI 0.14 that distribution is only valid
-        // AFTER the first GenerateNextToken runs the prefill forward — calling it
-        // right after AppendTokenSequences yields an uninitialized/garbage vector
-        // (observed on-console: NMSE ~0.98 vs the llama.cpp reference). Defined
-        // here, invoked once inside the loop below. DirectML models commonly emit
-        // float16, so convert to float32 to match the reference dump byte-for-byte.
+        // Logit-parity dump: capture the last prompt-token logits.
+        //
+        // ORT GenAI state machine (verified on the vendored source, identical in
+        // v0.14 and 0.15-dev — generators.cpp): AppendTokens runs the prefill
+        // forward itself and leaves computed_logits_=true, so GetLogits returns
+        // the true last-prompt-token distribution — equal to the last row of
+        // GetOutput("logits") and to llama_get_logits_ith(ctx,-1) (canonical
+        // pattern: test/c_api_tests.cpp GetLogitsCAPI). After the first
+        // GenerateNextToken the flag is false and GetLogits RECOMPUTES a forward
+        // over the just-sampled token — the "position after the first generated
+        // token" bug observed on-console (golden argmax at rank ~2780).
+        //
+        // Must be invoked right after AppendTokenSequences, BEFORE the first
+        // GenerateNextToken. The C API always copies to a float32 [batch,1,vocab]
+        // tensor (ort_genai_c.cpp), but keep the fp16 branch defensive.
         auto dump_prefill_logits = [&]() {
             OgaTensor* raw_logits = nullptr;
             oga_check(OgaGenerator_GetLogits(gen.get(), &raw_logits), "GetLogits");
@@ -239,6 +251,17 @@ InferenceResult run_inference_ort(const InferenceParams& params) {
                 total *= shape[i];
             const int vocab =
                 rank > 0 ? static_cast<int>(shape[rank - 1]) : static_cast<int>(total);
+
+            // Diagnostic: shape + dtype in the log so an on-device mismatch is
+            // attributable without another build cycle.
+            {
+                std::string s =
+                    "[xllama] logits tensor: etype=" + std::to_string(etype) + " shape=[";
+                for (size_t i = 0; i < rank; ++i)
+                    s += (i ? "," : "") + std::to_string(shape[i]);
+                s += "]\n";
+                log_output(s);
+            }
 
             void* data = nullptr;
             oga_check(OgaTensorGetData(logits_t.get(), &data), "TensorGetData");
@@ -282,6 +305,12 @@ InferenceResult run_inference_ort(const InferenceParams& params) {
             }
         };
 
+        // AppendTokenSequences has already run the prefill: computed_logits_ is
+        // true and GetLogits here is the last-prompt-token distribution. Any
+        // later (post-GenerateNextToken) capture reads the wrong position.
+        if (!params.dump_logits_path.empty())
+            dump_prefill_logits();
+
         auto t_prefill_end = t0;
 
         int n_generated = 0;
@@ -291,12 +320,8 @@ InferenceResult run_inference_ort(const InferenceParams& params) {
 
             // ORT GenAI ≥ 0.7: GenerateNextToken does compute + sample in one call
             oga_check(OgaGenerator_GenerateNextToken(gen.get()), "GenerateNextToken");
-            if (n_generated == 0) {
+            if (n_generated == 0)
                 t_prefill_end = std::chrono::steady_clock::now();
-                // Prefill just ran: the last prompt-token logits are now valid.
-                if (!params.dump_logits_path.empty())
-                    dump_prefill_logits();
-            }
 
             const int32_t* next_toks = nullptr;
             size_t n_next = 0;

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -456,9 +456,13 @@ InferenceResult run_inference_llama(const InferenceParams& params) {
 
     const llama_vocab* vocab = llama_model_get_vocab(model.get());
 
+    // parse_special only for --chat: there the prompt is a rendered template
+    // whose markers must map to the model's special ids (see session.cpp). A raw
+    // -p prompt keeps them as text so user input can't smuggle special tokens.
+    const bool parse_special = params.chat_template;
     int32_t n_tokens =
         llama_tokenize(vocab, params.prompt.c_str(), static_cast<int32_t>(params.prompt.size()),
-                       nullptr, 0, true, false);
+                       nullptr, 0, true, parse_special);
     if (n_tokens == INT32_MIN) {
         res.error_msg = "tokenization overflow";
         log_output("[xllama] tokenization overflow\n");
@@ -473,7 +477,7 @@ InferenceResult run_inference_llama(const InferenceParams& params) {
     std::vector<llama_token> tokens(static_cast<size_t>(n_tokens));
     n_tokens =
         llama_tokenize(vocab, params.prompt.c_str(), static_cast<int32_t>(params.prompt.size()),
-                       tokens.data(), n_tokens, true, false);
+                       tokens.data(), n_tokens, true, parse_special);
     if (n_tokens < 0) {
         res.error_msg = "tokenization failed";
         log_output("[xllama] tokenization failed\n");

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -199,7 +199,12 @@ class OrtSession final : public Session {
                   "OgaTokenizerEncode");
         int n_prompt_tok = static_cast<int>(OgaSequencesGetSequenceCount(seqs.get(), 0));
 
-        OgaGeneratorParamsPtr gparams = make_params(gp, gp.n_predict + 512);
+        // Size max_length from the ACTUAL prompt, clamped to the model context.
+        // The old fixed "n_predict + 512" headroom was structurally too small for
+        // routed turns: routing sends >600-token prompts to the GPU, so a 959-tok
+        // turn hit "input_ids size (959) ... exceeds max length (768)".
+        const int max_len = std::min(m_n_ctx, n_prompt_tok + gp.n_predict);
+        OgaGeneratorParamsPtr gparams = make_params(gp, max_len);
         OgaGenerator* raw_gen = nullptr;
         oga_check(OgaCreateGenerator(m_model.get(), gparams.get(), &raw_gen), "OgaCreateGenerator");
         OgaGeneratorPtr gen(raw_gen);

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -439,14 +439,24 @@ class LlamaSession final : public Session {
 
         const llama_sampler_chain_params sparams = llama_sampler_chain_default_params();
         LlamaSamplerPtr sampler(llama_sampler_chain_init(sparams));
-        if (gp.repetition_penalty > 0.0f) {
-            llama_sampler_chain_add(
-                sampler.get(), llama_sampler_init_penalties(64, gp.repetition_penalty, 0.0f, 0.0f));
+        if (gp.temperature <= 0.0f) {
+            // temperature 0 (API "deterministic" request / logit parity): pure
+            // argmax. The full chain must NOT run here — the default
+            // repetition_penalty (1.1) reweighs prompt tokens BEFORE the temp
+            // stage's argmax and can flip the top token (observed on-device:
+            // LFM2.5 answered "User\n\n<|end|>" at temp 0 via the endpoint while
+            // pure argmax on the same prompt answers "Hello!").
+            llama_sampler_chain_add(sampler.get(), llama_sampler_init_greedy());
+        } else {
+            if (gp.repetition_penalty > 0.0f) {
+                llama_sampler_chain_add(sampler.get(), llama_sampler_init_penalties(
+                                                           64, gp.repetition_penalty, 0.0f, 0.0f));
+            }
+            llama_sampler_chain_add(sampler.get(), llama_sampler_init_top_k(gp.top_k));
+            llama_sampler_chain_add(sampler.get(), llama_sampler_init_top_p(gp.top_p, 1));
+            llama_sampler_chain_add(sampler.get(), llama_sampler_init_temp(gp.temperature));
+            llama_sampler_chain_add(sampler.get(), llama_sampler_init_dist(gp.seed));
         }
-        llama_sampler_chain_add(sampler.get(), llama_sampler_init_top_k(gp.top_k));
-        llama_sampler_chain_add(sampler.get(), llama_sampler_init_top_p(gp.top_p, 1));
-        llama_sampler_chain_add(sampler.get(), llama_sampler_init_temp(gp.temperature));
-        llama_sampler_chain_add(sampler.get(), llama_sampler_init_dist(gp.seed));
 
         int n_generated = 0;
         bool stopped_by_seq = false;

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -404,9 +404,16 @@ class LlamaSession final : public Session {
 
         const llama_vocab* vocab = llama_model_get_vocab(m_model.get());
 
+        // parse_special=true: every Session caller (chat UI, API endpoint, bench)
+        // passes a TEMPLATED prompt, whose <|im_start|>/<|im_end|> markers must
+        // become the special ids the model was trained on. As plain text the
+        // model sees an alien template and its next-token distribution goes flat
+        // (LFM2.5: top-2 gap 0.52 vs 3.91 with specials) — flat enough that the
+        // Zen2-vs-desktop kernel jitter (max |Δlogit| ~1.6 measured) flipped the
+        // greedy token on-device ("User\n\n<|end|>" instead of a greeting).
         int32_t n_tokens =
             llama_tokenize(vocab, gp.prompt.c_str(), static_cast<int32_t>(gp.prompt.size()),
-                           nullptr, 0, full_prompt, false);
+                           nullptr, 0, full_prompt, true);
         if (n_tokens == INT32_MIN) {
             res.error_msg = "tokenize overflow";
             return res;
@@ -416,7 +423,7 @@ class LlamaSession final : public Session {
 
         std::vector<llama_token> tokens(static_cast<size_t>(n_tokens));
         n_tokens = llama_tokenize(vocab, gp.prompt.c_str(), static_cast<int32_t>(gp.prompt.size()),
-                                  tokens.data(), n_tokens, full_prompt, false);
+                                  tokens.data(), n_tokens, full_prompt, true);
         if (n_tokens < 0) {
             res.error_msg = "tokenize failed";
             return res;
@@ -511,8 +518,11 @@ class LlamaSession final : public Session {
 
     int count_tokens(const std::string& prompt) override {
         const llama_vocab* vocab = llama_model_get_vocab(m_model.get());
+        // parse_special=true to match generate(): counting template markers as
+        // plain text overcounts a chat prompt by ~70% (50 vs 29 tokens on a
+        // 2-turn ChatML render), which skews the routing threshold.
         int32_t n = llama_tokenize(vocab, prompt.c_str(), static_cast<int32_t>(prompt.size()),
-                                   nullptr, 0, true, false);
+                                   nullptr, 0, true, true);
         if (n == INT32_MIN)
             return 0;
         return -n;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,11 @@ int main(int argc, char** argv) {
     // CLI feeds the prompt verbatim and generates to n_predict.
     if (params.chat_template) {
         const xllama::ChatFormat fmt = xllama::chat_format_for(params.model_path);
-        params.prompt = fmt.render_prompt(/*system=*/"", /*history=*/{}, params.prompt);
+        // Seed the same default system prompt as the chat UI and the API
+        // endpoint: an empty system turn makes small instruct models hallucinate
+        // the next role instead of answering (see api-server.cpp).
+        params.prompt = fmt.render_prompt(/*system=*/"You are a helpful AI assistant.",
+                                          /*history=*/{}, params.prompt);
         params.stop_sequences = fmt.stop_sequences;
     }
 

--- a/tests/test_chat_prompt.cpp
+++ b/tests/test_chat_prompt.cpp
@@ -87,6 +87,20 @@ TEST_CASE("phi detection") {
     CHECK_FALSE(model_is_phi("gemma3-270m"));
 }
 
+TEST_CASE("model detection ignores directory names (full-path ids)") {
+    // The CLI passes a FULL path; directory names must not select a template.
+    // A cache dir literally named "xllama-gguf" contains "llama" and used to
+    // force the Llama-3 template onto LFM2.5 (which then echoed <|eot_id|> as
+    // text instead of answering).
+    CHECK_FALSE(model_is_llama("/home/user/.cache/xllama-gguf/LFM2.5-350M-Q4_K_M.gguf"));
+    CHECK(chat_format_for("/home/user/.cache/xllama-gguf/LFM2.5-350M-Q4_K_M.gguf").kind ==
+          ChatFormatKind::ChatML);
+    CHECK(model_is_llama("/models/lfm-dir/Llama-3.2-3B-Instruct-Q3_K_S.gguf"));
+    CHECK_FALSE(model_is_phi("C:\\phi-cache\\LFM2.5-350M-Q4_K_M.gguf"));
+    CHECK(model_is_phi("C:\\models\\Phi-3.5-mini-instruct-Q3_K_S.gguf"));
+    CHECK_FALSE(model_is_gemma("/srv/gemma-store/lfm25-350m.gguf"));
+}
+
 TEST_CASE("chat format selection") {
     CHECK(chat_format_for("smollm2-360m-cpu-int4").kind == ChatFormatKind::ChatML);
     CHECK(chat_format_for("lfm25-350m").kind == ChatFormatKind::ChatML);

--- a/uwp/model-downloader.cpp
+++ b/uwp/model-downloader.cpp
@@ -165,12 +165,19 @@ IAsyncAction ModelDownloader::DownloadAsync(std::wstring hf_repo_url, std::wstri
             // --- Open target file ---------------------------------------------
             // filename may carry a relative subpath (e.g. "unet/model.onnx");
             // create intermediate folders as needed.
+            //
+            // Download into "<leaf>.part" and rename over the target only after
+            // the full body is written. ReplaceExisting directly on the live file
+            // truncated a good model.onnx first and secured bytes later — any
+            // mid-download failure (or a locked mmap'd model) left a corrupt
+            // 464 MB file that OgaCreateModel then failed to parse.
             StorageFolder folder{nullptr};
             StorageFile out_file{nullptr};
+            std::wstring leaf;
             bool create_failed = false;
             try {
                 folder = co_await StorageFolder::GetFolderFromPathAsync(local_dir);
-                std::wstring leaf = f.filename;
+                leaf = f.filename;
                 size_t sep;
                 while ((sep = leaf.find_first_of(L"/\\")) != std::wstring::npos) {
                     folder = co_await folder.CreateFolderAsync(
@@ -178,7 +185,7 @@ IAsyncAction ModelDownloader::DownloadAsync(std::wstring hf_repo_url, std::wstri
                     leaf = leaf.substr(sep + 1);
                 }
                 out_file = co_await folder.CreateFileAsync(
-                    winrt::hstring(leaf), CreationCollisionOption::ReplaceExisting);
+                    winrt::hstring(leaf + L".part"), CreationCollisionOption::ReplaceExisting);
             } catch (...) {
                 last_err = L"Cannot create file " + f.filename + L" in " + local_dir;
                 create_failed = true;
@@ -262,6 +269,27 @@ IAsyncAction ModelDownloader::DownloadAsync(std::wstring hf_repo_url, std::wstri
             co_await out_writer.FlushAsync();
             out_writer.DetachStream();
             out_stream = nullptr;
+
+            // Atomically promote the completed .part over the target. The old
+            // file is only replaced once every byte is on disk; a locked target
+            // fails the rename here without having destroyed the existing model.
+            bool rename_failed = false;
+            try {
+                co_await out_file.RenameAsync(winrt::hstring(leaf),
+                                              NameCollisionOption::ReplaceExisting);
+            } catch (...) {
+                last_err = L"Cannot replace " + f.filename + L" (target in use?)";
+                rename_failed = true;
+            }
+            if (rename_failed) {
+                try {
+                    co_await out_file.DeleteAsync();
+                } catch (...) {
+                }
+                co_await resume_foreground(dispatcher);
+                on_done(false, last_err);
+                co_return;
+            }
 
             log_output(("[downloader] " + ::xllama::wstring_to_utf8(f.filename) + " done (" +
                         std::to_string(bytes_done) + " bytes total so far)")
@@ -383,9 +411,15 @@ std::vector<std::wstring> list_relative_files(const std::filesystem::path& dir) 
     for (const auto& ent : std::filesystem::recursive_directory_iterator(dir, ec)) {
         if (!ent.is_regular_file(ec))
             continue;
-        std::error_code rel_ec;
-        auto rel = std::filesystem::relative(ent.path(), dir, rel_ec);
-        if (rel_ec)
+        // Lexical relative path — NOT std::filesystem::relative(), which calls
+        // weakly_canonical() on both operands and fails inside the Xbox
+        // AppContainer on inaccessible parent segments (same class of failure as
+        // the documented ORT external-data gotcha). When it failed here, every
+        // file was skipped, the list came back empty, and EnsureModel declared a
+        // fully-present GPU model "missing" — triggering a destructive
+        // re-download that truncated a good model.onnx.
+        auto rel = ent.path().lexically_relative(dir);
+        if (rel.empty())
             continue;
         std::wstring w = rel.wstring();
         if (w == L".complete")

--- a/uwp/models/manifest.json
+++ b/uwp/models/manifest.json
@@ -32,7 +32,7 @@
         {
           "filename": "genai_config.json",
           "remote": "smollm2-360m-dml-fp16_genai_config.json",
-          "approx_bytes": 1456
+          "approx_bytes": 1599
         },
         {
           "filename": "tokenizer.json",
@@ -42,12 +42,12 @@
         {
           "filename": "tokenizer_config.json",
           "remote": "smollm2-360m-dml-fp16_tokenizer_config.json",
-          "approx_bytes": 453
+          "approx_bytes": 452
         },
         {
           "filename": "model.onnx",
           "remote": "smollm2-360m-dml-fp16_model.onnx",
-          "approx_bytes": 691000000
+          "approx_bytes": 724910374
         }
       ]
     },


### PR DESCRIPTION
## Context
The full-functionality live test on Xbox Series S (v1.2.0.518/519) surfaced 5 real bugs. Each was root-caused with an on-device or local repro (3 parallel investigation passes over the ORT GenAI vendored sources, the API/chat-template path, and the EnsureModel/downloader flow).

## Fixes

| # | Bug | Root cause | Fix |
|---|-----|-----------|-----|
| 1 | Logit-parity dump uncorrelated with golden | `GetLogits` after the first `GenerateNextToken` **recomputes** over the sampled token (`computed_logits_` state machine, verified in v0.14/0.15 sources + `GetLogitsCAPI` test) | Capture right after `AppendTokenSequences` (prefill runs there); shape/dtype diagnostics |
| 2 | LFM2.5 echoes template tokens as text | `model_is_llama/phi/gemma/qwen` substring-match the **full path** — `~/.cache/xllama-gguf/` contains "llama" → Llama-3 template on LFM2.5 | Match basename only + regression test. Local repro: `--chat` now answers `"Hello!"` |
| 3 | EnsureModel re-downloads a fully-present GPU model | `std::filesystem::relative` → `weakly_canonical` fails in the Xbox AppContainer → file list empty → "missing" | `lexically_relative` (no fs access) |
| 4 | Re-download **corrupts** the live model (464 MB truncation → protobuf failure) | `CreateFileAsync(ReplaceExisting)` truncates before securing bytes; plus wrong manifest `approx_bytes` (691000000 vs real 724910374) made `file_already_complete` always false | `.part` + `RenameAsync` (atomic promote); exact sizes in manifest |
| 5 | GPU-routed turn crashes: `input_ids (959) exceeds max length (768)` | `max_length = n_predict + 512` ignores the prompt; routing sends >600-tok prompts to GPU by definition | `max_length = n_prompt_tok + n_predict` clamped to `n_ctx` (both ORT sites) |

Plus: `--chat` seeds the default system prompt (same as UI/API — empty system makes small models hallucinate the role); `validate-api.sh` chat is now deterministic (`temperature:0, seed:42`) and its JSON parse no longer breaks on multi-line content (the earlier "API chat FAIL" was sampling flakiness + this parse bug — direct probe on v1.2.0.519 answers correctly).

## Verification
- Linux: build green, full suite green (incl. new template regression + logit-parity golden).
- Local repro of #2 fixed (`<|eot_id|>` garbage → `"Hello!"`).
- On-device re-validation (logit parity vs golden, routing A/B, API chat deterministic) planned on this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat responses by applying a consistent default assistant instruction.
  * Prevented incorrect chat template selection for models stored in directories with misleading names.
  * Reduced context-length errors for long prompts.
  * Improved model downloads by preventing incomplete files from replacing existing models.
  * Fixed model catalogue handling in restricted environments.

* **Reliability**
  * Made API validation results deterministic and improved handling of invalid responses.
  * Added clearer inference diagnostics and more accurate prompt-processing behavior.

* **Maintenance**
  * Updated download size information for the SmolLM2 model files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->