### PR TITLE
fix(routing): disable DML text routing — GQA logits wrong on-device (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **DML text routing disabled (#91)** — the logit-parity harness caught the DML
+  GQA decoder computing numerically wrong logits on the Series S GPU (NMSE ~1
+  vs the CPU reference at fp16 AND int4; invariant to `ORT_DISABLE_ALL`,
+  `ep.dml.disable_graph_fusion` and a capture-disabled GenAI DLL; the same
+  weights are correct on CPU EP; SD-Turbo — no GQA — is correct on the same
+  device). `decide_routing` now forces the CPU model in every mode
+  (`kDmlTextLogitsBroken`, `routing_policy.h`); GPU-routed answers had been
+  silently degraded since the routing feature shipped. Re-enable gate:
+  `scripts/validate-logit-parity.sh` PASS on a DML text model. Diffusion (plain
+  ORT, validated) is unaffected. `validate-console.sh routing` now asserts the
+  gate holds. Probe log in #91.
+
 ### Fixed
 
 - **Catalogue download resilience** — `ModelDownloader` retries transient failures

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 `xllama` is a UWP application for Xbox Series S|X in Dev Mode that runs LLM chat and Stable-Diffusion image generation locally, with no cloud dependency and a gamepad-friendly UI.
 
-The project started as a port of [`llama.cpp`](https://github.com/ggml-org/llama.cpp) (GGUF files, CPU-only), then migrated to **ONNX Runtime GenAI + DirectML**. The measured verdict is **per-workload** (see [docs/technical-report.md](./docs/technical-report.md)): the Zen 2 **CPU wins autoregressive decode** at this model scale (~66 tok/s, SmolLM2-360M int4), the RDNA 2 **GPU wins batch compute** — prefill at ~1k prompt tokens (1.8× faster) and image generation (**11.1×** on the diffusion workload: SD-Turbo 512×512 in ~7 s). The app routes per conversation (CPU / GPU / auto). The llama.cpp path serves Linux development, CI, and — in the `unified` UWP build — modern GGUF-only models (Qwen3.5, LFM2.5); for the same model, ORT stays the text backend (measured decode parity, better prefill).
+The project started as a port of [`llama.cpp`](https://github.com/ggml-org/llama.cpp) (GGUF files, CPU-only), then migrated to **ONNX Runtime GenAI + DirectML**. The measured verdict is **per-workload** (see [docs/technical-report.md](./docs/technical-report.md)): the Zen 2 **CPU wins autoregressive decode** at this model scale (~66 tok/s, SmolLM2-360M int4), the RDNA 2 **GPU wins batch compute** — prefill at ~1k prompt tokens (1.8× faster) and image generation (**11.1×** on the diffusion workload: SD-Turbo 512×512 in ~7 s). GPU **text** routing is currently disabled ([#91](https://github.com/gianlucamazza/xllama/issues/91): the DML GQA decoder computes wrong logits on the Series S GPU — caught by the logit-parity harness); diffusion stays on the GPU. The llama.cpp path serves Linux development, CI, and — in the `unified` UWP build — modern GGUF-only models (Qwen3.5, LFM2.5); for the same model, ORT stays the text backend (measured decode parity, better prefill).
 
 The default chat model on the shipping **unified** build is **LFM2.5-350M Q4_K_M** (~219 MB, ~94 tok/s), downloaded on first launch from the GitHub Release model catalogue — the MSIX itself is ~19 MB and ships no model. ORT-only builds still default to SmolLM2-360M INT4.
 
@@ -248,17 +248,17 @@ Models come from the catalogue `uwp/models/manifest.json` (assets hosted on the 
 Catalogue overview (roles + sizes; **decode/prefill/RAM numbers live in
 [docs/benchmarks.md](./docs/benchmarks.md)**, the perf SSOT):
 
-| Model                      | Format        | Size    | Xbox UWP | Role                                                       |
-| -------------------------- | ------------- | ------- | -------- | ---------------------------------------------------------- |
-| LFM2.5-350M Q4_K_M         | GGUF          | 219 MB  | ✅       | **Default chat** on unified shipping; fastest+lightest     |
-| SmolLM2-360M-Instruct INT4 | ONNX GenAI    | 417 MB  | ✅       | ORT default / routing base (CPU)                           |
-| SmolLM2-360M fp16 DML      | ONNX GenAI    | ~700 MB | ✅       | Routing target (long-prompt prefill on GPU)                |
-| SmolLM2-1.7B-Instruct INT4 | ONNX GenAI    | 1.4 GB  | ✅       | Larger CPU chat (~20.6 tok/s; in-app `models-v1` download) |
-| Qwen3.5-0.8B Q4_K_M        | GGUF          | 508 MB  | ✅       | `unified` builds (llama.cpp)                               |
-| Gemma-3-270M Q4_K_M        | GGUF          | 253 MB  | ✅       | `unified` builds; fast, tiny                               |
-| Gemma-4-E2B Q3_K_S         | GGUF          | 2.45 GB | ✅       | `unified` builds; heavy/advanced                           |
-| SD-Turbo fp16 (image)      | ONNX DirectML | 2.4 GB  | ✅       | Image gen ([diffusion/README.md](./diffusion/README.md))   |
-| Phi-3.5-mini CPU INT4      | ONNX GenAI    | ~2.7 GB | ❌       | Not attempted (>2 GB single-file ONNX, §8)                 |
+| Model                      | Format        | Size    | Xbox UWP | Role                                                                        |
+| -------------------------- | ------------- | ------- | -------- | --------------------------------------------------------------------------- |
+| LFM2.5-350M Q4_K_M         | GGUF          | 219 MB  | ✅       | **Default chat** on unified shipping; fastest+lightest                      |
+| SmolLM2-360M-Instruct INT4 | ONNX GenAI    | 417 MB  | ✅       | ORT default / routing base (CPU)                                            |
+| SmolLM2-360M fp16 DML      | ONNX GenAI    | ~700 MB | ✅       | Routing target (long-prompt prefill on GPU)                                 |
+| SmolLM2-1.7B-Instruct INT4 | ONNX GenAI    | 1.4 GB  | ✅       | Larger CPU chat (~20.6 tok/s; in-app `models-v1` download)                  |
+| Qwen3.5-0.8B Q4_K_M        | GGUF          | 508 MB  | ✅       | `unified` builds (llama.cpp)                                                |
+| Gemma-3-270M Q4_K_M        | GGUF          | 253 MB  | ✅       | `unified` builds; fast, tiny                                                |
+| Gemma-4-E2B Q3_K_S         | GGUF          | 2.45 GB | ✅       | `unified` builds; heavy/advanced                                            |
+| SD-Turbo fp16 (image)      | ONNX DirectML | 2.4 GB  | ✅       | Image gen ([diffusion/README.md](./diffusion/README.md))                    |
+| Phi-3.5-mini CPU INT4      | ONNX GenAI    | ~2.7 GB | ❌       | Not attempted (>2 GB single-file ONNX, §8)                                  |
 | Phi-3.5-mini Q3_K_S        | GGUF          | 1.68 GB | ⚠️       | H4 A/B measured 11.3 tok/s / 2453 MB; loses to `llama32-3b` — not catalogue |
 
 See [docs/uwp-constraints.md](./docs/uwp-constraints.md) for the measured GPU budget (3801 MB), the disk budget, and AppContainer workarounds.

--- a/docs/technical-report.md
+++ b/docs/technical-report.md
@@ -50,6 +50,16 @@ Three hypotheses died against these numbers:
    66.3); the crossover exists only in prefill, where batch amortises dispatch
    (1.8× at ~1k tokens). The app therefore routes per-workload (long-prompt
    conversations → DML fp16, decode → CPU int4), sticky per conversation.
+   **Superseded by #91 (2026-07-16): DML text routing is disabled.** The logit-
+   parity harness showed the DML GQA decoder computes numerically wrong logits
+   on the Series S GPU (NMSE ~1 vs the CPU reference, top-1 disagrees; fp16 AND
+   int4; invariant to graph/session/capture options; the same weights are
+   correct on CPU EP and on desktop-class CPU runs; SD-Turbo — no GQA — is
+   correct on the same device). All tok/s numbers above are real, but the GPU
+   text output they measured was silently degraded. Text routing is forced to
+   CPU (`routing_policy.h kDmlTextLogitsBroken`) until
+   `scripts/validate-logit-parity.sh` passes on a DML text model. Diffusion
+   routing is unaffected.
 2. **"DML int4 decode collapses because a kernel is missing."** Falsified by
    desk-check and confirmed on hardware: `MatMulNBits` _is_ on the GPU (compute
    engines 87–90 % busy at 8.8 tok/s) but DirectML implements it **non-fused**

--- a/include/xllama/routing_policy.h
+++ b/include/xllama/routing_policy.h
@@ -27,13 +27,23 @@ struct RoutingDecision {
     int token_count = 0;
 };
 
+// DML text inference computes numerically wrong logits on the Series S
+// Dev-Mode GPU (issue #91): GQA decoder graphs produce deterministic garbage
+// (parity NMSE ~1 vs the CPU reference, top-1 disagrees), invariant to every
+// graph/session/capture knob, at fp16 AND int4, while the same weights are
+// correct on CPU EP and SD-Turbo (no GQA) is correct on the same device. Until
+// the parity gate (scripts/validate-logit-parity.sh) passes on a DML text
+// model, GPU routing for text is forced off — Auto and GpuOnly both resolve to
+// the CPU model. Diffusion (plain ORT, validated correct) is unaffected.
+inline constexpr bool kDmlTextLogitsBroken = true;
+
 // Decide which model directory to load for the first turn of a conversation.
 // |gpu_available| must reflect IsModelProvisioned(gpu_model) — callers gate UX.
 inline RoutingDecision decide_routing(const RoutingSettings& s, int n_tok, bool base_is_gguf,
                                       bool gpu_available) {
     RoutingDecision d;
     d.token_count = n_tok;
-    if (base_is_gguf || s.mode == RoutingMode::CpuOnly) {
+    if (base_is_gguf || s.mode == RoutingMode::CpuOnly || kDmlTextLogitsBroken) {
         d.active_model = s.cpu_model;
         d.use_gpu = false;
         return d;

--- a/patches/onnxruntime-genai-2280-dml-fallback.patch
+++ b/patches/onnxruntime-genai-2280-dml-fallback.patch
@@ -1,5 +1,21 @@
+diff --git a/src/config.cpp b/src/config.cpp
+index b3e35c9c..0e794aa6 100644
+--- a/src/config.cpp
++++ b/src/config.cpp
+@@ -1421,7 +1421,10 @@ bool IsGraphCaptureEnabled(const Config::SessionOptions& session_options) {
+         }
+         return false;
+       } else if (provider_options->name == "DML") {
+-        return true;
++        // xllama: DML graph capture disabled — replayed command lists produce
++        // deterministic garbage logits on the Xbox Series S Dev-Mode D3D12
++        // device (correct on CPU EP and with plain non-captured ORT sessions).
++        return false;
+       } else if (provider_options->name == "WebGPU") {
+         for (const auto& value : provider_options->options) {
+           if (value.first == "enableGraphCapture" && value.second == "1") {
 diff --git a/src/dml/dml_helpers.cpp b/src/dml/dml_helpers.cpp
-index f3cfe32..c29e693 100644
+index f3cfe324..c29e693a 100644
 --- a/src/dml/dml_helpers.cpp
 +++ b/src/dml/dml_helpers.cpp
 @@ -135,12 +135,26 @@ DmlObjects CreateDmlObjects(const std::string& current_module_path, PLUID device
@@ -31,4 +47,21 @@ index f3cfe32..c29e693 100644
 +  if (!agility_device_created) {
      THROW_IF_FAILED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&dml_objects.d3d12_device)));
    }
+ 
+diff --git a/src/dml/session_options.cpp b/src/dml/session_options.cpp
+index a7f8abcf..293d531b 100644
+--- a/src/dml/session_options.cpp
++++ b/src/dml/session_options.cpp
+@@ -38,9 +38,9 @@ DeviceInterface* AppendExecutionProvider(OrtSessionOptions& session_options,
+   // Non-decoder sessions (vision, speech, embedding) have control-flow nodes
+   // that are incompatible with graph capture, so the caller sets
+   // disable_graph_capture=true for those sessions.
+-  if (!disable_graph_capture) {
+-    session_options.AddConfigEntry("ep.dml.enable_graph_capture", "1");
+-  }
++  // xllama: never enable DML graph capture (see IsGraphCaptureEnabled in
++  // config.cpp) — capture replay corrupts logits on the Xbox Dev-Mode device.
++  (void)disable_graph_capture;
+ 
+   SetDmlProvider(session_options);
  

--- a/scripts/validate-console.sh
+++ b/scripts/validate-console.sh
@@ -238,27 +238,28 @@ JSON
 	fi
 	# The routing log line uses "auto -> gpu"/"auto -> cpu" (ASCII arrow in the
 	# C++ is "→"; match on the tok field to be encoding-robust).
+	#
+	# #91 gate: kDmlTextLogitsBroken (routing_policy.h) forces text routing to
+	# CPU in every mode — DML GQA logits are numerically wrong on the Series S
+	# GPU (parity NMSE ~1). Until the parity harness passes on a DML text model,
+	# the CORRECT behavior is: long turn stays CPU and NO gpu routing line ever
+	# appears. When the gate is lifted, restore the pre-#91 auto→gpu assertions.
 	local gpu_line cpu_line
 	gpu_line=$(grep -aE 'routing: auto .* gpu \([0-9]+ tok' "$log" | head -1 || true)
 	cpu_line=$(grep -aE 'routing: auto .* cpu \([0-9]+ tok' "$log" | head -1 || true)
-	if [[ -z "$gpu_line" ]]; then
-		echo "  FAIL: no 'auto -> gpu' routing line for the long-context turn"
+	if [[ -n "$gpu_line" ]]; then
+		echo "  FAIL: a turn routed to GPU despite the #91 gate: ${gpu_line}"
+		verdict=1
+	else
+		echo "  ok: no GPU-routed text turn (#91 gate holds)"
+	fi
+	if [[ -z "$cpu_line" ]]; then
+		echo "  FAIL: no 'auto -> cpu' routing line (routing never ran)"
 		verdict=1
 	else
 		local ntok
-		ntok=$(sed -n 's/.*(\([0-9]\+\) tok.*/\1/p' <<<"$gpu_line")
-		if ((ntok <= 600)); then
-			echo "  FAIL: gpu-routed turn had only ${ntok} tok (<=600)"
-			verdict=1
-		else
-			echo "  ok: long turn routed to GPU (${ntok} tok)"
-		fi
-	fi
-	if [[ -z "$cpu_line" ]]; then
-		echo "  FAIL: no 'auto -> cpu' routing line for the new short chat"
-		verdict=1
-	else
-		echo "  ok: new short chat routed to CPU"
+		ntok=$(sed -n 's/.*(\([0-9]\+\) tok.*/\1/p' <<<"$cpu_line")
+		echo "  ok: turns routed to CPU (first line: ${ntok} tok)"
 	fi
 	if grep -aq '887A0036' "$log"; then
 		echo "  FAIL: 887A0036 present — patched GenAI DLL did not take"

--- a/tests/test_routing_policy.cpp
+++ b/tests/test_routing_policy.cpp
@@ -17,7 +17,22 @@ TEST_CASE("routing: cpu-only") {
     CHECK_FALSE(d.use_gpu);
 }
 
-TEST_CASE("routing: gpu-only with gpu available") {
+// While kDmlTextLogitsBroken holds (#91: DML GQA logits are garbage on the
+// Series S GPU), every mode resolves to the CPU model. The pre-#91 GPU
+// expectations are kept below, guarded, so re-enabling is a one-flag flip.
+TEST_CASE("routing: #91 gate forces cpu in every mode") {
+    RoutingSettings s;
+    s.cpu_model = "cpu";
+    s.gpu_model = "gpu";
+    for (auto mode : {RoutingMode::GpuOnly, RoutingMode::Auto}) {
+        s.mode = mode;
+        auto d = decide_routing(s, 2000, false, true);
+        CHECK(d.active_model == (kDmlTextLogitsBroken ? "cpu" : "gpu"));
+        CHECK(d.use_gpu == !kDmlTextLogitsBroken);
+    }
+}
+
+TEST_CASE("routing: gpu-only with gpu available" * doctest::skip(kDmlTextLogitsBroken)) {
     RoutingSettings s;
     s.mode = RoutingMode::GpuOnly;
     s.cpu_model = "cpu";
@@ -48,7 +63,8 @@ TEST_CASE("routing: auto short prompt stays cpu") {
     CHECK_FALSE(d.use_gpu);
 }
 
-TEST_CASE("routing: auto long prompt uses gpu when available") {
+TEST_CASE("routing: auto long prompt uses gpu when available" *
+          doctest::skip(kDmlTextLogitsBroken)) {
     RoutingSettings s;
     s.mode = RoutingMode::Auto;
     s.token_threshold = 600;


### PR DESCRIPTION
## Context
Deep-dive on #91. The parity harness proved the **DML GQA decoder computes wrong logits on the Series S GPU** — and always has: throughput was benched, correctness never.

## Probe matrix (all on-device, deterministic)
| Probe | Result |
|---|---|
| fp16 GQA / int4 GQA vs golden | NMSE ~1, top1 ` the`, seq=1 pure noise |
| `ORT_DISABLE_ALL` / `ep.dml.disable_graph_fusion` | **bit-identical** garbage |
| GenAI DLL rebuilt with graph capture disabled | **bit-identical** garbage |
| Same weights on CPU EP | ✅ top1 ` Paris`, overlap 0.90–1.00 |
| SD-Turbo (plain ORT, no GQA) on same device | ✅ correct |
| Forced-MHA build | loads on DML; GenAI 0.14 can't allocate non-share-buffer KV on DML (0-length first-step buffer) |
| `disable_metacommands` | provider option unreachable via GenAI's DML1 registration; DirectML 1.15.4 is the last release |

**Conclusion:** the corruption is in the DML GQA execution path on this driver/device, below every config- or DLL-reachable knob.

## Change
- `routing_policy.h`: `kDmlTextLogitsBroken` forces the CPU model in every routing mode (Auto/GpuOnly). One-flag flip to re-enable, gated on `scripts/validate-logit-parity.sh` PASS.
- `validate-console.sh` §2: asserts the gate holds (no GPU-routed text turn).
- Tests updated; pre-#91 GPU expectations kept under `doctest::skip` for the flip.
- README / technical-report / CHANGELOG document the finding honestly (prior GPU text numbers were real throughput on degraded output).

Diffusion (validated correct) stays on the GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled GPU text routing on Series S to prevent incorrect generated outputs caused by decoder logit mismatches.
  - Text generation now consistently uses the CPU backend across routing modes until GPU parity is verified.
  - Improved DirectML device fallback behavior when preferred graphics initialization fails.
  - Disabled DirectML graph capture for more reliable inference.

- **Documentation**
  - Updated the README, changelog, and technical report to explain current text and diffusion routing behavior. Diffusion GPU routing remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->