### PR TITLE
fix(uwp): don't auto-provision the gated gpu_model (#95)

### DIFF
--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -1427,6 +1427,10 @@ void MainPageController::FinishDiffusion() {
 // ---------------------------------------------------------------------------
 
 void MainPageController::EnsureGpuModelIfNeeded() {
+    // #91/#95: while DML text logits are broken, routing can never pick the GPU
+    // model — don't background-download 725 MB that cannot be used.
+    if (::xllama::kDmlTextLogitsBroken)
+        return;
     if (m_routing == 0)
         return;
     const std::wstring gpu = ::xllama::utf8_to_wstring(m_gpu_model);

--- a/uwp/models/manifest.json
+++ b/uwp/models/manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "smollm2-360m-dml-fp16",
-      "display": "SmolLM2 360M (GPU fp16, routing)",
+      "display": "SmolLM2 360M (GPU fp16, routing — disabled #91)",
       "hf_base_url": "https://github.com/gianlucamazza/xllama/releases/download/models-v1",
       "files": [
         {


### PR DESCRIPTION
## Summary
- Gate `EnsureGpuModelIfNeeded` on `kDmlTextLogitsBroken` (#91): while text routing is forced to CPU, don't background-download the 725 MB `smollm2-360m-dml-fp16` that routing can never select.
- Mark the catalogue display name: `SmolLM2 360M (GPU fp16, routing — disabled #91)`.

Closes #95

## How verified
- `linux-test` build + ctest PASS locally (the gate flag lives in `routing_policy.h`, covered by `test_routing_policy.cpp`).
- UWP path compiles only on Windows CI — the gate is a two-line early-return before any manifest/IO work.
- Re-enabling is the same one-flag flip as the routing gate: when `kDmlTextLogitsBroken` goes false, provisioning resumes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)