### PR TITLE
fix(uwp): don't block the turn on a missing gpu_model under the #91 gate

### DIFF
--- a/scripts/provision-models.sh
+++ b/scripts/provision-models.sh
@@ -36,9 +36,11 @@ MANIFEST="${REPO_ROOT}/uwp/models/manifest.json"
 	exit 2
 }
 
-# Models the full-functionality live test needs pre-seeded (chat GGUF, DML
-# routing / logit-parity reference, and diffusion).
-ALL_TEST=(lfm25-350m smollm2-360m-dml-fp16 sd-turbo-fp16)
+# Models the full-functionality live test needs pre-seeded (chat GGUF, the CPU
+# model routing resolves to under the #91 gate / logit-parity reference, and
+# diffusion). smollm2-360m-dml-fp16 is intentionally NOT here while
+# kDmlTextLogitsBroken holds (#95): nothing can use it.
+ALL_TEST=(lfm25-350m smollm2-360m-cpu-int4 sd-turbo-fp16)
 
 FORCE=false
 MODELS=()

--- a/scripts/validate-console.sh
+++ b/scripts/validate-console.sh
@@ -7,8 +7,10 @@
 #   ./scripts/validate-console.sh <routing|gguf|taesd|all>
 #
 # Requires: an installed xllama build with the autopilot (>= 1.1.3.0), the
-# relevant models already in LocalState (smollm2-360m-dml-fp16 for routing,
-# lfm25-350m for gguf, sd-turbo-fp16 for taesd), and XBOX_IP/USER/PASS env.
+# relevant models already in LocalState (smollm2-360m-cpu-int4 for routing —
+# the #91 gate forces CPU, so the dml-fp16 model is not needed nor provisioned
+# while it holds (#95) — lfm25-350m for gguf, sd-turbo-fp16 for taesd), and
+# XBOX_IP/USER/PASS env. Seed with scripts/provision-models.sh.
 #
 # Contract per subcommand: upload chats/autopilot.json + autopilot.flag,
 # restart the app, poll LocalState\autopilot-done.txt, fetch xllama.log, and
@@ -156,12 +158,13 @@ model_provisioned() {
 
 validate_routing() {
 	echo "=== §2 routing A/B ==="
-	if ! model_provisioned "smollm2-360m-dml-fp16"; then
-		echo "  FAIL: smollm2-360m-dml-fp16 is not in LocalState\\models\\"
-		echo "  Upload the DML fp16 model before routing validation:"
-		echo "    PFN=\$(./scripts/deploy.sh pfn)"
-		echo "    ./scripts/deploy.sh upload-dir <host-path>/smollm2-360m-dml-fp16 \"\$PFN\" \"models\\\\smollm2-360m-dml-fp16\""
-		echo "  (not on models-v1 — USB/Device Portal only; reinstalling the MSIX wipes LocalState)"
+	# While kDmlTextLogitsBroken holds (#91), the gate resolves every mode to the
+	# CPU model, and #95 stops provisioning the DML one — so the only model this
+	# test actually loads is smollm2-360m-cpu-int4. When the gate is lifted, the
+	# dml-fp16 model becomes a precondition again (provision-models.sh).
+	if ! model_provisioned "smollm2-360m-cpu-int4"; then
+		echo "  FAIL: smollm2-360m-cpu-int4 is not in LocalState\\models\\"
+		echo "  Seed it first:  ./scripts/provision-models.sh smollm2-360m-cpu-int4"
 		echo "§2 routing: FAIL"
 		return 1
 	fi

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -1907,7 +1907,11 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
                 n_tok = static_cast<int>(full_prompt.size() / 4);
         }
 
-        if (m_routing == 1 && !gpu_provisioned) {
+        // #91/#95: while kDmlTextLogitsBroken holds, decide_routing resolves every
+        // mode to the CPU model and the GPU model is intentionally not provisioned
+        // — a missing gpu_model must not block the turn or nag the user.
+        const bool warn_gpu_missing = !::xllama::kDmlTextLogitsBroken && !gpu_provisioned;
+        if (m_routing == 1 && warn_gpu_missing) {
             SetStatus(L"GPU model '" + ::xllama::utf8_to_wstring(m_gpu_model) +
                           L"' is not on this console.\n"
                           L"Upload it to LocalState\\models\\" +
@@ -1917,7 +1921,7 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
             SetRunning(false);
             return;
         }
-        if (m_routing == 2 && n_tok > rs.token_threshold && !gpu_provisioned) {
+        if (m_routing == 2 && n_tok > rs.token_threshold && warn_gpu_missing) {
             SetStatus(L"GPU model '" + ::xllama::utf8_to_wstring(m_gpu_model) +
                           L"' is not on this console — staying on CPU.\n"
                           L"Upload it to LocalState\\models\\" +


### PR DESCRIPTION
## Summary
Live-test fallout of #95 on console (v1.2.0.532):
- The `StartInference` pre-checks for a missing `gpu_model` (`routing==1`, and `routing==2` past the token threshold) **errored and returned**, blocking chat at the first send — with #95 the missing GPU model is now the normal state, and under `kDmlTextLogitsBroken` `decide_routing` resolves to CPU regardless. The checks are now bypassed while the gate holds (they come back verbatim when it lifts).
- `validate-console.sh routing`: stale precondition required `smollm2-360m-dml-fp16` on device — post #91/#95 the test only loads `smollm2-360m-cpu-int4`; require that instead.
- `provision-models.sh --all-test`: seed `cpu-int4` instead of the gated `dml-fp16`.

## How verified
- Found by the on-device suite: `validate-console.sh routing` FAILed with `autopilot: error: action 1 send: GPU model 'smollm2-360m-dml-fp16' is not on this console`.
- `linux-test` build + ctest PASS; shellcheck PASS on both scripts.
- #95 gate itself verified on hardware in the same run: with `routing:2` seeded and the model absent, no `background provision` log line and no `models\smollm2-360m-dml-fp16` dir created.
- Full re-run of the routing gate on console follows this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)