### PR TITLE
docs: consolidate the #91/#95/#100 state across all documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   GQA decoder computing numerically wrong logits on the Series S GPU (NMSE ~1
   vs the CPU reference at fp16 AND int4; invariant to `ORT_DISABLE_ALL`,
   `ep.dml.disable_graph_fusion` and a capture-disabled GenAI DLL; the same
-  weights are correct on CPU EP; SD-Turbo — no GQA — is correct on the same
-  device). `decide_routing` now forces the CPU model in every mode
+  weights are correct on CPU EP; SD-Turbo — decomposed attention, no contrib
+  ops — is correct on the same device). The #94 probe later showed the
+  **MultiHeadAttention** kernel is equally broken (same NMSE ~0.98 as GQA), so
+  the fault is the DML attention path on this driver, not one op.
+  `decide_routing` now forces the CPU model in every mode
   (`kDmlTextLogitsBroken`, `routing_policy.h`); GPU-routed answers had been
   silently degraded since the routing feature shipped. Re-enable gate:
   `scripts/validate-logit-parity.sh` PASS on a DML text model. Diffusion (plain
   ORT, validated) is unaffected. `validate-console.sh routing` now asserts the
   gate holds. Probe log in #91.
+- **Upstream GenAI PR toward the DML re-enable path** —
+  [microsoft/onnxruntime-genai#2300](https://github.com/microsoft/onnxruntime-genai/pull/2300):
+  graph-capture opt-out via the `dml` provider option
+  (`enable_graph_capture: "0"`) + zero-length KV placeholder clamp, both proven
+  on-device during the #94 probe (fork branch
+  `upstream-pr/dml-graph-capture-optout`). Closes #97. Driver-side track:
+  microsoft/onnxruntime#29739.
 
 ### Fixed
 
@@ -33,6 +43,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   remains `Q4_K_M` when no token is found.
 - **`bench-xbox-ort.sh`** — does not upload ORT `genai_config.json` into GGUF
   model dirs when `--threads` is set (threads still via `bench_threads.txt`).
+- **`gpu_model` no longer auto-downloaded under the #91 gate (#98, closes #95)**
+  — `EnsureGpuModelIfNeeded` skips the 725 MB `smollm2-360m-dml-fp16` download
+  while `kDmlTextLogitsBroken` holds (routing can never select it); the
+  catalogue display now reads "GPU fp16, routing — disabled #91".
+- **Missing `gpu_model` no longer blocks the turn under the #91 gate (#100)** —
+  the `StartInference` pre-checks that errored-and-returned on a missing
+  `gpu_model` (now the normal state after #95) are bypassed while the gate
+  holds. `validate-console.sh routing` precondition switched to
+  `smollm2-360m-cpu-int4`; `provision-models.sh --all-test` seeds `cpu-int4`
+  instead of the gated `dml-fp16`.
+
+### Docs
+
+- **Publishing runbook for ORT model assets (#99, closes #96)** — "Publishing
+  ORT model assets (models-v1) — logit-parity gate" in
+  `docs/model-selection.md` (+ CONTRIBUTING pointer): no ORT text asset is
+  uploaded without passing the parity gate (llama.cpp golden → host CPU-EP
+  compare → on-device `validate-logit-parity.sh` for DML → exact
+  `approx_bytes`).
 
 ### Added
 
@@ -50,6 +79,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   **Note:** console field package was still `1.1.8.507` during the campaign;
   deploy `1.2.0.x` (+ this fix set) for catalogue download hardening and the Phi
   template on-device.
+- **Full validation suite PASS on `1.2.0.534`** (2026-07-16, Series S, main):
+  logit-parity cpu-int4 vs GGUF golden NMSE **0.094** / top-10 **0.90**, §2
+  routing gate holds (no `auto → gpu`, CPU turn at 959 tok), GGUF chat, TAESD
+  VAE **621.7 ms**, LAN API ALL PASS, and the #95 gate verified live (0
+  `background provision` lines with `routing:2` and the DML model absent).
+  Supersedes the `1.1.8.507` caveat above.
 
 ## [1.2.0.0] - 2026-07-16
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 `xllama` is a UWP application for Xbox Series S|X in Dev Mode that runs LLM chat and Stable-Diffusion image generation locally, with no cloud dependency and a gamepad-friendly UI.
 
-The project started as a port of [`llama.cpp`](https://github.com/ggml-org/llama.cpp) (GGUF files, CPU-only), then migrated to **ONNX Runtime GenAI + DirectML**. The measured verdict is **per-workload** (see [docs/technical-report.md](./docs/technical-report.md)): the Zen 2 **CPU wins autoregressive decode** at this model scale (~66 tok/s, SmolLM2-360M int4), the RDNA 2 **GPU wins batch compute** — prefill at ~1k prompt tokens (1.8× faster) and image generation (**11.1×** on the diffusion workload: SD-Turbo 512×512 in ~7 s). GPU **text** routing is currently disabled ([#91](https://github.com/gianlucamazza/xllama/issues/91): the DML GQA decoder computes wrong logits on the Series S GPU — caught by the logit-parity harness); diffusion stays on the GPU. The llama.cpp path serves Linux development, CI, and — in the `unified` UWP build — modern GGUF-only models (Qwen3.5, LFM2.5); for the same model, ORT stays the text backend (measured decode parity, better prefill).
+The project started as a port of [`llama.cpp`](https://github.com/ggml-org/llama.cpp) (GGUF files, CPU-only), then migrated to **ONNX Runtime GenAI + DirectML**. The measured verdict is **per-workload** (see [docs/technical-report.md](./docs/technical-report.md)): the Zen 2 **CPU wins autoregressive decode** at this model scale (~66 tok/s, SmolLM2-360M int4), the RDNA 2 **GPU wins batch compute** — prefill at ~1k prompt tokens (1.8× faster) and image generation (**11.1×** on the diffusion workload: SD-Turbo 512×512 in ~7 s). GPU **text** routing is currently disabled ([#91](https://github.com/gianlucamazza/xllama/issues/91): the DML attention path — GQA **and** MultiHeadAttention — computes wrong logits on the Series S GPU, caught by the logit-parity harness); diffusion stays on the GPU. The llama.cpp path serves Linux development, CI, and — in the `unified` UWP build — modern GGUF-only models (Qwen3.5, LFM2.5); for the same model, ORT stays the text backend (measured decode parity, better prefill).
 
 The default chat model on the shipping **unified** build is **LFM2.5-350M Q4_K_M** (~219 MB, ~94 tok/s), downloaded on first launch from the GitHub Release model catalogue — the MSIX itself is ~19 MB and ships no model. ORT-only builds still default to SmolLM2-360M INT4.
 
@@ -90,7 +90,8 @@ See [docs/install-release.md](./docs/install-release.md) to install a tagged rel
 **Measured performance (Xbox Series S):** fastest chat decode **94.2 tok/s**
 (LFM2.5-350M GGUF); the shipped default SmolLM2-360M int4 runs ~66–71 tok/s; Gemma
 models run on-device (Gemma-3-270M **76.8 tok/s**); prefill at ~1k tokens is
-**354 tok/s on GPU fp16** vs 198 CPU (the crossover that motivates routing);
+**354 tok/s on GPU fp16** vs 198 CPU (the crossover that motivated routing —
+disabled since #91, DML text logits are wrong);
 KV-cache reuse makes turn-2 prefill ~**4×** faster on **both** backends; SD-Turbo
 draws a 512×512 image in **~6.9 s** on DirectML. **The full, disambiguated tables
 are the single source of truth in [docs/benchmarks.md](./docs/benchmarks.md)**
@@ -125,7 +126,7 @@ are the single source of truth in [docs/benchmarks.md](./docs/benchmarks.md)**
 │  ├─ per-model backend dispatch:          │
 │  │  • ORT chat → CPU EP (Zen 2)         │
 │  │  • long-prompt prefill → DML fp16    │
-│  │    (per-conversation routing)         │
+│  │    (routing — disabled, #91)          │
 │  │  • GGUF chat → llama.cpp CPU +       │
 │  │    KV-reuse (unified build)           │
 │  └─ image gen → SD-Turbo on DirectML    │
@@ -248,18 +249,18 @@ Models come from the catalogue `uwp/models/manifest.json` (assets hosted on the 
 Catalogue overview (roles + sizes; **decode/prefill/RAM numbers live in
 [docs/benchmarks.md](./docs/benchmarks.md)**, the perf SSOT):
 
-| Model                      | Format        | Size    | Xbox UWP | Role                                                                        |
-| -------------------------- | ------------- | ------- | -------- | --------------------------------------------------------------------------- |
-| LFM2.5-350M Q4_K_M         | GGUF          | 219 MB  | ✅       | **Default chat** on unified shipping; fastest+lightest                      |
-| SmolLM2-360M-Instruct INT4 | ONNX GenAI    | 417 MB  | ✅       | ORT default / routing base (CPU)                                            |
-| SmolLM2-360M fp16 DML      | ONNX GenAI    | ~700 MB | ✅       | Routing target (long-prompt prefill on GPU)                                 |
-| SmolLM2-1.7B-Instruct INT4 | ONNX GenAI    | 1.4 GB  | ✅       | Larger CPU chat (~20.6 tok/s; in-app `models-v1` download)                  |
-| Qwen3.5-0.8B Q4_K_M        | GGUF          | 508 MB  | ✅       | `unified` builds (llama.cpp)                                                |
-| Gemma-3-270M Q4_K_M        | GGUF          | 253 MB  | ✅       | `unified` builds; fast, tiny                                                |
-| Gemma-4-E2B Q3_K_S         | GGUF          | 2.45 GB | ✅       | `unified` builds; heavy/advanced                                            |
-| SD-Turbo fp16 (image)      | ONNX DirectML | 2.4 GB  | ✅       | Image gen ([diffusion/README.md](./diffusion/README.md))                    |
-| Phi-3.5-mini CPU INT4      | ONNX GenAI    | ~2.7 GB | ❌       | Not attempted (>2 GB single-file ONNX, §8)                                  |
-| Phi-3.5-mini Q3_K_S        | GGUF          | 1.68 GB | ⚠️       | H4 A/B measured 11.3 tok/s / 2453 MB; loses to `llama32-3b` — not catalogue |
+| Model                      | Format        | Size    | Xbox UWP | Role                                                                                   |
+| -------------------------- | ------------- | ------- | -------- | -------------------------------------------------------------------------------------- |
+| LFM2.5-350M Q4_K_M         | GGUF          | 219 MB  | ✅       | **Default chat** on unified shipping; fastest+lightest                                 |
+| SmolLM2-360M-Instruct INT4 | ONNX GenAI    | 417 MB  | ✅       | ORT default / routing base (CPU)                                                       |
+| SmolLM2-360M fp16 DML      | ONNX GenAI    | ~725 MB | ✅       | Routing target — **disabled #91** (wrong text logits on DML; not auto-downloaded, #95) |
+| SmolLM2-1.7B-Instruct INT4 | ONNX GenAI    | 1.4 GB  | ✅       | Larger CPU chat (~20.6 tok/s; in-app `models-v1` download)                             |
+| Qwen3.5-0.8B Q4_K_M        | GGUF          | 508 MB  | ✅       | `unified` builds (llama.cpp)                                                           |
+| Gemma-3-270M Q4_K_M        | GGUF          | 253 MB  | ✅       | `unified` builds; fast, tiny                                                           |
+| Gemma-4-E2B Q3_K_S         | GGUF          | 2.45 GB | ✅       | `unified` builds; heavy/advanced                                                       |
+| SD-Turbo fp16 (image)      | ONNX DirectML | 2.4 GB  | ✅       | Image gen ([diffusion/README.md](./diffusion/README.md))                               |
+| Phi-3.5-mini CPU INT4      | ONNX GenAI    | ~2.7 GB | ❌       | Not attempted (>2 GB single-file ONNX, §8)                                             |
+| Phi-3.5-mini Q3_K_S        | GGUF          | 1.68 GB | ⚠️       | H4 A/B measured 11.3 tok/s / 2453 MB; loses to `llama32-3b` — not catalogue            |
 
 See [docs/uwp-constraints.md](./docs/uwp-constraints.md) for the measured GPU budget (3801 MB), the disk budget, and AppContainer workarounds.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,23 +11,24 @@ docs quote a headline and link back:
 - **UWP/AppContainer constraints** (§1–§12) → [uwp-constraints.md](./uwp-constraints.md)
 - **Version / current state** → [../CHANGELOG.md](../CHANGELOG.md) + [../ROADMAP.md](../ROADMAP.md)
 
-| Document                                                         | Description                                                                                                                                |
-| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| [architecture.md](./architecture.md)                             | Component/data-flow map: modules, runtime backend dispatch, chat templates, KV-reuse, routing, provisioning auto-upgrade, membw, diffusion |
-| [install-release.md](./install-release.md)                       | Install a tagged GitHub Release build on your Xbox (cert + VCLibs + MSIX)                                                                  |
-| [using-the-app.md](./using-the-app.md)                           | App guide: chat, settings (model picker, routing, KV reuse), image generation                                                              |
-| [uwp-constraints.md](./uwp-constraints.md)                       | UWP sandbox limitations, measured GPU budget, AppContainer filesystem quirks, and how xllama works around them                             |
-| [technical-report.md](./technical-report.md)                     | The measured story (v1.0 snapshot); published as [Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76)                  |
-| [console-validation-runbook.md](./console-validation-runbook.md) | Ordered on-console validation checklist with measured results per section                                                                  |
-| [fp16-extdata-runbook.md](./fp16-extdata-runbook.md)             | Unblock fp16 models >2 GB on the GPU: zero-code USB spike, then the ORT `weakly_canonical` patch (Fase 1) — entrypoint for the scripts     |
-| [windows-dev-vm.md](./windows-dev-vm.md)                         | Windows VM setup for local UWP/MSIX builds                                                                                                 |
-| [device-portal.md](./device-portal.md)                           | How to enable Dev Mode and deploy via Device Portal                                                                                        |
-| [phase1-runbook.md](./phase1-runbook.md)                         | End-to-end developer build, deploy, and benchmark instructions                                                                             |
-| [model-selection.md](./model-selection.md)                       | Choosing/adding models: hard limits, evaluation sequence, tested models, manifest override how-to                                          |
-| [benchmarks.md](./benchmarks.md)                                 | Consolidated perf for every tested model (decode/prefill/RAM, 3 backends) + comparative charts (`benchmarks-charts.html`)                  |
-| [recommended-config.md](./recommended-config.md)                 | Correct modern settings: models, genai_config, settings.json, build variants, obsolete myths                                               |
-| [project-analysis-2026-07.md](./project-analysis-2026-07.md)     | Project health snapshot (2026-07-15, currency 2026-07-16): status matrix, risks — **not** a perf SSOT                                      |
-| [vendor-lifecycle-plan.md](./vendor-lifecycle-plan.md)           | Piano di risoluzione residuo: drop pin GenAI/ORT, upstream ReadFile, demo video, catalogue opzionale                                      |
-| [phase7-hypotheses.md](./phase7-hypotheses.md)                   | Phase 7 research: peer-class model hypotheses (H1–H9), shortlist, campaign results — **not** a perf SSOT                                   |
+| Document                                                         | Description                                                                                                                                  |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| [architecture.md](./architecture.md)                             | Component/data-flow map: modules, runtime backend dispatch, chat templates, KV-reuse, routing, provisioning auto-upgrade, membw, diffusion   |
+| [install-release.md](./install-release.md)                       | Install a tagged GitHub Release build on your Xbox (cert + VCLibs + MSIX)                                                                    |
+| [using-the-app.md](./using-the-app.md)                           | App guide: chat, settings (model picker, routing, KV reuse), image generation                                                                |
+| [uwp-constraints.md](./uwp-constraints.md)                       | UWP sandbox limitations, measured GPU budget, AppContainer filesystem quirks, and how xllama works around them                               |
+| [technical-report.md](./technical-report.md)                     | The measured story (v1.0 snapshot); published as [Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76)                    |
+| [console-validation-runbook.md](./console-validation-runbook.md) | Ordered on-console validation checklist with measured results per section                                                                    |
+| [fp16-extdata-runbook.md](./fp16-extdata-runbook.md)             | Unblock fp16 models >2 GB on the GPU: zero-code USB spike, then the ORT `weakly_canonical` patch (Fase 1) — entrypoint for the scripts       |
+| [windows-dev-vm.md](./windows-dev-vm.md)                         | Windows VM setup for local UWP/MSIX builds                                                                                                   |
+| [device-portal.md](./device-portal.md)                           | How to enable Dev Mode and deploy via Device Portal                                                                                          |
+| [phase1-runbook.md](./phase1-runbook.md)                         | End-to-end developer build, deploy, and benchmark instructions                                                                               |
+| [model-selection.md](./model-selection.md)                       | Choosing/adding models: hard limits, evaluation sequence, tested models, manifest override how-to + ORT-asset publishing (logit-parity gate) |
+| [api-endpoint.md](./api-endpoint.md)                             | LAN HTTP endpoint (OpenAI-compatible, opt-in, default OFF): enable, protocol, concurrency, validation                                        |
+| [benchmarks.md](./benchmarks.md)                                 | Consolidated perf for every tested model (decode/prefill/RAM, 3 backends) + comparative charts (`benchmarks-charts.html`)                    |
+| [recommended-config.md](./recommended-config.md)                 | Correct modern settings: models, genai_config, settings.json, build variants, obsolete myths                                                 |
+| [project-analysis-2026-07.md](./project-analysis-2026-07.md)     | Project health snapshot (2026-07-15, currency 2026-07-16): status matrix, risks — **not** a perf SSOT                                        |
+| [vendor-lifecycle-plan.md](./vendor-lifecycle-plan.md)           | Piano di risoluzione residuo: drop pin GenAI/ORT, upstream ReadFile, demo video, catalogue opzionale                                         |
+| [phase7-hypotheses.md](./phase7-hypotheses.md)                   | Phase 7 research: peer-class model hypotheses (H1–H9), shortlist, campaign results — **not** a perf SSOT                                     |
 
 See also [../CHANGELOG.md](../CHANGELOG.md) for the full pivot history (llama.cpp → ORT GenAI → CPU EP → per-workload routing) and [../diffusion/README.md](../diffusion/README.md) for the SD-Turbo model toolchain.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,9 @@ Two text backends, selected by build variant **and** per model at runtime:
 
 - **ORT GenAI / DirectML** (`XLLAMA_USE_ORT`) — `OrtSession` in `src/bridge/session.cpp`.
   Runs ONNX GenAI models (`kind: "ort-genai"`); CPU int4 decode + DirectML fp16
-  prefill, with per-conversation EP routing.
+  prefill, with per-conversation EP routing. **Text is currently forced to CPU
+  in every mode** (`kDmlTextLogitsBroken`, #91 — the DML EP computes wrong text
+  logits on the Series S driver); diffusion stays on GPU.
 - **llama.cpp / GGUF** (`XLLAMA_USE_LLAMA`) — `LlamaSession` in
   `src/bridge/session.cpp`. Runs `.gguf` models (`kind: "gguf"`); CPU-only on Xbox
   (no ggml GPU backend), with KV-cache reuse.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -26,17 +26,17 @@ Metrics: **prefill** = prompt tok/s (throughput ingesting the prompt), **decode*
 
 Best measured decode configuration per model.
 
-| Model        | Params | Quant  | Backend               | Prefill tok/s | Decode tok/s | Peak RAM MB | Source CSV                  |
-| ------------ | ------ | ------ | --------------------- | ------------: | -----------: | ----------: | --------------------------- |
-| LFM2.5-350M  | 350M   | Q4_K_M | llama.cpp CPU · t6    |         241.4 |     **94.2** |         321 | `phase5-gguf`               |
-| SmolLM2-360M | 360M   | int4   | ORT-GenAI CPU         |         219.8 |         70.9 |         722 | `phase1-cpu` / `phase2-dml` |
-| SmolLM2-360M | 360M   | Q4_K_M | llama.cpp CPU · t6    |         141.5 |         62.9 |         402 | `phase35-llamacpp-scaling`  |
-| SmolLM2-360M | 360M   | fp16   | ORT DML (routing GPU) |         353.5 |         46.8 |        1154 | `phase2-dml`                |
-| Qwen3.5-0.8B | 0.8B   | Q4_K_M | llama.cpp CPU · t6    |          98.1 |         35.1 |         718 | `phase5-gguf`               |
-| SmolLM2-1.7B | 1.7B   | int4   | ORT-GenAI CPU         |          54.9 |         20.6 |        2423 | `phase35-1b-cpu`            |
-| SmolLM2-360M | 360M   | int4   | ORT DML int4          |       152–334 |          8.8 |    999–1525 | `phase2-dml`                |
-| Llama-3.2-3B | 3B     | Q3_K_S | llama.cpp CPU · t6    |          19.5 |     **14.2** |        1824 | `phase7-scale`              |
-| Phi-3.5-mini | 3.8B   | Q3_K_S | llama.cpp CPU · t6    |          15.3 |         11.3 |        2453 | `phase7-scale`              |
+| Model        | Params | Quant  | Backend                        | Prefill tok/s | Decode tok/s | Peak RAM MB | Source CSV                  |
+| ------------ | ------ | ------ | ------------------------------ | ------------: | -----------: | ----------: | --------------------------- |
+| LFM2.5-350M  | 350M   | Q4_K_M | llama.cpp CPU · t6             |         241.4 |     **94.2** |         321 | `phase5-gguf`               |
+| SmolLM2-360M | 360M   | int4   | ORT-GenAI CPU                  |         219.8 |         70.9 |         722 | `phase1-cpu` / `phase2-dml` |
+| SmolLM2-360M | 360M   | Q4_K_M | llama.cpp CPU · t6             |         141.5 |         62.9 |         402 | `phase35-llamacpp-scaling`  |
+| SmolLM2-360M | 360M   | fp16   | ORT DML — routing disabled #91 |         353.5 |         46.8 |        1154 | `phase2-dml`                |
+| Qwen3.5-0.8B | 0.8B   | Q4_K_M | llama.cpp CPU · t6             |          98.1 |         35.1 |         718 | `phase5-gguf`               |
+| SmolLM2-1.7B | 1.7B   | int4   | ORT-GenAI CPU                  |          54.9 |         20.6 |        2423 | `phase35-1b-cpu`            |
+| SmolLM2-360M | 360M   | int4   | ORT DML int4                   |       152–334 |          8.8 |    999–1525 | `phase2-dml`                |
+| Llama-3.2-3B | 3B     | Q3_K_S | llama.cpp CPU · t6             |          19.5 |     **14.2** |        1824 | `phase7-scale`              |
+| Phi-3.5-mini | 3.8B   | Q3_K_S | llama.cpp CPU · t6             |          15.3 |         11.3 |        2453 | `phase7-scale`              |
 
 Notes:
 
@@ -51,14 +51,19 @@ Notes:
   Campaign headless used ChatML; Phi-3 template (`ChatFormatKind::Phi3`) landed
   after the run — tok/s/RAM still valid.
 
-
 - **LFM2.5-350M** is the fastest chat model and the lightest (321 MB RAM) — the
   default chat model on unified builds.
 - **DML int4** (8.8 tok/s) is ~8× slower than CPU at this scale: no fused low-bit
   GPU GEMM, so decode is memory-bound reading fp16 weights round-tripped through
-  VRAM. DML fp16 is only worth it for long-prefill routing (353 tok/s prefill).
-- **Routing**: Auto switches SmolLM2-360M CPU → DML fp16 above a 600-token prompt
-  (`routing_policy.h`), trading decode (70.9 → 46.8) for prefill (219 → 353).
+  VRAM. DML fp16's prefill number (353 tok/s) stands as a raw throughput
+  measurement only — **its text output is numerically wrong on this device
+  (#91)**.
+- **Routing — disabled (#91)**: DML text logits are wrong on the Series S driver
+  (attention path, GQA and MHA alike), so `routing_policy.h`
+  (`kDmlTextLogitsBroken`) forces every text turn to the CPU model and the
+  600-token Auto switch never fires. The pre-#91 trade (decode 70.9 → 46.8 for
+  prefill 219 → 353) returns if `validate-logit-parity.sh` ever passes on a DML
+  text model. All DML tok/s rows above remain valid as throughput measurements.
 
 ## KV-cache reuse — both backends, CPU
 

--- a/docs/console-validation-runbook.md
+++ b/docs/console-validation-runbook.md
@@ -62,13 +62,16 @@ turn-2 cold re-prefills the full 2-turn context, reuse only the ~10-token delta.
 confirm multi-turn **coherence** (read the log's decoded turn-2 output) before trusting
 `kv_reuse` as the interactive default.
 
-## 2. PR #2 — CPU/GPU routing (Stage 3) — ✅ MEASURED 2026-07-14 (`validate-console.sh routing`)
+## 2. PR #2 — CPU/GPU routing (Stage 3) — ✅ GATE HOLDS 2026-07-16 (`validate-console.sh routing`)
 
-**Validates**: the `routing=2` (auto) path picks GPU (DML fp16) for long prompts and CPU
-for decode, sticky per conversation.
+**Validates (since #91)**: the `kDmlTextLogitsBroken` gate holds — every text
+turn stays on the CPU model in every routing mode, and no turn is blocked or
+degraded by it. The pre-#91 semantics (auto picks DML fp16 for long prompts)
+return, and this section flips back to an A/B, when the gate is lifted
+(`validate-logit-parity.sh` PASS on a DML text model).
 
 > **Automated gate (official).** Dev Mode gives the console no working text-input
-> path, so this A/B is driven by the in-app **autopilot** (build ≥ 1.1.3.0):
+> path, so this check is driven by the in-app **autopilot** (build ≥ 1.1.3.0):
 >
 > ```bash
 > source ~/.config/xllama/xbox-env
@@ -76,22 +79,28 @@ for decode, sticky per conversation.
 > ```
 >
 > It seeds a >600-token decoy conversation, replays load_chat → send → new_chat →
-> send via `autopilot.flag`/`autopilot.json`, and greps `xllama.log` for
-> `auto → gpu (N>600 tok`, `auto → cpu` on the new chat, and the absence of
-> `887A0036`. **A PASS here is the official §2 gate** (same `StartInference` in the
-> live XAML process as a human run). The manual steps below remain for debugging.
+> send via `autopilot.flag`/`autopilot.json`, and greps `xllama.log` for the
+> **absence** of `auto → gpu` (the gate must hold), the **presence** of
+> `auto → cpu` (the turn must still run, #100), and the absence of `887A0036`.
+> **A PASS here is the official §2 gate** (same `StartInference` in the live
+> XAML process as a human run). The manual steps below remain for debugging.
 
-**Measured (2026-07-14, unified 1.1.3.0 + 1.1.4.0, patched GenAI):** long turn
-auto→GPU (**959 tok**), new short chat auto→CPU, no `887A0036`. Full suite:
-`./scripts/validate-console.sh all` → **ALL PASS**.
+**Measured (2026-07-16, unified 1.2.0.534):** long turn (**959 tok**) routed to
+CPU, no `auto → gpu` line, no `887A0036` — gate holds. Full suite PASS (parity,
+routing, GGUF, TAESD, API). _(Historical, pre-#91 — 2026-07-14, 1.1.3.0/1.1.4.0:
+long turn auto→GPU at 959 tok, short chat auto→CPU. Those answers were later
+shown numerically wrong — see #91.)_
 
 **Prereqs** (manual path):
 
 1. A **unified + PatchedGenAI #2280** MSIX — the default `xllama-appx` CI artifact
    (`build-uwp.yml`); vanilla NuGet `onnxruntime-genai.dll` hits `887A0036` in XAML.
-   Local build: `./scripts/build-uwp.ps1 -Backend unified -PatchedGenAI`.
-2. `smollm2-360m-dml-fp16` in `LocalState\models\` (catalogue download from
-   `models-v1`, or WDP upload via `deploy.sh upload-dir`).
+   (Under the #91 gate this matters for diffusion and for the future re-enable,
+   not for the text path — which is CPU in every mode.)
+2. `smollm2-360m-cpu-int4` in `LocalState\models\` — seed it with
+   `./scripts/provision-models.sh smollm2-360m-cpu-int4` (or `--all-test`).
+   The `smollm2-360m-dml-fp16` model is **not** required nor auto-downloaded
+   while the gate holds (#95).
 3. Preload modern settings (tokenizer-accurate threshold **600 tok**). NB: the
    app reads `settings.json`, so upload under that name:
 
@@ -106,10 +115,12 @@ Then, at the console: launch xllama → paste a **long** prompt (>~600 tokens �
 `bench/prompts/long-1k.txt`) → send; then a short follow-up; then **+ New** and a short
 prompt. Fetch the log afterwards (`deploy.sh get-log`).
 
-**Looking for** (in the log): a line like `routing: auto → gpu (N tok, threshold 600, ...)`
-on the long-prompt first turn; follow-up stays on the same EP (sticky); new chat with a
-short prompt shows `routing: auto → cpu`. No `887A0036`. Optional: `./scripts/profile-dml-run.sh`
-on a GPU-routed turn → `VERDICT: GPU`.
+**Looking for** (in the log, while the #91 gate holds): `routing: auto → cpu (N
+tok, ...)` on the long-prompt first turn — and **no** `routing: auto → gpu` line
+anywhere (its presence means the gate regressed). No `887A0036`. _(Pre-#91
+expectation, restored when the gate lifts: `auto → gpu` on the long turn, sticky
+per conversation, `auto → cpu` on the short new chat; optional
+`./scripts/profile-dml-run.sh` → `VERDICT: GPU`.)_
 
 ## 3. PR #2 — 0.14.1 decode overhead — ✅ MEASURED 2026-07-08 (flat vs v0.3.6, `phase35-014-*.csv`)
 
@@ -288,10 +299,13 @@ restart → poll → verdict.
 
 **WDP quirks (2026-07-14 fixes):** `upload_file` mkdirs remote dirs before POST
 (chats, nested model paths). `model_provisioned` checks `filename=genai_config.json`
-(basename only — not a full path). After an MSIX **uninstall** (not upgrade),
-LocalState is wiped — re-provision models or let the catalogue download finish
-before running gates. `install-latest-build.sh` leaves `bench.flag` in LocalState
-(headless bench on next launch); delete it for UI/autopilot validation:
+(basename only — not a full path). After an MSIX **uninstall**, LocalState is
+wiped — and `install-latest-build.sh` **always uninstalls first** (to avoid the
+double-MSIX disk footprint), so **every install wipes LocalState**: provision
+models AFTER the install, never before
+(`./scripts/provision-models.sh --all-test`). `install-latest-build.sh` uploads
+`bench.flag` only with `--bench` (headless bench on next launch); if present,
+delete it for UI/autopilot validation:
 
 ```bash
 ./scripts/deploy.sh stop-app

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -72,14 +72,14 @@ and llama.cpp (GGUF, CPU).
 
 ## Reference: tested models
 
-| Model                          | On-disk (merged) | CPU EP                                  | DirectML EP                                      | Notes                                                                                                     |
-| ------------------------------ | ---------------- | --------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
-| SmolLM2-360M-Instruct INT4 CPU | 417 MB           | ✅ Active baseline (66.3 tok/s, 0.14.1) | ❌ `80070057` (CPU-int4 graph in DML fused node) | Default; downloaded from the `models-v1` Release catalogue                                                |
-| SmolLM2-360M-Instruct INT4 DML | 285 MB           | —                                       | ✅ **8.8 tok/s** (headless v0.3.4)               | Built with ORT GenAI model builder (`-p int4 -e dml`); CPU ~8× faster — DML not competitive at this scale |
-| SmolLM2-1.7B-Instruct INT4 CPU | 1.4 GB           | ✅ in-app (`models-v1` catalogue)       | —                                                | Console: 20.6 tok/s decode, peak 2423 MB (`phase35-1b-cpu.csv`); also USB/LocalState                      |
-| Phi-3.5-mini INT4 CPU          | ~2.7 GB          | ❌ Disk budget                          | —                                                | Not attempted                                                                                             |
-| Phi-3.5-mini GPU INT4 AWQ      | ~2.2 GB          | —                                       | ❌ GPU OOM + disk                                | Not viable                                                                                                |
-| Phi-3.5-mini Q3_K_S (GGUF)     | 1.68 GB          | ✅ H4 A/B (11.3 tok/s, 2453 MB)         | —                                                | Loses speed+RAM vs Llama-3.2-3B Q3; **not** catalogue (`phase7-scale.csv`)                                |
+| Model                          | On-disk (merged) | CPU EP                                  | DirectML EP                                      | Notes                                                                                                                                 |
+| ------------------------------ | ---------------- | --------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| SmolLM2-360M-Instruct INT4 CPU | 417 MB           | ✅ Active baseline (66.3 tok/s, 0.14.1) | ❌ `80070057` (CPU-int4 graph in DML fused node) | Default; downloaded from the `models-v1` Release catalogue                                                                            |
+| SmolLM2-360M-Instruct INT4 DML | 285 MB           | —                                       | ⚠️ **8.8 tok/s** but wrong logits (#91)          | Built with ORT GenAI model builder (`-p int4 -e dml`); CPU ~8× faster — and DML text output is numerically wrong on this device (#91) |
+| SmolLM2-1.7B-Instruct INT4 CPU | 1.4 GB           | ✅ in-app (`models-v1` catalogue)       | —                                                | Console: 20.6 tok/s decode, peak 2423 MB (`phase35-1b-cpu.csv`); also USB/LocalState                                                  |
+| Phi-3.5-mini INT4 CPU          | ~2.7 GB          | ❌ Disk budget                          | —                                                | Not attempted                                                                                                                         |
+| Phi-3.5-mini GPU INT4 AWQ      | ~2.2 GB          | —                                       | ❌ GPU OOM + disk                                | Not viable                                                                                                                            |
+| Phi-3.5-mini Q3_K_S (GGUF)     | 1.68 GB          | ✅ H4 A/B (11.3 tok/s, 2453 MB)         | —                                                | Loses speed+RAM vs Llama-3.2-3B Q3; **not** catalogue (`phase7-scale.csv`)                                                            |
 
 ## Candidates evaluated (HF Hub file sizes, 2026-07-02)
 
@@ -113,8 +113,10 @@ directly, console-validated with a 1.86 GB int4 model. **But this does not make 
 fp16 models viable on the GPU**: a native-DML 1B fp16 (2.49 GB) loads yet OOMs
 inference within the 3801 MB budget (`uwp-constraints.md §7`). Practical takeaway:
 the >2 GB path is a **CPU/int4** enabler; DML-fp16 stays ≤~360-500 M
-(`smollm2-360m-dml-fp16`). Build DML models natively (`builder … -p fp16 -e dml`) —
-a cuda-fp16 re-host loads but fails DML inference.
+(`smollm2-360m-dml-fp16` — whose text output is anyway wrong on this device,
+#91: the model is kept only as the parity-gate probe). Build DML models
+natively (`builder … -p fp16 -e dml`) — a cuda-fp16 re-host loads but fails DML
+inference.
 
 **Future — BitNet / INT2 models**: Microsoft BitNet b1.58 (1-bit/1.58-bit quantization)
 could bring a 1.7B–3B model under 400 MB, fitting both the disk and GPU budgets.

--- a/docs/phase7-hypotheses.md
+++ b/docs/phase7-hypotheses.md
@@ -8,12 +8,12 @@ bandwidth or fused DML int4.
 
 ## Hardware bound (measured)
 
-| Resource | Series S (Dev Mode) | Implication |
-| --- | --- | --- |
-| Useful CPU cores | ~6 (t7/t8 livelock ggml) | Cap llama at t6 |
-| Effective decode BW | ~12.4–13 GB/s | M=1 GEMV ceiling |
-| GPU budget | 3801 MB Game | Prefill/diffusion; not small-model decode |
-| Peak RAM seen | ~2.7 GB GGUF | 3B Q3 class fits |
+| Resource            | Series S (Dev Mode)      | Implication                               |
+| ------------------- | ------------------------ | ----------------------------------------- |
+| Useful CPU cores    | ~6 (t7/t8 livelock ggml) | Cap llama at t6                           |
+| Effective decode BW | ~12.4–13 GB/s            | M=1 GEMV ceiling                          |
+| GPU budget          | 3801 MB Game             | Prefill/diffusion; not small-model decode |
+| Peak RAM seen       | ~2.7 GB GGUF             | 3B Q3 class fits                          |
 
 Naive BW bound (13 GB/s, one weight read/token): **3B Q4 ~8 tok/s**, **7B Q4 ~3–4
 tok/s**. Measured rows already saturate ≤1B (LFM 94, 0.8B 35, 1.7B 21). Peer
@@ -22,24 +22,24 @@ active parameters** (MoE / extreme quant) — not by violating physics.
 
 ## Goals (do not conflate)
 
-| ID | Goal | Operational target |
-| --- | --- | --- |
-| G1 | Capability | Chat quality ≈ casual 3B–7B peer |
-| G2 | Throughput | ≥12–15 tok/s interactive decode |
-| G3 | Prefill/RAG | Low TTFT at 1k+ tokens |
+| ID  | Goal        | Operational target               |
+| --- | ----------- | -------------------------------- |
+| G1  | Capability  | Chat quality ≈ casual 3B–7B peer |
+| G2  | Throughput  | ≥12–15 tok/s interactive decode  |
+| G3  | Prefill/RAG | Low TTFT at 1k+ tokens           |
 
 Series S product priority: **G1 ≥ G2** (smart 2–3B at 10–15 tok/s beats dumb
 350M at 94).
 
 ## Shipping baseline (SSOT excerpt)
 
-| Model | Decode | Peak | Role |
-| --- | --- | --- | --- |
-| LFM2.5-350M Q4 | **94.2** | 321 MB | default, G2 king |
-| Qwen3.5-0.8B Q4 | 35.1 | 718 MB | mid |
-| SmolLM2-1.7B int4 | 20.6 | 2423 MB | mid |
-| Llama-3.2-3B Q3 | **14.2** | 1824 MB | dense peer-class (catalogue advanced) |
-| Gemma-4-E2B Q3 | 15.3 | 2742 MB | best heavy quality so far |
+| Model             | Decode   | Peak    | Role                                  |
+| ----------------- | -------- | ------- | ------------------------------------- |
+| LFM2.5-350M Q4    | **94.2** | 321 MB  | default, G2 king                      |
+| Qwen3.5-0.8B Q4   | 35.1     | 718 MB  | mid                                   |
+| SmolLM2-1.7B int4 | 20.6     | 2423 MB | mid                                   |
+| Llama-3.2-3B Q3   | **14.2** | 1824 MB | dense peer-class (catalogue advanced) |
+| Gemma-4-E2B Q3    | 15.3     | 2742 MB | best heavy quality so far             |
 
 Closed negative: DML int4 decode, 1B fp16 DML inference, llama≫ORT BW, AppContainer mmap.
 
@@ -54,7 +54,7 @@ Closed negative: DML int4 decode, 1B fp16 DML inference, llama≫ORT BW, AppCont
 
 ### H2 — MoE with ~1–2B active params
 
-- **Claim:** Decode scales with *active* weights; MoE delivers peer quality at mid speed.
+- **Claim:** Decode scales with _active_ weights; MoE delivers peer quality at mid speed.
 - **PASS:** Peak &lt; 4 GB, decode ≥12, quality &gt; Qwen3.5-0.8B.
 - **FAIL:** Arch missing from UWP static lib / OOM / &lt;8 tok/s.
 - **Status:** Open — pin includes many `*moe*.cpp` + `lfm2moe` via `src/models/*.cpp` wildcard; needs small-enough GGUF candidate.
@@ -91,7 +91,9 @@ Closed negative: DML int4 decode, 1B fp16 DML inference, llama≫ORT BW, AppCont
 ### H8 — Series X GPU budget for 1B fp16 DML
 
 - **Claim:** Higher Game budget avoids 8007000E on 1B fp16 inference.
-- **Status:** Opportunistic if Series X available.
+- **Status:** Opportunistic if Series X available. **#91 gate applies**: even a
+  passing H8 yields wrong text logits until `validate-logit-parity.sh` passes
+  on that device (the DML attention fault may or may not affect Series X).
 
 ### H9 — Task suite (capability, not tok/s)
 
@@ -104,30 +106,30 @@ GPU decode@360M, llama 2× ORT BW, mmap load win, extdata→1B fp16 GPU, DML int
 
 ## Shortlist (desk, 2026-07-16)
 
-| Hypothesis | Candidate | Repo / file | Size | Why |
-| --- | --- | --- | --- | --- |
-| H4 | Llama-3.2-3B-Instruct Q3_K_S | `unsloth/Llama-3.2-3B-Instruct-GGUF` | 1.54 GB | **Measured preferred** — catalogue `llama32-3b` |
-| H4 | Llama-3.2-3B-Instruct Q4_K_M | same | 2.02 GB | Quality control if Q3 weak (not needed after Q3 PASS) |
-| H4 | Phi-3.5-mini Q3_K_S | `bartowski/Phi-3.5-mini-instruct-GGUF` | 1.68 GB | **Measured** — loses A/B; no catalogue |
-| H1 | Larger LFM / LFM2-MoE if &lt;3 GB | check LiquidAI / unsloth | TBD | Efficiency line |
-| H2 | Small MoE GGUF with arch in tree | e.g. OLMoE/Qwen-MoE tiny | TBD | Only if &lt;~3.5 GB Q3 |
+| Hypothesis | Candidate                         | Repo / file                            | Size    | Why                                                   |
+| ---------- | --------------------------------- | -------------------------------------- | ------- | ----------------------------------------------------- |
+| H4         | Llama-3.2-3B-Instruct Q3_K_S      | `unsloth/Llama-3.2-3B-Instruct-GGUF`   | 1.54 GB | **Measured preferred** — catalogue `llama32-3b`       |
+| H4         | Llama-3.2-3B-Instruct Q4_K_M      | same                                   | 2.02 GB | Quality control if Q3 weak (not needed after Q3 PASS) |
+| H4         | Phi-3.5-mini Q3_K_S               | `bartowski/Phi-3.5-mini-instruct-GGUF` | 1.68 GB | **Measured** — loses A/B; no catalogue                |
+| H1         | Larger LFM / LFM2-MoE if &lt;3 GB | check LiquidAI / unsloth               | TBD     | Efficiency line                                       |
+| H2         | Small MoE GGUF with arch in tree  | e.g. OLMoE/Qwen-MoE tiny               | TBD     | Only if &lt;~3.5 GB Q3                                |
 
 ## Console campaign results
 
 Source CSV: `bench/results/phase7-scale.csv` (Xbox Series S, t6, `standard-512.txt`,
 median of 3 runs with run-1 dropped).
 
-| Model | Quant | Decode | Prefill | Peak MB | Load ms | Verdict |
-| --- | --- | --- | --- | --- | --- | --- |
-| Llama-3.2-3B-Instruct (`llama32-3b-q3ks`) | Q3_K_S | **14.16** | 19.51 | **1824** | ~16900 | **H4 PASS · preferred** |
-| Phi-3.5-mini-instruct (`phi35-mini-q3ks`) | Q3_K_S | **11.31** | 15.29 | **2453** | ~24200 | **H4 PASS · loses A/B** |
+| Model                                     | Quant  | Decode    | Prefill | Peak MB  | Load ms | Verdict                 |
+| ----------------------------------------- | ------ | --------- | ------- | -------- | ------- | ----------------------- |
+| Llama-3.2-3B-Instruct (`llama32-3b-q3ks`) | Q3_K_S | **14.16** | 19.51   | **1824** | ~16900  | **H4 PASS · preferred** |
+| Phi-3.5-mini-instruct (`phi35-mini-q3ks`) | Q3_K_S | **11.31** | 15.29   | **2453** | ~24200  | **H4 PASS · loses A/B** |
 
 Notes:
 
 - Quant column was auto-mislabeled `Q4_K_M` by the bench harness (first-token
   heuristic); corrected to **Q3_K_S** (on-disk file name) for both rows.
 - Peak **1824 MB** (Llama) is ~900 MB under Gemma-4-E2B Q3 (2742 MB) at nearly
-  the same decode (14.2 vs 15.3) — dense 3B is *lighter* than E2B MatFormer at
+  the same decode (14.2 vs 15.3) — dense 3B is _lighter_ than E2B MatFormer at
   this quant. Phi-3.5-mini (~3.8B) peaks **2453 MB** — still under the 3.5 GB
   gate, but ~630 MB heavier than Llama at the same quant class.
 - Naive BW bound for 3B Q4 was ~8 tok/s; Q3_K_S at **14 tok/s** (Llama) /
@@ -141,12 +143,12 @@ Notes:
 
 ### H4 decision
 
-| Criterion | Llama-3.2-3B | Phi-3.5-mini |
-| --- | --- | --- |
-| Decode ≥ 8 tok/s | **14.16** ✅ | **11.31** ✅ |
-| Peak &lt; 3.5 GB | **1.82 GB** ✅ | **2.45 GB** ✅ |
-| Coherent generate (bench path) | ✅ | ✅ |
-| vs E2B (15.3 tok/s, 2742 MB) | Similar speed, **much less RAM** | Slower, still under E2B RAM |
+| Criterion                      | Llama-3.2-3B                     | Phi-3.5-mini                |
+| ------------------------------ | -------------------------------- | --------------------------- |
+| Decode ≥ 8 tok/s               | **14.16** ✅                     | **11.31** ✅                |
+| Peak &lt; 3.5 GB               | **1.82 GB** ✅                   | **2.45 GB** ✅              |
+| Coherent generate (bench path) | ✅                               | ✅                          |
+| vs E2B (15.3 tok/s, 2742 MB)   | Similar speed, **much less RAM** | Slower, still under E2B RAM |
 
 **H4: PASS.** Dense ~3B Q3 is viable on Series S. **Llama-3.2-3B is the preferred
 peer-class dense candidate** (faster + lighter). Phi-3.5-mini also clears H4
@@ -162,9 +164,9 @@ overturns that.
 
 ## Decision log
 
-| Date | Decision |
-| --- | --- |
-| 2026-07-16 | Open Phase 7 research; prioritize H4 then H1; H3/H6 eng only after H4 data |
-| 2026-07-16 | **H4 PASS** — Llama-3.2-3B Q3_K_S @14.2 tok/s, 1824 MB peak (`phase7-scale.csv`) |
-| 2026-07-16 | Catalogue **`llama32-3b`** (HF Q3_K_S) + `ChatFormatKind::Llama3`; default stays LFM |
+| Date       | Decision                                                                                                      |
+| ---------- | ------------------------------------------------------------------------------------------------------------- |
+| 2026-07-16 | Open Phase 7 research; prioritize H4 then H1; H3/H6 eng only after H4 data                                    |
+| 2026-07-16 | **H4 PASS** — Llama-3.2-3B Q3_K_S @14.2 tok/s, 1824 MB peak (`phase7-scale.csv`)                              |
+| 2026-07-16 | Catalogue **`llama32-3b`** (HF Q3_K_S) + `ChatFormatKind::Llama3`; default stays LFM                          |
 | 2026-07-16 | **Phi-3.5-mini Q3_K_S A/B** — 11.31 tok/s, 2453 MB; H4 PASS but loses to Llama on speed+RAM; **no catalogue** |

--- a/docs/recommended-config.md
+++ b/docs/recommended-config.md
@@ -25,24 +25,24 @@ Upstream: [microsoft/onnxruntime-genai#2280](https://github.com/microsoft/onnxru
 
 ## UWP build variants
 
-| Variant                      | CI artifact / command              | When to use                              |
-| ---------------------------- | ---------------------------------- | ---------------------------------------- |
-| **unified+#2280+PatchedOrt** (shipping) | `xllama-appx` from `build-uwp.yml` | GGUF + ORT, routing GPU, external-data ORT |
-| **llamacpp**                            | `xllama-appx-llamacpp`             | Bench A/B only — not for end users         |
+| Variant                                 | CI artifact / command              | When to use                                                      |
+| --------------------------------------- | ---------------------------------- | ---------------------------------------------------------------- |
+| **unified+#2280+PatchedOrt** (shipping) | `xllama-appx` from `build-uwp.yml` | GGUF + ORT, external-data ORT (GPU text routing suspended — #91) |
+| **llamacpp**                            | `xllama-appx-llamacpp`             | Bench A/B only — not for end users                               |
 
 ## Chat models
 
 The decode figures below are rough guidance; the authoritative, disambiguated
 tables are in [benchmarks.md](benchmarks.md) (the perf SSOT).
 
-| Use case              | Catalogue `name`        | Backend               | Measured decode                          |
-| --------------------- | ----------------------- | --------------------- | ---------------------------------------- |
-| **Default (unified)** | `lfm25-350m`            | llama.cpp (`unified`) | **94.2 tok/s** (recommended)             |
-| **ORT default**       | `smollm2-360m-cpu-int4` | ORT CPU int4          | ~66 tok/s                                |
-| **Routing GPU**       | `smollm2-360m-dml-fp16` | ORT DML fp16          | ~47 tok/s decode; ~354 tok/s prefill @1k |
-| **Larger chat**       | `smollm2-1.7b-cpu-int4` | ORT CPU int4          | ~21 tok/s (in-app `models-v1` download)  |
-| **Modern GGUF**       | `qwen35-0.8b`           | llama.cpp (`unified`) | 35.1 tok/s (98.1 prefill, t6)            |
-| **Fast modern GGUF**  | `lfm25-350m`            | llama.cpp (`unified`) | 94.2 tok/s (241.4 prefill, t6)           |
+| Use case                       | Catalogue `name`        | Backend               | Measured decode                                                                                                        |
+| ------------------------------ | ----------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **Default (unified)**          | `lfm25-350m`            | llama.cpp (`unified`) | **94.2 tok/s** (recommended)                                                                                           |
+| **ORT default**                | `smollm2-360m-cpu-int4` | ORT CPU int4          | ~66 tok/s                                                                                                              |
+| **Routing GPU** — disabled #91 | `smollm2-360m-dml-fp16` | ORT DML fp16          | ~47 tok/s decode; ~354 tok/s prefill @1k — **text logits wrong on DML (#91): not routable, not auto-downloaded (#95)** |
+| **Larger chat**                | `smollm2-1.7b-cpu-int4` | ORT CPU int4          | ~21 tok/s (in-app `models-v1` download)                                                                                |
+| **Modern GGUF**                | `qwen35-0.8b`           | llama.cpp (`unified`) | 35.1 tok/s (98.1 prefill, t6)                                                                                          |
+| **Fast modern GGUF**           | `lfm25-350m`            | llama.cpp (`unified`) | 94.2 tok/s (241.4 prefill, t6)                                                                                         |
 
 GGUF thread default: llama.cpp auto-detect is capped at **6** on console
 (`detect_threads_llama` — t6 measured optimum, t7/t8 livelock); explicit
@@ -85,21 +85,23 @@ Models must be **self-contained** `model.onnx` (< 2 GB merged) — run
 
 Copy [`bench/configs/settings-modern.json`](../bench/configs/settings-modern.json) via Device Portal, or use the UI.
 
-| Key                    | Recommended                       | Notes                                            |
-| ---------------------- | --------------------------------- | ------------------------------------------------ |
-| `model`                | `lfm25-350m`                      | First-launch default on **unified** shipping     |
-| `kv_reuse`             | `true`                            | 4.87× ORT / 4.07× GGUF turn-2 prefill (measured) |
-| `routing`              | `2` (Auto) on unified             | needs DML fp16 model + PatchedGenAI; GGUF skips  |
-| `gpu_model`            | `smollm2-360m-dml-fp16`           | Catalogue download (`models-v1`, ~691 MB) or WDP |
-| `diffuse_taesd_vae`    | `true` after asset on `models-v1` | ~4.5 s/image target                              |
-| `sampling.temperature` | `0.8`                             | UI default                                       |
-| `sampling.n_predict`   | `512`                             | UI default                                       |
+| Key                    | Recommended                       | Notes                                                                             |
+| ---------------------- | --------------------------------- | --------------------------------------------------------------------------------- |
+| `model`                | `lfm25-350m`                      | First-launch default on **unified** shipping                                      |
+| `kv_reuse`             | `true`                            | 4.87× ORT / 4.07× GGUF turn-2 prefill (measured)                                  |
+| `routing`              | `2` (Auto) on unified             | inert for text while #91 holds (always CPU); GGUF skips                           |
+| `gpu_model`            | `smollm2-360m-dml-fp16`           | NOT auto-downloaded while #91 holds (#95); 725 MB, WDP/`provision-models.sh` only |
+| `diffuse_taesd_vae`    | `true` after asset on `models-v1` | ~4.5 s/image target                                                               |
+| `sampling.temperature` | `0.8`                             | UI default                                                                        |
+| `sampling.n_predict`   | `512`                             | UI default                                                                        |
 
 Factory defaults match [`settings-modern.json`](../bench/configs/settings-modern.json)
 on unified builds (`DefaultChatModelId()` → `lfm25-350m`). ORT-only builds still
 default to `smollm2-360m-cpu-int4`.
 
-Routing Auto uses **600 tokens** (real tokenizer count), sticky per conversation.
+Routing Auto uses **600 tokens** (real tokenizer count), sticky per conversation
+— but the #91 gate (`kDmlTextLogitsBroken`) precedes the threshold: while it
+holds, every text turn resolves to the CPU model regardless of length.
 
 ## Image generation
 
@@ -142,9 +144,11 @@ ctest --test-dir build/linux-test --output-on-failure
 ## Validation checklist
 
 1. Deploy the default **`xllama-appx`** CI artifact (unified + PatchedGenAI #2280; version is `Major.Minor.Build` from `uwp/AppxManifest.xml` with the **Revision** auto-stamped from the CI run number — see `CHANGELOG.md`)
-2. Ensure models are provisioned (`smollm2-360m-dml-fp16` for routing — catalogue or WDP;
-   `sd-turbo-fp16` + TAESD asset for §7c). MSIX **uninstall** wipes LocalState.
-3. Remove `bench.flag` from LocalState if `install-latest-build.sh` left it behind
+2. Provision models AFTER the install — `install-latest-build.sh` always
+   uninstalls first, wiping LocalState: `./scripts/provision-models.sh --all-test`
+   (seeds `lfm25-350m`, `smollm2-360m-cpu-int4` for routing/parity, `sd-turbo-fp16`;
+   the gated `dml-fp16` is intentionally excluded — #91/#95).
+3. Remove `bench.flag` from LocalState if `install-latest-build.sh --bench` left it behind
 4. Run the automated gate:
 
    ```bash

--- a/docs/technical-report.md
+++ b/docs/technical-report.md
@@ -51,15 +51,18 @@ Three hypotheses died against these numbers:
    (1.8× at ~1k tokens). The app therefore routes per-workload (long-prompt
    conversations → DML fp16, decode → CPU int4), sticky per conversation.
    **Superseded by #91 (2026-07-16): DML text routing is disabled.** The logit-
-   parity harness showed the DML GQA decoder computes numerically wrong logits
-   on the Series S GPU (NMSE ~1 vs the CPU reference, top-1 disagrees; fp16 AND
-   int4; invariant to graph/session/capture options; the same weights are
-   correct on CPU EP and on desktop-class CPU runs; SD-Turbo — no GQA — is
-   correct on the same device). All tok/s numbers above are real, but the GPU
-   text output they measured was silently degraded. Text routing is forced to
-   CPU (`routing_policy.h kDmlTextLogitsBroken`) until
-   `scripts/validate-logit-parity.sh` passes on a DML text model. Diffusion
-   routing is unaffected.
+   parity harness showed the DML attention path computes numerically wrong
+   logits on the Series S GPU — GQA **and** MultiHeadAttention alike (NMSE ~1
+   vs the CPU reference, top-1 disagrees; fp16 AND int4; invariant to
+   graph/session/capture options; the same weights are correct on CPU EP and
+   on desktop-class CPU runs; SD-Turbo — decomposed attention, no contrib ops —
+   is correct on the same device). All tok/s numbers above are real, but the
+   GPU text output they measured was silently degraded. Text routing is forced
+   to CPU (`routing_policy.h kDmlTextLogitsBroken`) until
+   `scripts/validate-logit-parity.sh` passes on a DML text model, and the
+   GPU model is no longer auto-provisioned (#95). Diffusion routing is
+   unaffected. Upstream: microsoft/onnxruntime#29739 (driver),
+   microsoft/onnxruntime-genai#2300 (capture opt-out tooling).
 2. **"DML int4 decode collapses because a kernel is missing."** Falsified by
    desk-check and confirmed on hardware: `MatMulNBits` _is_ on the GPU (compute
    engines 87–90 % busy at 8.8 tok/s) but DirectML implements it **non-fused**
@@ -129,7 +132,8 @@ hardware, because console runtime errors are expensive to attribute:
 
 ## 5. What ships in v1.0.0
 
-- Chat UI (ChatML, history, settings) with per-conversation CPU/GPU routing and
+- Chat UI (ChatML, history, settings) with per-conversation CPU/GPU routing
+  (GPU-text routing since disabled — #91) and
   KV-cache reuse; models described by a `manifest.json` catalogue (bundled +
   Device-Portal-overridable) with in-app download from the `models-v1` GitHub
   Release (the upstream HF path shipped a non-merged model and was retired).

--- a/docs/using-the-app.md
+++ b/docs/using-the-app.md
@@ -38,11 +38,15 @@ Generation shows live tok/s; **■ Cancel** stops a running reply.
 - **KV-cache reuse** (default on) — reuses the conversation's KV cache across
   turns; measured **4.87×** faster turn-2 prefill on console. Leave it on
   unless debugging.
-- **EP routing (per conversation)** — where inference runs:
+- **EP routing (per conversation)** — where inference runs.
+  **Superseded by #91**: while `kDmlTextLogitsBroken` holds (the DML EP
+  computes wrong text logits on the Series S driver), every mode resolves to
+  the CPU model, the `gpu_model` is not auto-downloaded (#95), and a missing
+  `gpu_model` never blocks a turn (#100). Diffusion (plain ORT) stays on GPU.
+  The pre-#91 semantics, which return verbatim when the gate lifts:
   - **CPU only (default)** — best decode throughput at 360M scale (~66 tok/s).
   - **GPU only (DML)** — forces DirectML (needs the `gpu_model`, e.g.
-    `smollm2-360m-dml-fp16`, in LocalState — catalogue download from
-    `models-v1` or WDP upload).
+    `smollm2-360m-dml-fp16`, in LocalState).
   - **Auto (long prompts → GPU)** — long first prompts route to GPU fp16
     (prefill is 1.8× faster at ~1k tokens), short chats stay on CPU; the
     choice is sticky per conversation.

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -98,7 +98,10 @@ Readings:
 DirectML kernel-_design_ limit (non-fused low-bit GEMM), not a hardware limit and
 not fixable by our quantization config — see §12 for the full analysis and the
 config tests that confirm it. Effective bandwidth: CPU ~13 GB/s, GPU fp16
-~34 GB/s, against a ~224 GB/s theoretical bus.
+~34 GB/s, against a ~224 GB/s theoretical bus. **#91 caveat**: independent of
+these throughput numbers, DML **text** output is numerically wrong on this
+device (attention path, GQA and MHA) — text is CPU-forced in every mode until
+the parity gate passes; the GPU-prefill win is currently moot for text.
 
 **Effect on disk**: models too large to fit the Dev Mode partition also fail before reaching `OgaCreateModel`. This is a distinct failure mode — see §9.
 
@@ -146,7 +149,7 @@ When `OgaCreateModel` initialises the DirectML execution provider, the DML alloc
 
 The fault manifests before any inference call — at model load time. There is no recovery path short of using a smaller model or switching to CPU EP.
 
-**The binding limit is the inference working set, not just the weights (measured 2026-07-15).** A native-DML Llama-3.2-1B fp16 (2.49 GB weights, GQA) **loads** fine — `gpu-mem post-load: 2878/3801 MB` — but every inference call then OOMs: `AppendTokenSequences … DmlCommittedResourceAllocator … 8007000E Not enough memory`, even at `context_length=2048`. The DML inference working set (graph-capture command allocators + prefill activations + the `past_present_share_buffer` KV buffer) needs more than the ~900 MB left after weights. So the usable DML-fp16 ceiling on Series S is set by **weights + working set ≤ 3801 MB**, which in practice caps fp16 at ~360-500 M (e.g. `smollm2-360m-dml-fp16`, ~700 MB weights). Any fp16 model large enough to require the >2 GB external-data path (§8) is ≥~1 B → over this wall.
+**The binding limit is the inference working set, not just the weights (measured 2026-07-15).** A native-DML Llama-3.2-1B fp16 (2.49 GB weights, GQA) **loads** fine — `gpu-mem post-load: 2878/3801 MB` — but every inference call then OOMs: `AppendTokenSequences … DmlCommittedResourceAllocator … 8007000E Not enough memory`, even at `context_length=2048`. The DML inference working set (graph-capture command allocators + prefill activations + the `past_present_share_buffer` KV buffer) needs more than the ~900 MB left after weights. So the usable DML-fp16 ceiling on Series S is set by **weights + working set ≤ 3801 MB**, which in practice caps fp16 at ~360-500 M (e.g. `smollm2-360m-dml-fp16`, ~725 MB weights). Any fp16 model large enough to require the >2 GB external-data path (§8) is ≥~1 B → over this wall. (For **text** models this ceiling is currently academic — DML text logits are wrong on this device, #91; it still governs the memory analysis and diffusion.)
 
 **Distinct failure mode — DML EP init `887A0036` in XAML apps** (2026-07-07,
 GPU-truth run, ORT GenAI 0.13.2 / ORT 1.24.4 / DirectML 1.15.4) — **root cause
@@ -334,7 +337,8 @@ and GPU-executed; the limit is that DirectML's kernel is **non-fused**.
 **Consequence for xllama**: int4-on-DML has **no path to beat fp16-on-DML** for
 decode by any quantization config we control, and fp16-on-DML (46.8) still loses
 to CPU int4 (68). So **CPU int4 stays the decode default**, and the GPU's real
-win is prefill (§5, reading 1) and larger-model bandwidth. A genuinely fused
+win is prefill (§5, reading 1 — moot for text while #91 holds: DML text logits
+are wrong on this device) and larger-model bandwidth. A genuinely fused
 low-bit GPU GEMM would be a DirectML-team feature, not an ORT-side PR; treat GPU
 int4 decode as blocked upstream, not a local TODO.
 

--- a/docs/vendor-lifecycle-plan.md
+++ b/docs/vendor-lifecycle-plan.md
@@ -9,14 +9,14 @@ riscrittura di scienza già closed-negative).
 
 ## 0. Cosa è già chiuso
 
-| Item | Evidenza |
-| --- | --- |
-| PatchedOrt in shipping MSIX | 1.1.8.0 + `vendor-dlls-v1` + `SHA256SUMS` |
-| PatchedGenAI hash-pin (no rebuild per PR) | `build-uwp.yml` + GenAI `SHA256SUMS` |
-| #2280 upstream merged | microsoft/onnxruntime-genai#2280 (2026-07-13) |
-| weakly_canonical su ORT `main` | microsoft/onnxruntime#28509 (non in NuGet 1.24.4) |
-| Docs drift D1–D8 | currency pass in `project-analysis-2026-07.md` |
-| Issue tracker SSOT | xllama #84, #85, #86; ORT #29730 |
+| Item                                      | Evidenza                                                                                     |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------- |
+| PatchedOrt in shipping MSIX               | 1.1.8.0 + `vendor-dlls-v1` + `SHA256SUMS`                                                    |
+| PatchedGenAI hash-pin (no rebuild per PR) | `build-uwp.yml` + GenAI `SHA256SUMS`                                                         |
+| #2280 upstream merged                     | microsoft/onnxruntime-genai#2280 (2026-07-13, commit `ff53d6b9` on main — gap is NuGet-only) |
+| weakly_canonical su ORT `main`            | microsoft/onnxruntime#28509 (non in NuGet 1.24.4)                                            |
+| Docs drift D1–D8                          | currency pass in `project-analysis-2026-07.md`                                               |
+| Issue tracker SSOT                        | xllama #84, #85, #86; ORT #29730                                                             |
 
 ---
 
@@ -42,14 +42,15 @@ flowchart LR
   B2 --> DropOrt
 ```
 
-| ID | Obiettivo | Issue | Priorità | Effort | Dipendenze |
-| --- | --- | --- | --- | --- | --- |
-| **R1** | Demo video (clip 60–90 s) | ROADMAP Phase 6 | **P1** content | S–M | Field smoke 1.1.8 PASS; **solo capture umano** |
-| **R2** | Drop `-PatchedGenAI` | [#84](https://github.com/gianlucamazza/xllama/issues/84) | **blocked** NuGet | S | Poll: `scripts/check-vendor-nuget-status.sh` (latest still 0.14.1) |
-| **R3** | Upstream ReadFile 16 MB | [#86](https://github.com/gianlucamazza/xllama/issues/86) | **PR open** | M | [ORT #29732](https://github.com/microsoft/onnxruntime/pull/29732) + [#29730](https://github.com/microsoft/onnxruntime/issues/29730) |
-| **R4** | Drop `-PatchedOrt` | [#85](https://github.com/gianlucamazza/xllama/issues/85) | **blocked** NuGet | S | Attende merge #29732 + NuGet con #28509 |
-| **R5** | Catalogue entry >2 GB int4 extdata | ROADMAP optional | **deferred** | M | HF flaky; Meta license — non mirrorare su models-v1; USB/LocalState già valida PatchedOrt |
-| **R6** | Vendor pin refresh ops | #85 | **done tooling** | S | Dual pin + `check-vendor-nuget-status.sh` + fail-closed GenAI install |
+| ID     | Obiettivo                          | Issue                                                    | Priorità          | Effort | Dipendenze                                                                                                                                                                                                                                                         |
+| ------ | ---------------------------------- | -------------------------------------------------------- | ----------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **R1** | Demo video (clip 60–90 s)          | ROADMAP Phase 6                                          | **P1** content    | S–M    | Field smoke 1.1.8 PASS; **solo capture umano**                                                                                                                                                                                                                     |
+| **R2** | Drop `-PatchedGenAI`               | [#84](https://github.com/gianlucamazza/xllama/issues/84) | **blocked** NuGet | S      | Poll: `scripts/check-vendor-nuget-status.sh` (latest still 0.14.1)                                                                                                                                                                                                 |
+| **R3** | Upstream ReadFile 16 MB            | [#86](https://github.com/gianlucamazza/xllama/issues/86) | **PR open**       | M      | [ORT #29732](https://github.com/microsoft/onnxruntime/pull/29732) + [#29730](https://github.com/microsoft/onnxruntime/issues/29730)                                                                                                                                |
+| **R4** | Drop `-PatchedOrt`                 | [#85](https://github.com/gianlucamazza/xllama/issues/85) | **blocked** NuGet | S      | Attende merge #29732 + NuGet con #28509                                                                                                                                                                                                                            |
+| **R5** | Catalogue entry >2 GB int4 extdata | ROADMAP optional                                         | **deferred**      | M      | HF flaky; Meta license — non mirrorare su models-v1; USB/LocalState già valida PatchedOrt                                                                                                                                                                          |
+| **R6** | Vendor pin refresh ops             | #85                                                      | **done tooling**  | S      | Dual pin + `check-vendor-nuget-status.sh` + fail-closed GenAI install                                                                                                                                                                                              |
+| **R7** | DML graph-capture opt-out upstream | [#91](https://github.com/gianlucamazza/xllama/issues/91) | **PR open**       | S      | [GenAI #2300](https://github.com/microsoft/onnxruntime-genai/pull/2300) (opt-out + KV clamp, on-device proven); tooling prerequisite for re-enabling DML text once the driver fault ([ORT #29739](https://github.com/microsoft/onnxruntime/issues/29739)) is fixed |
 
 ---
 
@@ -57,54 +58,54 @@ flowchart LR
 
 ### Fase A — Product close (questa settimana / prossima)
 
-1. **Demo video (R1)**  
-   - Deploy [v1.1.8.0](https://github.com/gianlucamazza/xllama/releases/tag/v1.1.8.0) o ultimo `xllama-appx`.  
-   - Checklist ROADMAP: first-launch LFM → chat short/long → Image Generate → capture.  
+1. **Demo video (R1)**
+   - Deploy [v1.1.8.0](https://github.com/gianlucamazza/xllama/releases/tag/v1.1.8.0) o ultimo `xllama-appx`.
+   - Checklist ROADMAP: first-launch LFM → chat short/long → Image Generate → capture.
    - Chiudere bullet ROADMAP + nota in Discussion #76 se utile.
 
 ### Fase B — Watch & drop GenAI (event-driven)
 
-2. **Monitor NuGet GenAI (R2)**  
+2. **Monitor NuGet GenAI (R2)**
    - Trigger: nuova versione `Microsoft.ML.OnnxRuntimeGenAI.DirectML` con #2280  
-     (verificare `CreateDmlObjects` / `agility_device_created` nel tree del tag).  
-   - Eseguire checklist issue #84 (bump packages.config → rimuovere pin CI → smoke XAML+DML).  
+     (verificare `CreateDmlObjects` / `agility_device_created` nel tree del tag).
+   - Eseguire checklist issue #84 (bump packages.config → rimuovere pin CI → smoke XAML+DML).
    - Chiudere #84; aggiornare #85.
 
 ### Fase C — ORT path (parallelo, non bloccante)
 
-3. **PR ORT #29732 (R3) — APERTA 2026-07-16**  
-   - https://github.com/microsoft/onnxruntime/pull/29732  
-   - Prossimo: review MS → merge → attendere NuGet → drop PatchedOrt (#85).  
-   - Se rifiutano: tenere pin; rivalutare solo al bump ORT.  
+3. **PR ORT #29732 (R3) — APERTA 2026-07-16**
+   - https://github.com/microsoft/onnxruntime/pull/29732
+   - Prossimo: review MS → merge → attendere NuGet → drop PatchedOrt (#85).
+   - Se rifiutano: tenere pin; rivalutare solo al bump ORT.
    - **Non** reimplementare weakly_canonical (già #28509 su main).
 
-4. **Drop PatchedOrt (R4)** solo dopo NuGet che include:  
-   - path AppContainer (#28509 o equivalente), **e**  
-   - chunk ReadFile (nostra o loro).  
+4. **Drop PatchedOrt (R4)** solo dopo NuGet che include:
+   - path AppContainer (#28509 o equivalente), **e**
+   - chunk ReadFile (nostra o loro).
    - Checklist simmetrica a #84; chiudere #85 quando entrambi i pin sono spariti.
 
 ### Fase D — Opzionale product surface
 
-5. **Catalogue >2 GB extdata int4 (R5)**  
-   - Solo se si vuole rendere PatchedOrt **visibile** in picker senza USB.  
-   - Asset + `manifest.json` + smoke download/load.  
+5. **Catalogue >2 GB extdata int4 (R5)**
+   - Solo se si vuole rendere PatchedOrt **visibile** in picker senza USB.
+   - Asset + `manifest.json` + smoke download/load.
    - Non prioritario se non c’è un modello “vetrina”.
 
 ### Fase E — Manutenzione pin (continua)
 
-6. **Refresh pin (R6)**  
-   - GenAI: `gh workflow run build-uwp-patched.yml` → re-validate → upload `vendor-dlls-v1` → bump `SHA256SUMS`.  
-   - ORT: `build-uwp-ort-patched.yml` (1–3 h) → stesso flusso.  
+6. **Refresh pin (R6)**
+   - GenAI: `gh workflow run build-uwp-patched.yml` → re-validate → upload `vendor-dlls-v1` → bump `SHA256SUMS`.
+   - ORT: `build-uwp-ort-patched.yml` (1–3 h) → stesso flusso.
    - **Mai** cambiare hash senza console re-validate.
 
 ---
 
 ## 3. Criteri di “done” per i pin
 
-| Pin | Done quando | Verifica console |
-| --- | --- | --- |
-| GenAI | NuGet stock passa XAML + DML `OgaCreateModel` senza `887A0036` | Routing GPU load + short decode |
-| ORT | NuGet stock carica model con `.onnx.data` >~1.5 GB senza weakly_canonical crash e senza errcode 1450 | 2–3 restart load+generate |
+| Pin   | Done quando                                                                                          | Verifica console                |
+| ----- | ---------------------------------------------------------------------------------------------------- | ------------------------------- |
+| GenAI | NuGet stock passa XAML + DML `OgaCreateModel` senza `887A0036`                                       | Routing GPU load + short decode |
+| ORT   | NuGet stock carica model con `.onnx.data` >~1.5 GB senza weakly_canonical crash e senza errcode 1450 | 2–3 restart load+generate       |
 
 ---
 
@@ -132,9 +133,9 @@ Già closed-negative con evidenza — non investire:
 
 ## 6. Riferimenti
 
-- ROADMAP Phase 6 open bullets  
-- `vendor/onnxruntime-genai-patched/`, `vendor/onnxruntime-patched/`  
-- `patches/README.md`  
-- `docs/uwp-constraints.md` §7–§8  
-- Issues: [#84](https://github.com/gianlucamazza/xllama/issues/84), [#85](https://github.com/gianlucamazza/xllama/issues/85), [#86](https://github.com/gianlucamazza/xllama/issues/86)  
+- ROADMAP Phase 6 open bullets
+- `vendor/onnxruntime-genai-patched/`, `vendor/onnxruntime-patched/`
+- `patches/README.md`
+- `docs/uwp-constraints.md` §7–§8
+- Issues: [#84](https://github.com/gianlucamazza/xllama/issues/84), [#85](https://github.com/gianlucamazza/xllama/issues/85), [#86](https://github.com/gianlucamazza/xllama/issues/86)
 - Upstream: [GenAI #2280](https://github.com/microsoft/onnxruntime-genai/pull/2280), [ORT #28509](https://github.com/microsoft/onnxruntime/pull/28509), [ORT #29730](https://github.com/microsoft/onnxruntime/issues/29730)

--- a/include/xllama/routing_policy.h
+++ b/include/xllama/routing_policy.h
@@ -28,13 +28,15 @@ struct RoutingDecision {
 };
 
 // DML text inference computes numerically wrong logits on the Series S
-// Dev-Mode GPU (issue #91): GQA decoder graphs produce deterministic garbage
-// (parity NMSE ~1 vs the CPU reference, top-1 disagrees), invariant to every
-// graph/session/capture knob, at fp16 AND int4, while the same weights are
-// correct on CPU EP and SD-Turbo (no GQA) is correct on the same device. Until
-// the parity gate (scripts/validate-logit-parity.sh) passes on a DML text
-// model, GPU routing for text is forced off — Auto and GpuOnly both resolve to
-// the CPU model. Diffusion (plain ORT, validated correct) is unaffected.
+// Dev-Mode GPU (issue #91): the attention path — GQA and MultiHeadAttention
+// alike (#94 probe) — produces deterministic garbage (parity NMSE ~1 vs the
+// CPU reference, top-1 disagrees), invariant to every graph/session/capture
+// knob, at fp16 AND int4, while the same weights are correct on CPU EP and
+// SD-Turbo (decomposed attention, no contrib ops) is correct on the same
+// device. Until the parity gate (scripts/validate-logit-parity.sh) passes on a
+// DML text model, GPU routing for text is forced off — Auto and GpuOnly both
+// resolve to the CPU model. Diffusion (plain ORT, validated correct) is
+// unaffected.
 inline constexpr bool kDmlTextLogitsBroken = true;
 
 // Decide which model directory to load for the first turn of a conversation.

--- a/scripts/validate-console.sh
+++ b/scripts/validate-console.sh
@@ -243,8 +243,9 @@ JSON
 	# C++ is "→"; match on the tok field to be encoding-robust).
 	#
 	# #91 gate: kDmlTextLogitsBroken (routing_policy.h) forces text routing to
-	# CPU in every mode — DML GQA logits are numerically wrong on the Series S
-	# GPU (parity NMSE ~1). Until the parity harness passes on a DML text model,
+	# CPU in every mode — DML attention logits (GQA and MHA alike, #94) are
+	# numerically wrong on the Series S GPU (parity NMSE ~1). Until the parity
+	# harness passes on a DML text model,
 	# the CORRECT behavior is: long turn stays CPU and NO gpu routing line ever
 	# appears. When the gate is lifted, restore the pre-#91 auto→gpu assertions.
 	local gpu_line cpu_line

--- a/tests/test_routing_policy.cpp
+++ b/tests/test_routing_policy.cpp
@@ -17,9 +17,10 @@ TEST_CASE("routing: cpu-only") {
     CHECK_FALSE(d.use_gpu);
 }
 
-// While kDmlTextLogitsBroken holds (#91: DML GQA logits are garbage on the
-// Series S GPU), every mode resolves to the CPU model. The pre-#91 GPU
-// expectations are kept below, guarded, so re-enabling is a one-flag flip.
+// While kDmlTextLogitsBroken holds (#91: DML attention logits — GQA and MHA
+// alike — are garbage on the Series S GPU), every mode resolves to the CPU
+// model. The pre-#91 GPU expectations are kept below, guarded, so re-enabling
+// is a one-flag flip.
 TEST_CASE("routing: #91 gate forces cpu in every mode") {
     RoutingSettings s;
     s.cpu_model = "cpu";


### PR DESCRIPTION
## Summary
Team-audited consolidation pass: 3 parallel doc auditors (runbooks/guides, technical report/reference, CHANGELOG/vendor) + 1 adversarial verifier that checked every introduced claim against primary sources (code, scripts, manifest, gh). **Zero refuted claims.**

Highlights:
- **console-validation-runbook §2** now documents the inverted gate semantics (PASS = no `auto → gpu`, CPU turn runs, no 887A0036), cpu-int4 prereq, the always-uninstall install flow, and keeps the pre-#91 A/B as historical.
- **benchmarks.md + uwp-constraints.md** (the two perf/constraint SSOTs) previously had **no #91 reference at all** — DML rows are kept as raw throughput with the "text output numerically wrong" caveat.
- **CHANGELOG [Unreleased]**: +#98/#100 fixes, +#99 docs runbook, +genai#2300 upstream entry, +v1.2.0.534 full-suite PASS.
- **725 MB** unified everywhere (old "~691 MB" was MiB mislabeled; ~700 MB rounded); `docs/README.md` index gains `api-endpoint.md`.
- Source comments (`routing_policy.h`, `validate-console.sh`, `test_routing_policy.cpp`) widened from "GQA" to the #94 verdict (attention path, GQA and MHA alike) — comment-only.
- Issues updated alongside (not in this diff): #91 status roll-up, #84/#85 notes.

## How verified
- `linux-test` build + ctest PASS; shellcheck PASS; anchors and internal links resolved by the verifier (including the CONTRIBUTING → model-selection slug).
- Verifier confirmed against source: gate ordering in `decide_routing`, `EnsureGpuModelIfNeeded` early-return, `warn_gpu_missing` bypass, `ALL_TEST` set, unconditional uninstall in `install-latest-build.sh`, `--bench`-only flag upload, manifest display string, parity calibration numbers (NMSE 0.094 / top-10 0.90), 959 tok decoy, TAESD range, issue/PR/commit numbers (#2280 `ff53d6b9`, #2300 head branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that DirectML text generation may produce incorrect results, so text routing remains on CPU until parity validation passes.
  - Documented that diffusion workloads remain GPU-accelerated.
  - Updated model catalogs, benchmarks, configuration guidance, validation procedures, and troubleshooting notes.
  - Added guidance for the opt-in LAN-compatible API endpoint and model asset publishing.
- **Chores**
  - Refined release status, validation results, vendor lifecycle notes, and formatting across project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->