### PR TITLE
docs: address CodeRabbit nits from #101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Docs accuracy pass (CodeRabbit on #101)** — §2 runbook claims Auto-only
+  coverage (matches `validate-console.sh routing`); H8 requires explicit
+  `MODEL=`/`golden` for DML parity (not the cpu-int4 default); `using-the-app`
+  documents `gpu_available` fallback after the gate lifts; validation date in
+  `recommended-config` set to 2026-07-16 / `1.2.0.534`; `#91` escaped in
+  model-selection; H2 “mid-speed” hyphen.
 - **DML text routing disabled (#91)** — the logit-parity harness caught the DML
   GQA decoder computing numerically wrong logits on the Series S GPU (NMSE ~1
   vs the CPU reference at fp16 AND int4; invariant to `ORT_DISABLE_ALL`,

--- a/docs/console-validation-runbook.md
+++ b/docs/console-validation-runbook.md
@@ -64,11 +64,12 @@ confirm multi-turn **coherence** (read the log's decoded turn-2 output) before t
 
 ## 2. PR #2 — CPU/GPU routing (Stage 3) — ✅ GATE HOLDS 2026-07-16 (`validate-console.sh routing`)
 
-**Validates (since #91)**: the `kDmlTextLogitsBroken` gate holds — every text
-turn stays on the CPU model in every routing mode, and no turn is blocked or
-degraded by it. The pre-#91 semantics (auto picks DML fp16 for long prompts)
-return, and this section flips back to an A/B, when the gate is lifted
-(`validate-logit-parity.sh` PASS on a DML text model).
+**Validates (since #91)**: the `kDmlTextLogitsBroken` gate holds — under the
+official automated check (Auto routing only; see below), a long text turn stays
+on the CPU model, and no turn is blocked or degraded by the gate. The pre-#91
+semantics (auto picks DML fp16 for long prompts) return, and this section flips
+back to an A/B, when the gate is lifted (`validate-logit-parity.sh` PASS on a
+DML text model).
 
 > **Automated gate (official).** Dev Mode gives the console no working text-input
 > path, so this check is driven by the in-app **autopilot** (build ≥ 1.1.3.0):
@@ -78,12 +79,14 @@ return, and this section flips back to an A/B, when the gate is lifted
 > ./scripts/validate-console.sh routing   # PASS/FAIL from the log, exit code
 > ```
 >
-> It seeds a >600-token decoy conversation, replays load_chat → send → new_chat →
-> send via `autopilot.flag`/`autopilot.json`, and greps `xllama.log` for the
-> **absence** of `auto → gpu` (the gate must hold), the **presence** of
-> `auto → cpu` (the turn must still run, #100), and the absence of `887A0036`.
-> **A PASS here is the official §2 gate** (same `StartInference` in the live
-> XAML process as a human run). The manual steps below remain for debugging.
+> It seeds settings with **`"routing": 2` (Auto only)** — CpuOnly and GpuOnly are
+> not exercised by this script — then seeds a >600-token decoy conversation,
+> replays load_chat → send → new_chat → send via `autopilot.flag`/`autopilot.json`,
+> and greps `xllama.log` for the **absence** of `auto → gpu` (the gate must hold),
+> the **presence** of `auto → cpu` (the turn must still run, #100), and the
+> absence of `887A0036`. **A PASS here is the official §2 gate for Auto routing**
+> (same `StartInference` in the live XAML process as a human run). The manual
+> steps below remain for debugging CpuOnly/GpuOnly or for when the gate lifts.
 
 **Measured (2026-07-16, unified 1.2.0.534):** long turn (**959 tok**) routed to
 CPU, no `auto → gpu` line, no `887A0036` — gate holds. Full suite PASS (parity,
@@ -96,7 +99,8 @@ shown numerically wrong — see #91.)_
 1. A **unified + PatchedGenAI #2280** MSIX — the default `xllama-appx` CI artifact
    (`build-uwp.yml`); vanilla NuGet `onnxruntime-genai.dll` hits `887A0036` in XAML.
    (Under the #91 gate this matters for diffusion and for the future re-enable,
-   not for the text path — which is CPU in every mode.)
+   not for the text path — which the policy forces to CPU in every mode; the
+   automated §2 script only proves Auto.)
 2. `smollm2-360m-cpu-int4` in `LocalState\models\` — seed it with
    `./scripts/provision-models.sh smollm2-360m-cpu-int4` (or `--all-test`).
    The `smollm2-360m-dml-fp16` model is **not** required nor auto-downloaded

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -114,7 +114,7 @@ fp16 models viable on the GPU**: a native-DML 1B fp16 (2.49 GB) loads yet OOMs
 inference within the 3801 MB budget (`uwp-constraints.md §7`). Practical takeaway:
 the >2 GB path is a **CPU/int4** enabler; DML-fp16 stays ≤~360-500 M
 (`smollm2-360m-dml-fp16` — whose text output is anyway wrong on this device,
-#91: the model is kept only as the parity-gate probe). Build DML models
+`#91`: the model is kept only as the parity-gate probe). Build DML models
 natively (`builder … -p fp16 -e dml`) — a cuda-fp16 re-host loads but fails DML
 inference.
 

--- a/docs/phase7-hypotheses.md
+++ b/docs/phase7-hypotheses.md
@@ -54,7 +54,7 @@ Closed negative: DML int4 decode, 1B fp16 DML inference, llama≫ORT BW, AppCont
 
 ### H2 — MoE with ~1–2B active params
 
-- **Claim:** Decode scales with _active_ weights; MoE delivers peer quality at mid speed.
+- **Claim:** Decode scales with _active_ weights; MoE delivers peer quality at mid-speed.
 - **PASS:** Peak &lt; 4 GB, decode ≥12, quality &gt; Qwen3.5-0.8B.
 - **FAIL:** Arch missing from UWP static lib / OOM / &lt;8 tok/s.
 - **Status:** Open — pin includes many `*moe*.cpp` + `lfm2moe` via `src/models/*.cpp` wildcard; needs small-enough GGUF candidate.
@@ -92,8 +92,12 @@ Closed negative: DML int4 decode, 1B fp16 DML inference, llama≫ORT BW, AppCont
 
 - **Claim:** Higher Game budget avoids 8007000E on 1B fp16 inference.
 - **Status:** Opportunistic if Series X available. **#91 gate applies**: even a
-  passing H8 yields wrong text logits until `validate-logit-parity.sh` passes
-  on that device (the DML attention fault may or may not affect Series X).
+  passing H8 yields wrong text logits until logit parity is proven on **that**
+  DML asset — do **not** run bare `validate-logit-parity.sh` (default
+  `MODEL=smollm2-360m-cpu-int4` is a CPU path). Use an explicit pair, e.g.
+  `MODEL=<native-DML-1B-fp16-catalogue-name> ./scripts/validate-logit-parity.sh <matching-golden.bin>`
+  (or `MODEL=smollm2-360m-dml-fp16` with its matching golden for the smaller
+  DML probe). The DML attention fault may or may not affect Series X.
 
 ### H9 — Task suite (capability, not tok/s)
 

--- a/docs/recommended-config.md
+++ b/docs/recommended-config.md
@@ -153,7 +153,7 @@ ctest --test-dir build/linux-test --output-on-failure
 
    ```bash
    source ~/.config/xllama/xbox-env
-   ./scripts/validate-console.sh all   # routing + GGUF + TAESD → ALL PASS (2026-07-14)
+   ./scripts/validate-console.sh all   # routing + GGUF + TAESD → ALL PASS (2026-07-16, 1.2.0.534)
    ```
 
 5. Manual/debug path: [console-validation-runbook.md](./console-validation-runbook.md) per §

--- a/docs/using-the-app.md
+++ b/docs/using-the-app.md
@@ -44,13 +44,16 @@ Generation shows live tok/s; **■ Cancel** stops a running reply.
   computes wrong text logits on the Series S driver), every mode resolves to
   the CPU model, the `gpu_model` is not auto-downloaded (#95), and a missing
   `gpu_model` never blocks a turn (#100). Diffusion (plain ORT) stays on GPU.
-  The pre-#91 semantics, which return verbatim when the gate lifts:
+  The pre-#91 semantics, which return when the gate lifts (still subject to
+  `gpu_available` = provisioned `gpu_model` — see below):
   - **CPU only (default)** — best decode throughput at 360M scale (~66 tok/s).
-  - **GPU only (DML)** — forces DirectML (needs the `gpu_model`, e.g.
-    `smollm2-360m-dml-fp16`, in LocalState).
-  - **Auto (long prompts → GPU)** — long first prompts route to GPU fp16
-    (prefill is 1.8× faster at ~1k tokens), short chats stay on CPU; the
-    choice is sticky per conversation.
+  - **GPU only (DML)** — prefers DirectML when `gpu_model` is provisioned (e.g.
+    `smollm2-360m-dml-fp16` in LocalState); if `gpu_available` is false, falls
+    back to the CPU model.
+  - **Auto (long prompts → GPU)** — long first prompts route to GPU fp16 only
+    when `gpu_available` is true and the prompt exceeds the token threshold
+    (prefill is 1.8× faster at ~1k tokens); short chats, or any turn with a
+    missing GPU model, stay on CPU. The choice is sticky per conversation.
 
 **Note for GGUF models** (`kind: "gguf"` in the catalogue): **KV-cache reuse
 works** (the llama.cpp path keeps a persistent context and appends only the new


### PR DESCRIPTION
## Summary

Follow-up to the merged docs consolidate PR (#101). Closes the residual CodeRabbit findings that were left open after merge (bot-only; no human review required for substance).

| Priority | Fix |
|----------|-----|
| 🟠 Major | §2 runbook: official gate is **Auto only** (`"routing": 2`); CpuOnly/GpuOnly are manual/debug, not claimed by the script |
| 🟠 Major | H8: require explicit `MODEL=` + matching golden for DML parity — bare `validate-logit-parity.sh` defaults to cpu-int4 |
| 🟡 | `recommended-config`: ALL PASS date → **2026-07-16 / 1.2.0.534** |
| 🟡 | `model-selection`: escape `` `#91` `` so it is not an ATX heading |
| 🟡 | H2: “mid-speed” hyphen |
| 🟡 | `using-the-app`: after gate lifts, GpuOnly/Auto still need `gpu_available` / provisioned `gpu_model` or fall back to CPU |

## Test plan

- [x] Diff-only docs + CHANGELOG Unreleased line
- [x] Claims checked against `scripts/validate-console.sh` (seeds routing:2) and `include/xllama/routing_policy.h` (`gpu_available` fallback)
- [ ] CodeRabbit re-review on this PR (expect clean or residual cosmetic only)

Addresses CodeRabbit review on #101.