### PR TITLE
feat: list every servable on-device model in LAN API discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- LAN API model discovery (`/v1/models`, `/api/tags`) now lists **every
+  servable on-device model** (base GGUF or ORT layout under
+  `LocalState\models\`) instead of only the loaded one; the non-standard
+  `"active": true` flag marks the model the Session currently serves. Any
+  listed id is valid as the request `model` (the server already switched
+  Sessions on demand). Readiness predicate `model_dir_files_ready` is pure and
+  host-tested.
+
 ## [1.3.0.0] - 2026-07-17
 
 ### Added

--- a/docs/api-endpoint.md
+++ b/docs/api-endpoint.md
@@ -44,13 +44,21 @@ this is Dev Mode research, not a hosted service.
 
 ## Protocol (v1)
 
-| Method    | Path                   | Behaviour                                                             |
-| --------- | ---------------------- | --------------------------------------------------------------------- |
-| `GET`     | `/` or `/health`       | `200 {"status":"ok","service":"xllama"}` — the spike/liveness probe.  |
-| `GET`     | `/v1/models`           | OpenAI model discovery — lists the current/served model.              |
-| `GET`     | `/api/tags`            | Ollama model discovery — same model, Ollama shape.                    |
-| `POST`    | `/v1/chat/completions` | OpenAI-compatible chat completion, **non-streaming**.                 |
-| `OPTIONS` | _any_                  | CORS preflight (`204` + `Allow-Methods/Headers`) for browser clients. |
+| Method    | Path                   | Behaviour                                                                                                              |
+| --------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `GET`     | `/` or `/health`       | `200 {"status":"ok","service":"xllama"}` — the spike/liveness probe.                                                   |
+| `GET`     | `/v1/models`           | OpenAI model discovery — every servable on-device model; non-standard `"active": true` marks the one currently loaded. |
+| `GET`     | `/api/tags`            | Ollama model discovery — same list, Ollama shape.                                                                      |
+| `POST`    | `/v1/chat/completions` | OpenAI-compatible chat completion, **non-streaming**.                                                                  |
+| `OPTIONS` | _any_                  | CORS preflight (`204` + `Allow-Methods/Headers`) for browser clients.                                                  |
+
+Discovery semantics: a model is **servable** when its `LocalState\models\<id>`
+directory holds a base GGUF (any `*.gguf` except a bare runtime-LoRA
+`adapter.gguf`) or an ORT GenAI layout (`genai_config.json` / `model.onnx`) —
+predicate `model_dir_files_ready` in `include/xllama/model_provision.h`
+(host-tested). Any listed `id` is valid as the request `model`: the server
+lazily switches its single Session when the requested model differs from the
+loaded one (first request on a new model pays the load).
 
 Request body (subset): `model`, `messages[]` (`role` ∈ system/user/assistant, `content`),
 optional `max_completion_tokens` / `max_tokens` (default 512; the former wins — `max_tokens`

--- a/include/xllama/model_provision.h
+++ b/include/xllama/model_provision.h
@@ -63,4 +63,27 @@ inline bool dir_satisfies_expected_files(const std::vector<std::wstring>& presen
     return true;
 }
 
+// True iff a model directory's file listing makes it SERVABLE by Session:
+// a base GGUF (any *.gguf that is not a bare runtime-LoRA "adapter.gguf"),
+// or an ORT GenAI layout (genai_config.json / model.onnx). `files` are
+// directory-relative names; comparison is case-insensitive. Used by the LAN
+// API's /v1/models discovery — pure, host doctest-testable.
+inline bool model_dir_files_ready(const std::vector<std::string>& files) {
+    auto lower = [](std::string s) {
+        for (auto& c : s)
+            if (c >= 'A' && c <= 'Z')
+                c = static_cast<char>(c - 'A' + 'a');
+        return s;
+    };
+    for (const auto& f : files) {
+        const std::string name = lower(f);
+        if (name == "genai_config.json" || name == "model.onnx")
+            return true;
+        if (name.size() > 5 && name.compare(name.size() - 5, 5, ".gguf") == 0 &&
+            name != "adapter.gguf")
+            return true;
+    }
+    return false;
+}
+
 } // namespace xllama

--- a/tests/test_model_provision.cpp
+++ b/tests/test_model_provision.cpp
@@ -86,3 +86,22 @@ TEST_CASE("provision: diffusion with one required subdir file missing -> false")
 TEST_CASE("provision: normalize_model_path lowercases and unifies separators") {
     CHECK(normalize_model_path(L"UNet\\Model.ONNX") == L"unet/model.onnx");
 }
+
+TEST_CASE("model_dir_files_ready: base GGUF counts, bare adapter does not") {
+    CHECK(model_dir_files_ready({"model.gguf"}));
+    CHECK(model_dir_files_ready({"Model.GGUF", "adapter.gguf"}));
+    CHECK_FALSE(model_dir_files_ready({"adapter.gguf"}));
+    CHECK_FALSE(model_dir_files_ready({"ADAPTER.GGUF"}));
+}
+
+TEST_CASE("model_dir_files_ready: ORT layouts count") {
+    CHECK(model_dir_files_ready({"genai_config.json", "model.onnx.data"}));
+    CHECK(model_dir_files_ready({"model.onnx"}));
+    CHECK(model_dir_files_ready({"GenAI_Config.JSON"}));
+}
+
+TEST_CASE("model_dir_files_ready: junk-only directories are not servable") {
+    CHECK_FALSE(model_dir_files_ready({}));
+    CHECK_FALSE(model_dir_files_ready({"README.md", ".complete", "manifest.json"}));
+    CHECK_FALSE(model_dir_files_ready({"notgguf", "gguf", ".gguf-tmp"}));
+}

--- a/uwp/api-server.cpp
+++ b/uwp/api-server.cpp
@@ -18,13 +18,16 @@
 // clang-format on
 
     #include "xllama/chat_prompt.h"
+    #include "xllama/model_provision.h"
     #include "xllama/path_utils.h"
     #include "xllama/platform.h"
     #include "xllama/session.h"
 
+    #include <algorithm>
     #include <cctype>
     #include <cstdio>
     #include <ctime>
+    #include <filesystem>
     #include <memory>
     #include <mutex>
     #include <string>
@@ -388,16 +391,47 @@ std::string current_model_id() {
     return read_local_text("model.txt");
 }
 
-// OpenAI GET /v1/models — {"object":"list","data":[{id,object,created,owned_by}]}.
+// Catalogue ids ready to serve: every LocalState\models\<id> whose files make
+// it loadable (model_dir_files_ready — base GGUF or ORT layout). The active /
+// hinted model is appended if it is not already in the list (model.txt may
+// name a raw path outside the catalogue). Sorted for stable output; the scan
+// touches no shared state, so no g_mtx is needed.
+std::vector<std::string> servable_model_ids() {
+    std::vector<std::string> ids;
+    std::error_code ec;
+    const std::filesystem::path root = ::xllama::resolve_local_path("models");
+    for (const auto& entry : std::filesystem::directory_iterator(root, ec)) {
+        if (!entry.is_directory(ec))
+            continue;
+        std::vector<std::string> files;
+        for (const auto& f : std::filesystem::directory_iterator(entry.path(), ec))
+            files.push_back(f.path().filename().string());
+        if (::xllama::model_dir_files_ready(files))
+            ids.push_back(entry.path().filename().string());
+    }
+    std::sort(ids.begin(), ids.end());
+    const std::string current = current_model_id();
+    if (!current.empty() && std::find(ids.begin(), ids.end(), current) == ids.end())
+        ids.push_back(current);
+    return ids;
+}
+
+// OpenAI GET /v1/models — {"object":"list","data":[{id,object,created,owned_by}]}
+// listing every servable on-device model. The non-standard "active" flag marks
+// the model the lazily-owned Session currently has loaded (clients ignore
+// unknown fields); any listed id is valid for POST "model" — the server
+// switches Sessions on demand.
 std::string models_json() {
     JsonArray data;
-    const std::string id = current_model_id();
-    if (!id.empty()) {
+    const std::string current = current_model_id();
+    for (const std::string& id : servable_model_ids()) {
         JsonObject m;
         m.Insert(L"id", JsonValue::CreateStringValue(winrt::to_hstring(id)));
         m.Insert(L"object", JsonValue::CreateStringValue(L"model"));
         m.Insert(L"created", JsonValue::CreateNumberValue(static_cast<double>(time(nullptr))));
         m.Insert(L"owned_by", JsonValue::CreateStringValue(L"xllama"));
+        if (id == current)
+            m.Insert(L"active", JsonValue::CreateBooleanValue(true));
         data.Append(m);
     }
     JsonObject root;
@@ -409,8 +443,7 @@ std::string models_json() {
 // Ollama GET /api/tags — {"models":[{name,model}]} for Ollama-probing clients.
 std::string tags_json() {
     JsonArray models;
-    const std::string id = current_model_id();
-    if (!id.empty()) {
+    for (const std::string& id : servable_model_ids()) {
         JsonObject m;
         m.Insert(L"name", JsonValue::CreateStringValue(winrt::to_hstring(id)));
         m.Insert(L"model", JsonValue::CreateStringValue(winrt::to_hstring(id)));


### PR DESCRIPTION
## Summary

`GET /v1/models` (OpenAI) and `GET /api/tags` (Ollama) listed only the currently loaded model, making model discovery useless for multi-model consoles. They now enumerate **every servable model** under `LocalState\models\`:

- **Pure predicate** `model_dir_files_ready` in `include/xllama/model_provision.h` (host doctest-tested): a directory is servable with a base GGUF (any `*.gguf` except a bare runtime-LoRA `adapter.gguf`) or an ORT GenAI layout (`genai_config.json` / `model.onnx`).
- **`servable_model_ids()`** in `api-server.cpp` scans the models root (no shared state, no `g_mtx`), sorts ids, and appends the loaded/`model.txt`-hinted id when it is outside the catalogue.
- Non-standard **`"active": true`** marks the model the single Session currently serves (OpenAI clients ignore unknown fields).
- No behavioural change on the request side — the server already switched Sessions on demand for a differing `model`; now the ids are discoverable. Docs (`docs/api-endpoint.md`) spell out the servability semantics.

## Test plan
- [x] Host: `ctest` 100% PASS (new `model_dir_files_ready` cases: GGUF/ORT layouts, bare-adapter and junk-only dirs rejected, case-insensitivity).
- [x] clang-format 22.1.5 clean.
- [ ] Console (post-merge): `curl http://<xbox>:<port>/v1/models` on 1.3.0.556+ with the re-provisioned test set → expect `lfm25-350m`, `smollm2-360m-cpu-int4`, `sd-turbo-fp16` listed and the loaded one flagged active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)