### PR TITLE
exp(#111): single-op CPU-vs-DML repro kit (broken RMSNorm kernel)

### DIFF
--- a/docs/dml-rmsnorm-fix-runbook.md
+++ b/docs/dml-rmsnorm-fix-runbook.md
@@ -72,17 +72,54 @@ attention decomposition, `--fp32-qk`) remain available for future probes.
       in LocalState and the routing allowlist is keyed on the name; remote
       sizes verified byte-exact vs manifest `approx_bytes`; post-publish
       on-device parity PASS via `provision-models.sh` download).
-- [ ] Routing re-enable PR (#110): `dml_text_model_ok` allowlist in
-      `routing_policy.h` behind `token_threshold`, manifest `-v2` entry,
-      `validate-console.sh` §2 expectations flipped back to auto→gpu.
-- [ ] Upstream report (#111): DML EP `SimplifiedLayerNormalization` /
-      `SkipSimplifiedLayerNormalization` kernels produce wrong results on the
-      Xbox Series S driver — minimal repro = single-op model diff CPU vs DML
-      (supersedes the attention theory on microsoft/onnxruntime#29739). Where
-      needed, fork ORT and analyze/fix the DML operator itself (same vendored
-      pattern as the extdata and GenAI #2280 patches).
-- [ ] Re-test fused RMSNorm after future Xbox GameOS/driver updates (this is
-      a driver/kernel bug, not a graph bug).
+- [x] Routing re-enable PR (#110 → **PR #112, merged 2026-07-19**):
+      `dml_text_model_ok` allowlist in `routing_policy.h` behind
+      `token_threshold`, manifest `-v2` entry, `validate-console.sh` §2
+      expectations flipped back to auto→gpu. On-console merge gate ALL PASS
+      (first legitimate auto→gpu: 959 tok → GPU, decode 38.8 tok/s).
+- [ ] Upstream report (#111): draft pending explicit OK; see the repro
+      campaign below for what the report can and cannot claim.
+- [ ] Re-test fused RMSNorm after future Xbox GameOS/driver updates.
+
+## Repro campaign (#111, 2026-07-19 — PR #113)
+
+Source analysis (ORT v1.24.4): both `SimplifiedLayerNormalization` and
+`SkipSimplifiedLayerNormalization` lower to
+`DML_OPERATOR_MEAN_VARIANCE_NORMALIZATION2` with `UseMean=false`
+(`DmlOperatorLayerNormalization.cpp`, `DmlOperatorSkipLayerNormalization.cpp`).
+
+Tooling: `uwp/op-repro.cpp` (`oprepro.flag` headless plain-ORT runner, CPU
+session vs DML session on the same payload, optimization level from
+`repro-opt.txt`), `scripts/make-op-repro.py` (single-op models, `--scale`),
+`scripts/make-chain-repro.py` (decoder-shaped 25-node stack),
+`scripts/validate-op-repro.sh` (per-variant driver).
+
+**Every plain-ORT probe MATCHES on the Series S driver** (CPU-vs-DML NMSE
+≤ 2e-06 in all cases):
+
+| probe                                                                | opt level                | verdict |
+| -------------------------------------------------------------------- | ------------------------ | ------- |
+| simplified / skip / layernorm single op, scale 2                     | disable + all            | MATCH   |
+| same at scale 30 / 100 (Σx² far beyond fp16 max)                     | disable                  | MATCH   |
+| 25-node chain (SimplifiedLN→MatMul→skip residual ×8, real eps/shape) | disable + extended + all | MATCH   |
+
+(The high-scale `skip` "mismatches" under an absolute tolerance are 1-ulp
+fp16 divergence on the fp16 residual-sum output — not corruption.)
+
+**Interpretation.** The op — including the fused-graph DML compilation path —
+is correct standalone on this device. The corruption manifests only in the
+**ORT-GenAI DML execution context** (DML1 shared device/queue, GenAI's
+binding/allocation pattern, the decoder graph with past-KV I/O): fused
+RMSNorm there produces NMSE ~0.98, and decomposing only those nodes inside
+that same context fixes it. Any upstream fix or fork-level workaround must
+therefore target the GenAI-DML interaction, not the standalone kernel; the
+graph-level decomposition (this runbook's fix) remains the correct
+product-side workaround.
+
+Runner gotcha worth keeping: `Ort::TypeInfo` must outlive the
+`GetTensorTypeAndShapeInfo()` view (a temporary dangles → garbage shapes →
+`bad_alloc`), and per-input buffers must be reserved before wrapping their
+`data()` in `Ort::Value` (vector reallocation dangles earlier tensors).
 
 History: `docs/dml-metacommands-runbook.md` (metacommands experiment, FAIL,
 2026-07-19) and #94 (MHA probe) document the prior exonerated suspects.

--- a/scripts/make-chain-repro.py
+++ b/scripts/make-chain-repro.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Chain repro for #111: decoder-shaped RMSNorm/MatMul stacks, CPU vs DML.
+
+The single-op probes (make-op-repro.py) came back MATCH on the Series S
+driver — the (Skip)SimplifiedLayerNormalization kernel is correct in
+isolation. This generator raises the fidelity one notch: N transformer-ish
+blocks of
+
+    h_norm = SimplifiedLayerNormalization(h)        # pre-norm
+    proj   = MatMul(h_norm, W_i)                    # 960x960 fp16
+    h, _   = SkipSimplifiedLayerNormalization(h, proj)  # residual + post-norm
+              (output 3 = h + proj feeds the next block, like the decoder)
+
+ending with a final SimplifiedLayerNormalization "head". The float64
+reference is computed here; the on-device verdict is CPU-vs-DML via
+uwp/op-repro.cpp (same repro.onnx/repro-input.bin contract).
+
+Usage:
+    make-chain-repro.py [-o build/op-repro-chain] [--layers 8] [--tokens 6]
+                        [--hidden 960] [--scale 2.0] [--seed 91]
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+EPS = 9.999999747378752e-06
+
+
+def rms64(x, gamma):
+    ms = (x * x).mean(axis=-1, keepdims=True)
+    return x / np.sqrt(ms + EPS) * gamma
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("-o", "--out", type=Path, default=Path("build/op-repro-chain"))
+    ap.add_argument("--layers", type=int, default=8)
+    ap.add_argument("--tokens", type=int, default=6)
+    ap.add_argument("--hidden", type=int, default=960)
+    ap.add_argument("--scale", type=float, default=2.0)
+    ap.add_argument("--seed", type=int, default=91)
+    args = ap.parse_args()
+
+    rng = np.random.default_rng(args.seed)
+    H, T = args.hidden, args.tokens
+    shape = [1, T, H]
+
+    x = rng.standard_normal(shape).astype(np.float16).astype(np.float64) * args.scale
+
+    nodes, inits = [], []
+    h_name = "x"
+    h = x.copy()
+    fp16 = lambda a: a.astype(np.float16)  # noqa: E731
+
+    for i in range(args.layers):
+        gamma_pre = fp16(rng.standard_normal(H) * 0.5 + 1.0)
+        gamma_post = fp16(rng.standard_normal(H) * 0.5 + 1.0)
+        # Orthogonal-ish small weights keep magnitudes decoder-like across depth.
+        w = fp16(rng.standard_normal((H, H)) * (1.0 / np.sqrt(H)))
+        inits += [
+            numpy_helper.from_array(gamma_pre, f"g_pre_{i}"),
+            numpy_helper.from_array(w, f"w_{i}"),
+            numpy_helper.from_array(gamma_post, f"g_post_{i}"),
+        ]
+        nodes += [
+            helper.make_node(
+                "SimplifiedLayerNormalization",
+                [h_name, f"g_pre_{i}"],
+                [f"norm_{i}"],
+                axis=-1,
+                epsilon=EPS,
+                stash_type=1,
+            ),
+            helper.make_node("MatMul", [f"norm_{i}", f"w_{i}"], [f"proj_{i}"]),
+            helper.make_node(
+                "SkipSimplifiedLayerNormalization",
+                [h_name, f"proj_{i}", f"g_post_{i}"],
+                [f"post_{i}", "", "", f"h_{i}"],
+                domain="com.microsoft",
+                epsilon=EPS,
+            ),
+        ]
+        # Reference in float64 with per-step fp16 rounding to track the device.
+        g_pre64 = gamma_pre.astype(np.float64)
+        w64 = w.astype(np.float64)
+        g_post64 = gamma_post.astype(np.float64)
+        norm = fp16(rms64(h, g_pre64)).astype(np.float64)
+        proj = fp16(norm @ w64).astype(np.float64)
+        h = fp16(h + proj).astype(np.float64)
+        _post = fp16(rms64(h, g_post64)).astype(
+            np.float64
+        )  # graph output post_i unused
+        h_name = f"h_{i}"
+
+    gamma_final = fp16(rng.standard_normal(H) * 0.5 + 1.0)
+    inits.append(numpy_helper.from_array(gamma_final, "g_final"))
+    nodes.append(
+        helper.make_node(
+            "SimplifiedLayerNormalization",
+            [h_name, "g_final"],
+            ["y"],
+            axis=-1,
+            epsilon=EPS,
+            stash_type=1,
+        )
+    )
+    expected = fp16(rms64(h, gamma_final.astype(np.float64))).astype(np.float32)
+
+    graph = helper.make_graph(
+        nodes,
+        "oprepro_chain",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT16, shape)],
+        [helper.make_tensor_value_info("y", TensorProto.FLOAT16, shape)],
+        inits,
+    )
+    model = helper.make_model(
+        graph,
+        opset_imports=[
+            helper.make_opsetid("", 17),
+            helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 8
+
+    d = args.out / "chain"
+    d.mkdir(parents=True, exist_ok=True)
+    onnx.save(model, d / "repro.onnx")
+    x.reshape(-1).astype(np.float32).tofile(d / "repro-input.bin")
+    expected.reshape(-1).tofile(d / "repro-expected.bin")
+    print(
+        f"chain: {args.layers} blocks (2x SimplifiedLN + MatMul + skip residual each), "
+        f"h final max|h|={np.abs(h).max():.1f} -> {d}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/make-op-repro.py
+++ b/scripts/make-op-repro.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Generate single-op ONNX repro models for the #111 DML kernel investigation.
+
+The #91 root cause is the DML lowering of (Skip)SimplifiedLayerNormalization:
+both funnel into DML_OPERATOR_MEAN_VARIANCE_NORMALIZATION2 with UseMean=false
+(onnxruntime/core/providers/dml/.../DmlOperatorLayerNormalization.cpp), the
+"RMSNorm" MVN2 configuration. This script emits minimal models that exercise
+exactly that path — plus a non-simplified LayerNormalization control that uses
+the same MVN2 op with UseMean=true (expected correct):
+
+    simplified  -> one SimplifiedLayerNormalization node (default domain)
+    skip        -> one com.microsoft.SkipSimplifiedLayerNormalization node
+    layernorm   -> one LayerNormalization node (control)
+
+Each variant writes <out>/<name>/repro.onnx plus repro-input.bin (fp32 payload,
+inputs concatenated in model input order — the on-device runner contract, see
+uwp/op-repro.cpp) and repro-expected.bin (fp32 reference computed here in
+float64 then rounded, for host-side sanity only; the on-device verdict compares
+the device's own CPU vs DML runs).
+
+Usage:
+    make-op-repro.py [-o build/op-repro] [--hidden 960] [--tokens 8] [--seed 91]
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+EPS = 9.999999747378752e-06  # the decoder's epsilon, bit-exact
+
+
+def rms_ref(x, gamma):
+    x64 = x.astype(np.float64)
+    ms = (x64 * x64).mean(axis=-1, keepdims=True)
+    return (x64 / np.sqrt(ms + EPS) * gamma.astype(np.float64)).astype(np.float32)
+
+
+def ln_ref(x, gamma, beta):
+    x64 = x.astype(np.float64)
+    mu = x64.mean(axis=-1, keepdims=True)
+    var = ((x64 - mu) ** 2).mean(axis=-1, keepdims=True)
+    return (
+        (x64 - mu) / np.sqrt(var + EPS) * gamma.astype(np.float64)
+        + beta.astype(np.float64)
+    ).astype(np.float32)
+
+
+def build(variant, hidden, tokens, rng, out_dir):
+    shape = [1, tokens, hidden]
+    gamma = (
+        rng.standard_normal(hidden).astype(np.float16).astype(np.float32) * 0.5 + 1.0
+    )
+    x = (rng.standard_normal(shape).astype(np.float16).astype(np.float32)) * 2.0
+
+    inputs = [helper.make_tensor_value_info("x", TensorProto.FLOAT16, shape)]
+    inits = [numpy_helper.from_array(gamma.astype(np.float16), "gamma")]
+    payload = [x]
+
+    if variant == "simplified":
+        node = helper.make_node(
+            "SimplifiedLayerNormalization",
+            ["x", "gamma"],
+            ["y"],
+            axis=-1,
+            epsilon=EPS,
+            stash_type=1,
+        )
+        expected = rms_ref(x, gamma)
+        outputs = [helper.make_tensor_value_info("y", TensorProto.FLOAT16, shape)]
+    elif variant == "skip":
+        skip = (rng.standard_normal(shape).astype(np.float16).astype(np.float32)) * 2.0
+        payload.append(skip)
+        inputs.append(helper.make_tensor_value_info("skip", TensorProto.FLOAT16, shape))
+        node = helper.make_node(
+            "SkipSimplifiedLayerNormalization",
+            ["x", "skip", "gamma"],
+            ["y", "", "", "sum"],
+            domain="com.microsoft",
+            epsilon=EPS,
+        )
+        expected = rms_ref(x + skip, gamma)
+        outputs = [
+            helper.make_tensor_value_info("y", TensorProto.FLOAT16, shape),
+            helper.make_tensor_value_info("sum", TensorProto.FLOAT16, shape),
+        ]
+    elif variant == "layernorm":
+        beta = rng.standard_normal(hidden).astype(np.float16).astype(np.float32) * 0.1
+        inits.append(numpy_helper.from_array(beta.astype(np.float16), "beta"))
+        node = helper.make_node(
+            "LayerNormalization", ["x", "gamma", "beta"], ["y"], axis=-1, epsilon=EPS
+        )
+        expected = ln_ref(x, gamma, beta)
+        outputs = [helper.make_tensor_value_info("y", TensorProto.FLOAT16, shape)]
+    else:
+        raise ValueError(variant)
+
+    graph = helper.make_graph([node], f"oprepro_{variant}", inputs, outputs, inits)
+    model = helper.make_model(
+        graph,
+        opset_imports=[
+            helper.make_opsetid("", 17),
+            helper.make_opsetid("com.microsoft", 1),
+        ],
+    )
+    model.ir_version = 8
+
+    d = out_dir / variant
+    d.mkdir(parents=True, exist_ok=True)
+    onnx.save(model, d / "repro.onnx")
+    np.concatenate([p.reshape(-1) for p in payload]).astype(np.float32).tofile(
+        d / "repro-input.bin"
+    )
+    expected.reshape(-1).astype(np.float32).tofile(d / "repro-expected.bin")
+    print(
+        f"{variant}: repro.onnx + input ({sum(p.size for p in payload)} f32) "
+        f"+ expected ({expected.size} f32) -> {d}"
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("-o", "--out", type=Path, default=Path("build/op-repro"))
+    ap.add_argument("--hidden", type=int, default=960)
+    ap.add_argument("--tokens", type=int, default=8)
+    ap.add_argument("--seed", type=int, default=91)
+    args = ap.parse_args()
+
+    rng = np.random.default_rng(args.seed)
+    for variant in ("simplified", "skip", "layernorm"):
+        build(variant, args.hidden, args.tokens, rng, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/make-op-repro.py
+++ b/scripts/make-op-repro.py
@@ -48,12 +48,12 @@ def ln_ref(x, gamma, beta):
     ).astype(np.float32)
 
 
-def build(variant, hidden, tokens, rng, out_dir):
+def build(variant, hidden, tokens, rng, out_dir, scale=2.0):
     shape = [1, tokens, hidden]
     gamma = (
         rng.standard_normal(hidden).astype(np.float16).astype(np.float32) * 0.5 + 1.0
     )
-    x = (rng.standard_normal(shape).astype(np.float16).astype(np.float32)) * 2.0
+    x = (rng.standard_normal(shape).astype(np.float16).astype(np.float32)) * scale
 
     inputs = [helper.make_tensor_value_info("x", TensorProto.FLOAT16, shape)]
     inits = [numpy_helper.from_array(gamma.astype(np.float16), "gamma")]
@@ -71,7 +71,7 @@ def build(variant, hidden, tokens, rng, out_dir):
         expected = rms_ref(x, gamma)
         outputs = [helper.make_tensor_value_info("y", TensorProto.FLOAT16, shape)]
     elif variant == "skip":
-        skip = (rng.standard_normal(shape).astype(np.float16).astype(np.float32)) * 2.0
+        skip = (rng.standard_normal(shape).astype(np.float16).astype(np.float32)) * scale
         payload.append(skip)
         inputs.append(helper.make_tensor_value_info("skip", TensorProto.FLOAT16, shape))
         node = helper.make_node(
@@ -126,11 +126,13 @@ def main():
     ap.add_argument("--hidden", type=int, default=960)
     ap.add_argument("--tokens", type=int, default=8)
     ap.add_argument("--seed", type=int, default=91)
+    ap.add_argument("--scale", type=float, default=2.0,
+                    help="input magnitude; ~30+ makes sum(x^2) overflow fp16 (65504)")
     args = ap.parse_args()
 
     rng = np.random.default_rng(args.seed)
     for variant in ("simplified", "skip", "layernorm"):
-        build(variant, args.hidden, args.tokens, rng, args.out)
+        build(variant, args.hidden, args.tokens, rng, args.out, scale=args.scale)
 
 
 if __name__ == "__main__":

--- a/scripts/validate-op-repro.sh
+++ b/scripts/validate-op-repro.sh
@@ -73,8 +73,9 @@ restart_app() {
 }
 
 overall=0
-for variant in simplified skip layernorm; do
-	d="${REPRO_ROOT}/${variant}"
+for d in "${REPRO_ROOT}"/*/; do
+	d="${d%/}"
+	variant="$(basename "$d")"
 	[[ -f "$d/repro.onnx" ]] || {
 		echo "skip ${variant}: $d/repro.onnx not found (run make-op-repro.py)"
 		continue

--- a/scripts/validate-op-repro.sh
+++ b/scripts/validate-op-repro.sh
@@ -27,6 +27,9 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 DEPLOY="${SCRIPT_DIR}/deploy.sh"
 REPRO_ROOT="${1:-${REPO_ROOT}/build/op-repro}"
 TOLERANCE="${TOLERANCE:-0.01}"
+# disable|basic|extended|all — "extended"/"all" enable the DML EP graph-fusion
+# path (compiled DML_GRAPH partitions), the suspected #91 trigger.
+OPT_LEVEL="${OPT_LEVEL:-disable}"
 
 BASE_URL="https://${XBOX_IP}:11443"
 CURL_AUTH=(--basic -u "${XBOX_USER}:${XBOX_PASS}" -k -sS)
@@ -80,13 +83,15 @@ for d in "${REPRO_ROOT}"/*/; do
 		echo "skip ${variant}: $d/repro.onnx not found (run make-op-repro.py)"
 		continue
 	}
-	echo "=== op-repro: ${variant} ==="
+	echo "=== op-repro: ${variant} (opt=${OPT_LEVEL}) ==="
 
-	for f in repro.done repro-out-cpu.bin repro-out-dml.bin repro.onnx repro-input.bin; do
+	for f in repro.done repro-out-cpu.bin repro-out-dml.bin repro.onnx repro-input.bin repro-opt.txt; do
 		delete_file "$f"
 	done
 	upload_file "$d/repro.onnx"
 	upload_file "$d/repro-input.bin"
+	printf '%s' "$OPT_LEVEL" >"${TMPDIR_LOCAL}/repro-opt.txt"
+	upload_file "${TMPDIR_LOCAL}/repro-opt.txt"
 	printf 'go' >"${TMPDIR_LOCAL}/oprepro.flag"
 	upload_file "${TMPDIR_LOCAL}/oprepro.flag"
 	restart_app

--- a/scripts/validate-op-repro.sh
+++ b/scripts/validate-op-repro.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# validate-op-repro.sh — drive the single-op CPU-vs-DML repro on the console (#111).
+#
+# For each variant produced by scripts/make-op-repro.py (simplified, skip,
+# layernorm) this uploads repro.onnx + repro-input.bin, triggers the app's
+# oprepro.flag headless mode (uwp/op-repro.cpp), pulls repro-out-cpu.bin /
+# repro-out-dml.bin and prints a per-variant verdict:
+#   MATCH    max|cpu-dml| <= tolerance  (kernel agrees with CPU)
+#   MISMATCH otherwise                  (broken DML kernel isolated)
+#
+# Expected on the Series S driver (#91 root cause): simplified and skip
+# MISMATCH, layernorm (control, MVN2 UseMean=true) MATCH.
+#
+# Usage:
+#   source ~/.config/xllama/xbox-env
+#   ./scripts/make-op-repro.py -o build/op-repro
+#   ./scripts/validate-op-repro.sh [build/op-repro]
+
+set -euo pipefail
+
+: "${XBOX_IP:?XBOX_IP not set — run: source ~/.config/xllama/xbox-env}"
+: "${XBOX_USER:?XBOX_USER not set}"
+: "${XBOX_PASS:?XBOX_PASS not set}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEPLOY="${SCRIPT_DIR}/deploy.sh"
+REPRO_ROOT="${1:-${REPO_ROOT}/build/op-repro}"
+TOLERANCE="${TOLERANCE:-0.01}"
+
+BASE_URL="https://${XBOX_IP}:11443"
+CURL_AUTH=(--basic -u "${XBOX_USER}:${XBOX_PASS}" -k -sS)
+
+CSRF_TOKEN=$(curl "${CURL_AUTH[@]}" "${BASE_URL}/" -o /dev/null -D - 2>/dev/null |
+	sed -n 's/.*[Cc][Ss][Rr][Ff]-[Tt]oken=\([^;[:space:]]*\).*/\1/p' | tr -d '\r' | head -n1)
+[[ -z "$CSRF_TOKEN" ]] && echo "Warning: no CSRF token — POST/DELETE may fail" >&2
+
+PFN=$("${DEPLOY}" pfn 2>/dev/null)
+[[ -z "$PFN" ]] && {
+	echo "Error: xllama not found — deploy it first" >&2
+	exit 2
+}
+
+TMPDIR_LOCAL=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_LOCAL"' EXIT
+
+WDP_FILE="${BASE_URL}/api/filesystem/apps/file?knownfolderid=LocalAppData&packagefullname=${PFN}&path=%5CLocalState"
+
+upload_file() {
+	curl "${CURL_AUTH[@]}" -H "X-CSRF-Token:${CSRF_TOKEN}" -X POST \
+		-F "file=@${1};type=application/octet-stream" "${WDP_FILE}" >/dev/null
+}
+delete_file() {
+	curl "${CURL_AUTH[@]}" -H "X-CSRF-Token:${CSRF_TOKEN}" -X DELETE \
+		"${WDP_FILE}&filename=$1" >/dev/null 2>&1 || true
+}
+download_file() {
+	local code
+	code=$(curl "${CURL_AUTH[@]}" -o "$2" -w "%{http_code}" \
+		"${WDP_FILE}&filename=$1" 2>/dev/null || echo "000")
+	[[ "$code" == "200" ]]
+}
+restart_app() {
+	curl "${CURL_AUTH[@]}" -H "X-CSRF-Token:${CSRF_TOKEN}" -X DELETE \
+		"${BASE_URL}/api/taskmanager/app?package=${PFN}" >/dev/null 2>&1 || true
+	sleep 2
+	local pfamily aumid
+	# shellcheck disable=SC2001
+	pfamily=$(echo "$PFN" | sed 's/_[0-9][0-9.]*_[^_]*__/_/')
+	aumid=$(printf '%s!xllama' "$pfamily" | base64 -w0)
+	curl "${CURL_AUTH[@]}" -H "X-CSRF-Token:${CSRF_TOKEN}" -X POST -d "" \
+		"${BASE_URL}/api/taskmanager/app?appid=${aumid}" >/dev/null 2>&1 || true
+}
+
+overall=0
+for variant in simplified skip layernorm; do
+	d="${REPRO_ROOT}/${variant}"
+	[[ -f "$d/repro.onnx" ]] || {
+		echo "skip ${variant}: $d/repro.onnx not found (run make-op-repro.py)"
+		continue
+	}
+	echo "=== op-repro: ${variant} ==="
+
+	for f in repro.done repro-out-cpu.bin repro-out-dml.bin repro.onnx repro-input.bin; do
+		delete_file "$f"
+	done
+	upload_file "$d/repro.onnx"
+	upload_file "$d/repro-input.bin"
+	printf 'go' >"${TMPDIR_LOCAL}/oprepro.flag"
+	upload_file "${TMPDIR_LOCAL}/oprepro.flag"
+	restart_app
+
+	elapsed=0
+	until download_file "repro.done" "${TMPDIR_LOCAL}/repro.done"; do
+		((elapsed >= 180)) && {
+			echo "  FAIL: repro.done never appeared — check xllama.log"
+			overall=1
+			continue 2
+		}
+		sleep 5
+		((elapsed += 5))
+	done
+	if [[ "$(cat "${TMPDIR_LOCAL}/repro.done")" != "ok" ]]; then
+		echo "  FAIL: device reported: $(cat "${TMPDIR_LOCAL}/repro.done")"
+		overall=1
+		continue
+	fi
+	download_file "repro-out-cpu.bin" "${TMPDIR_LOCAL}/${variant}-cpu.bin" || {
+		echo "  FAIL: no CPU output"
+		overall=1
+		continue
+	}
+	download_file "repro-out-dml.bin" "${TMPDIR_LOCAL}/${variant}-dml.bin" || {
+		echo "  FAIL: no DML output"
+		overall=1
+		continue
+	}
+
+	python3 - "$d" "${TMPDIR_LOCAL}/${variant}-cpu.bin" "${TMPDIR_LOCAL}/${variant}-dml.bin" \
+		"$TOLERANCE" <<'PY' || overall=1
+import sys
+import numpy as np
+d, cpu_p, dml_p, tol = sys.argv[1], sys.argv[2], sys.argv[3], float(sys.argv[4])
+cpu = np.fromfile(cpu_p, dtype=np.float32)
+dml = np.fromfile(dml_p, dtype=np.float32)
+exp = np.fromfile(f"{d}/repro-expected.bin", dtype=np.float32)
+assert cpu.size == dml.size, f"size mismatch cpu={cpu.size} dml={dml.size}"
+n = exp.size  # first output; skip variant also emits the residual sum after it
+diff = np.abs(cpu - dml)
+host = np.abs(cpu[:n] - exp)
+nmse = float(((cpu - dml) ** 2).mean() / max(float((cpu**2).mean()), 1e-30))
+print(f"  cpu-vs-host-expected max|d|: {host.max():.6f} (CPU EP sanity)")
+print(f"  cpu-vs-dml           max|d|: {diff.max():.6f}  nmse: {nmse:.3e}")
+if diff.max() <= tol:
+    print("  MATCH: DML agrees with CPU on this op")
+else:
+    print("  MISMATCH: broken DML kernel isolated on this op")
+    sys.exit(1)
+PY
+done
+
+exit $overall

--- a/uwp/App.cpp
+++ b/uwp/App.cpp
@@ -276,6 +276,14 @@ int __stdcall wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
                 winrt::make<HeadlessView>(&::xllama::bridge::run_logits, "logits"));
             return 0; // not reached: CoreApplication::Exit terminates the process
         }
+        std::wstring oprepro_flag = flag_path_if_present(L"oprepro.flag");
+        if (!oprepro_flag.empty()) {
+            _wremove(oprepro_flag.c_str());
+            ::xllama::log_output("[xllama] oprepro.flag detected -> single-op CPU-vs-DML repro\n");
+            winrt::Windows::ApplicationModel::Core::CoreApplication::Run(
+                winrt::make<HeadlessView>(&::xllama::bridge::run_oprepro, "oprepro"));
+            return 0; // not reached: CoreApplication::Exit terminates the process
+        }
         std::wstring train_flag = flag_path_if_present(L"train.flag");
         if (!train_flag.empty()) {
             _wremove(train_flag.c_str());

--- a/uwp/inference-bridge.h
+++ b/uwp/inference-bridge.h
@@ -37,6 +37,14 @@ void run_diffuse();
 // llama.cpp golden via scripts/compare-logits.py.
 void run_logits();
 
+// Single-op CPU-vs-DML repro (#111): loads LocalState\repro.onnx with a plain
+// ORT CPU session and a DML session, feeds repro-input.bin and writes
+// repro-out-cpu.bin / repro-out-dml.bin (+ repro.done marker). Triggered by
+// LocalFolder\oprepro.flag; driven by scripts/validate-op-repro.sh. Used to
+// isolate broken DML kernels (first target: (Skip)SimplifiedLayerNormalization
+// -> MVN2 UseMean=false, the #91 root cause).
+void run_oprepro();
+
 // Lane B on-device training (ggml-opt partial FT). Triggered by
 // LocalFolder\train.flag; reads the job from LocalState\training\job.json
 // (paths inside the job are resolved relative to LocalState), runs

--- a/uwp/op-repro.cpp
+++ b/uwp/op-repro.cpp
@@ -81,9 +81,14 @@ std::vector<float> run_once(Ort::Session& session, const std::vector<float>& pay
     std::vector<Ort::AllocatedStringPtr> in_name_holders;
     std::vector<const char*> in_names;
     std::vector<Ort::Value> in_values;
-    // Keep converted fp16 buffers alive until Run().
+    // Keep converted buffers alive until Run(). Reserve up front: the created
+    // Ort::Value wraps the buffer's data() pointer, so a later push_back must
+    // never reallocate the outer vector (dangling tensor data otherwise).
     std::vector<std::vector<uint16_t>> half_buffers;
     std::vector<std::vector<float>> float_buffers;
+    half_buffers.reserve(n_in);
+    float_buffers.reserve(n_in);
+    in_name_holders.reserve(n_in);
 
     size_t cursor = 0;
     for (size_t i = 0; i < n_in; ++i) {
@@ -157,13 +162,16 @@ void run_oprepro() {
         const std::vector<float> payload = read_f32_file(resolve_local_path("repro-input.bin"));
         if (payload.empty())
             throw std::runtime_error("repro-input.bin missing or empty");
+        log_output("[xllama] oprepro: payload " + std::to_string(payload.size()) + " f32\n");
 
         Ort::Env env(ORT_LOGGING_LEVEL_ERROR, "oprepro");
+        log_output("[xllama] oprepro: env ready\n");
 
         {
             Ort::SessionOptions so;
             so.SetGraphOptimizationLevel(ORT_DISABLE_ALL); // the op itself, not a rewrite
             Ort::Session cpu(env, utf8_to_wstring(model_path).c_str(), so);
+            log_output("[xllama] oprepro: CPU session created\n");
             write_f32_file(resolve_local_path("repro-out-cpu.bin"), run_once(cpu, payload));
             log_output("[xllama] oprepro: CPU run done\n");
         }
@@ -176,6 +184,7 @@ void run_oprepro() {
             so.SetGraphOptimizationLevel(ORT_DISABLE_ALL);
             Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_DML(so, 0));
             Ort::Session dml(env, utf8_to_wstring(model_path).c_str(), so);
+            log_output("[xllama] oprepro: DML session created\n");
             write_f32_file(resolve_local_path("repro-out-dml.bin"), run_once(dml, payload));
             log_output("[xllama] oprepro: DML run done\n");
         }

--- a/uwp/op-repro.cpp
+++ b/uwp/op-repro.cpp
@@ -26,14 +26,14 @@
     #include <dml_provider_factory.h>
 // clang-format on
 
-#include <cstdio>
-#include <string>
-#include <vector>
+    #include <cstdio>
+    #include <string>
+    #include <vector>
 
-#include "xllama/diffusion/half.h"
-#include "xllama/path_utils.h"
-#include "xllama/platform.h"
-#include "xllama/utf8_utils.h"
+    #include "xllama/diffusion/half.h"
+    #include "xllama/path_utils.h"
+    #include "xllama/platform.h"
+    #include "xllama/utf8_utils.h"
 
 namespace xllama::bridge {
 
@@ -111,10 +111,9 @@ std::vector<float> run_once(Ort::Session& session, const std::vector<float>& pay
                 mem, half_buffers.back().data(), count * sizeof(uint16_t), shape.data(),
                 shape.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16));
         } else if (dt == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
-            float_buffers.emplace_back(payload.begin() + cursor,
-                                       payload.begin() + cursor + count);
-            in_values.push_back(Ort::Value::CreateTensor<float>(
-                mem, float_buffers.back().data(), count, shape.data(), shape.size()));
+            float_buffers.emplace_back(payload.begin() + cursor, payload.begin() + cursor + count);
+            in_values.push_back(Ort::Value::CreateTensor<float>(mem, float_buffers.back().data(),
+                                                                count, shape.data(), shape.size()));
         } else {
             throw std::runtime_error("unsupported repro input dtype (want fp16/fp32)");
         }
@@ -129,8 +128,8 @@ std::vector<float> run_once(Ort::Session& session, const std::vector<float>& pay
         out_names.push_back(out_name_holders.back().get());
     }
 
-    auto outputs = session.Run(Ort::RunOptions{nullptr}, in_names.data(), in_values.data(),
-                               n_in, out_names.data(), n_out);
+    auto outputs = session.Run(Ort::RunOptions{nullptr}, in_names.data(), in_values.data(), n_in,
+                               out_names.data(), n_out);
 
     std::vector<float> flat;
     for (auto& out : outputs) {

--- a/uwp/op-repro.cpp
+++ b/uwp/op-repro.cpp
@@ -39,6 +39,27 @@ namespace xllama::bridge {
 
 namespace {
 
+// Optimization level knob (LocalState\repro-opt.txt: disable|basic|extended|all,
+// default disable). "disable" runs the recorded ops as-is; "extended"/"all"
+// let the DML EP fuse the graph into compiled DML_GRAPH partitions — the
+// suspected #91 trigger the standalone-op runs cannot exercise.
+GraphOptimizationLevel read_opt_level() {
+    FILE* fp = _wfopen(utf8_to_wstring(resolve_local_path("repro-opt.txt")).c_str(), L"r");
+    if (!fp)
+        return ORT_DISABLE_ALL;
+    char buf[32] = {};
+    fgets(buf, sizeof(buf), fp);
+    fclose(fp);
+    const std::string v(buf);
+    if (v.find("all") == 0)
+        return ORT_ENABLE_ALL;
+    if (v.find("extended") == 0)
+        return ORT_ENABLE_EXTENDED;
+    if (v.find("basic") == 0)
+        return ORT_ENABLE_BASIC;
+    return ORT_DISABLE_ALL;
+}
+
 std::vector<float> read_f32_file(const std::string& path) {
     std::vector<float> out;
     FILE* fp = _wfopen(utf8_to_wstring(path).c_str(), L"rb");
@@ -169,11 +190,12 @@ void run_oprepro() {
         log_output("[xllama] oprepro: payload " + std::to_string(payload.size()) + " f32\n");
 
         Ort::Env env(ORT_LOGGING_LEVEL_ERROR, "oprepro");
-        log_output("[xllama] oprepro: env ready\n");
+        const GraphOptimizationLevel opt = read_opt_level();
+        log_output("[xllama] oprepro: env ready, opt level " + std::to_string(opt) + "\n");
 
         {
             Ort::SessionOptions so;
-            so.SetGraphOptimizationLevel(ORT_DISABLE_ALL); // the op itself, not a rewrite
+            so.SetGraphOptimizationLevel(opt);
             Ort::Session cpu(env, utf8_to_wstring(model_path).c_str(), so);
             log_output("[xllama] oprepro: CPU session created\n");
             write_f32_file(resolve_local_path("repro-out-cpu.bin"), run_once(cpu, payload));
@@ -185,7 +207,7 @@ void run_oprepro() {
             Ort::SessionOptions so;
             so.SetExecutionMode(ORT_SEQUENTIAL);
             so.DisableMemPattern();
-            so.SetGraphOptimizationLevel(ORT_DISABLE_ALL);
+            so.SetGraphOptimizationLevel(opt);
             Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_DML(so, 0));
             Ort::Session dml(env, utf8_to_wstring(model_path).c_str(), so);
             log_output("[xllama] oprepro: DML session created\n");

--- a/uwp/op-repro.cpp
+++ b/uwp/op-repro.cpp
@@ -1,0 +1,203 @@
+// op-repro.cpp — single-op CPU-vs-DML repro runner (#111).
+//
+// Purpose: isolate suspected-broken DML kernels (first target: the
+// (Skip)SimplifiedLayerNormalization -> DML MVN2 UseMean=false path behind
+// #91) with the smallest possible on-device experiment: one ONNX model, one
+// fixed input payload, the same forward pass on the CPU EP and on the DML EP,
+// raw outputs pulled back to the host for diffing.
+//
+// Contract (all files in LocalState, driven by scripts/validate-op-repro.sh):
+//   oprepro.flag       -> triggers this mode at launch (consumed by App.cpp)
+//   repro.onnx         -> model with STATIC input shapes only
+//   repro-input.bin    -> fp32 payload: model inputs concatenated in session
+//                         input order; converted per-tensor to the input dtype
+//                         (fp16 or fp32)
+//   repro-out-cpu.bin  -> all outputs of the CPU run, fp32, concatenated
+//   repro-out-dml.bin  -> same for the DML run
+//   repro.done         -> "ok" or "error:<message>"
+
+#include "inference-bridge.h"
+
+#ifdef XLLAMA_UWP
+
+// clang-format off
+    #include <windows.h>
+    #include <onnxruntime_cxx_api.h>
+    #include <dml_provider_factory.h>
+// clang-format on
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "xllama/diffusion/half.h"
+#include "xllama/path_utils.h"
+#include "xllama/platform.h"
+#include "xllama/utf8_utils.h"
+
+namespace xllama::bridge {
+
+namespace {
+
+std::vector<float> read_f32_file(const std::string& path) {
+    std::vector<float> out;
+    FILE* fp = _wfopen(utf8_to_wstring(path).c_str(), L"rb");
+    if (!fp)
+        return out;
+    fseek(fp, 0, SEEK_END);
+    long bytes = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+    out.resize(static_cast<size_t>(bytes) / sizeof(float));
+    if (fread(out.data(), 1, static_cast<size_t>(bytes), fp) != static_cast<size_t>(bytes))
+        out.clear();
+    fclose(fp);
+    return out;
+}
+
+void write_f32_file(const std::string& path, const std::vector<float>& data) {
+    FILE* fp = _wfopen(utf8_to_wstring(path).c_str(), L"wb");
+    if (!fp)
+        return;
+    fwrite(data.data(), sizeof(float), data.size(), fp);
+    fclose(fp);
+}
+
+void write_done(const std::string& msg) {
+    FILE* fp = _wfopen(utf8_to_wstring(resolve_local_path("repro.done")).c_str(), L"w");
+    if (fp) {
+        fputs(msg.c_str(), fp);
+        fclose(fp);
+    }
+}
+
+// Run repro.onnx once on the given session: slice the fp32 payload across the
+// model inputs (converting to fp16 where the input dtype asks for it) and
+// return every output converted to fp32, concatenated in output order.
+std::vector<float> run_once(Ort::Session& session, const std::vector<float>& payload) {
+    Ort::AllocatorWithDefaultOptions alloc;
+    Ort::MemoryInfo mem = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+
+    const size_t n_in = session.GetInputCount();
+    std::vector<Ort::AllocatedStringPtr> in_name_holders;
+    std::vector<const char*> in_names;
+    std::vector<Ort::Value> in_values;
+    // Keep converted fp16 buffers alive until Run().
+    std::vector<std::vector<uint16_t>> half_buffers;
+    std::vector<std::vector<float>> float_buffers;
+
+    size_t cursor = 0;
+    for (size_t i = 0; i < n_in; ++i) {
+        in_name_holders.push_back(session.GetInputNameAllocated(i, alloc));
+        in_names.push_back(in_name_holders.back().get());
+
+        auto info = session.GetInputTypeInfo(i).GetTensorTypeAndShapeInfo();
+        auto shape = info.GetShape();
+        size_t count = 1;
+        for (int64_t d : shape) {
+            if (d <= 0)
+                throw std::runtime_error("repro.onnx must use static input shapes");
+            count *= static_cast<size_t>(d);
+        }
+        if (cursor + count > payload.size())
+            throw std::runtime_error("repro-input.bin shorter than the model inputs");
+
+        const ONNXTensorElementDataType dt = info.GetElementType();
+        if (dt == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
+            std::vector<uint16_t> half(count);
+            for (size_t k = 0; k < count; ++k)
+                half[k] = ::xllama::diffusion::float_to_half(payload[cursor + k]);
+            half_buffers.push_back(std::move(half));
+            in_values.push_back(Ort::Value::CreateTensor(
+                mem, half_buffers.back().data(), count * sizeof(uint16_t), shape.data(),
+                shape.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16));
+        } else if (dt == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT) {
+            float_buffers.emplace_back(payload.begin() + cursor,
+                                       payload.begin() + cursor + count);
+            in_values.push_back(Ort::Value::CreateTensor<float>(
+                mem, float_buffers.back().data(), count, shape.data(), shape.size()));
+        } else {
+            throw std::runtime_error("unsupported repro input dtype (want fp16/fp32)");
+        }
+        cursor += count;
+    }
+
+    const size_t n_out = session.GetOutputCount();
+    std::vector<Ort::AllocatedStringPtr> out_name_holders;
+    std::vector<const char*> out_names;
+    for (size_t i = 0; i < n_out; ++i) {
+        out_name_holders.push_back(session.GetOutputNameAllocated(i, alloc));
+        out_names.push_back(out_name_holders.back().get());
+    }
+
+    auto outputs = session.Run(Ort::RunOptions{nullptr}, in_names.data(), in_values.data(),
+                               n_in, out_names.data(), n_out);
+
+    std::vector<float> flat;
+    for (auto& out : outputs) {
+        auto info = out.GetTensorTypeAndShapeInfo();
+        const size_t count = info.GetElementCount();
+        if (info.GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
+            const auto* p = out.GetTensorData<uint16_t>();
+            auto conv = ::xllama::diffusion::from_half(p, count);
+            flat.insert(flat.end(), conv.begin(), conv.end());
+        } else {
+            const float* p = out.GetTensorData<float>();
+            flat.insert(flat.end(), p, p + count);
+        }
+    }
+    return flat;
+}
+
+} // namespace
+
+void run_oprepro() {
+    set_cwd_to_local_folder();
+    log_output("[xllama] oprepro: single-op CPU-vs-DML repro run\n");
+    try {
+        const std::string model_path = resolve_local_path("repro.onnx");
+        const std::vector<float> payload = read_f32_file(resolve_local_path("repro-input.bin"));
+        if (payload.empty())
+            throw std::runtime_error("repro-input.bin missing or empty");
+
+        Ort::Env env(ORT_LOGGING_LEVEL_ERROR, "oprepro");
+
+        {
+            Ort::SessionOptions so;
+            so.SetGraphOptimizationLevel(ORT_DISABLE_ALL); // the op itself, not a rewrite
+            Ort::Session cpu(env, utf8_to_wstring(model_path).c_str(), so);
+            write_f32_file(resolve_local_path("repro-out-cpu.bin"), run_once(cpu, payload));
+            log_output("[xllama] oprepro: CPU run done\n");
+        }
+        {
+            // Same shape as the diffusion sessions (diffuse.cpp make_session),
+            // with optimizations off so DML executes the recorded op as-is.
+            Ort::SessionOptions so;
+            so.SetExecutionMode(ORT_SEQUENTIAL);
+            so.DisableMemPattern();
+            so.SetGraphOptimizationLevel(ORT_DISABLE_ALL);
+            Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_DML(so, 0));
+            Ort::Session dml(env, utf8_to_wstring(model_path).c_str(), so);
+            write_f32_file(resolve_local_path("repro-out-dml.bin"), run_once(dml, payload));
+            log_output("[xllama] oprepro: DML run done\n");
+        }
+
+        write_done("ok");
+        log_output("[xllama] oprepro: done\n");
+    } catch (const Ort::Exception& e) {
+        log_output(std::string("[xllama] oprepro ORT error: ") + e.what() + "\n");
+        write_done(std::string("error:") + e.what());
+    } catch (const std::exception& e) {
+        log_output(std::string("[xllama] oprepro error: ") + e.what() + "\n");
+        write_done(std::string("error:") + e.what());
+    }
+}
+
+} // namespace xllama::bridge
+
+#else
+
+namespace xllama::bridge {
+void run_oprepro() {}
+} // namespace xllama::bridge
+
+#endif // XLLAMA_UWP

--- a/uwp/op-repro.cpp
+++ b/uwp/op-repro.cpp
@@ -95,7 +95,11 @@ std::vector<float> run_once(Ort::Session& session, const std::vector<float>& pay
         in_name_holders.push_back(session.GetInputNameAllocated(i, alloc));
         in_names.push_back(in_name_holders.back().get());
 
-        auto info = session.GetInputTypeInfo(i).GetTensorTypeAndShapeInfo();
+        // Keep the owning TypeInfo alive: GetTensorTypeAndShapeInfo() returns a
+        // non-owning view into it (a temporary here would dangle -> garbage
+        // shapes -> bad_alloc on the resize below).
+        Ort::TypeInfo type_info = session.GetInputTypeInfo(i);
+        auto info = type_info.GetTensorTypeAndShapeInfo();
         auto shape = info.GetShape();
         size_t count = 1;
         for (int64_t d : shape) {

--- a/uwp/xllama.vcxproj
+++ b/uwp/xllama.vcxproj
@@ -307,6 +307,7 @@
     <!-- cli.cpp uses POSIX getopt — Linux only, excluded from UWP target -->
     <ClCompile Include="inference-bridge.cpp" />
     <ClCompile Include="diffuse.cpp" />
+    <ClCompile Include="op-repro.cpp" />
   </ItemGroup>
 
   <!-- xllama UWP app -->


### PR DESCRIPTION
Kit diagnostico per #111 + esito della campagna repro.

## Contenuto
- `uwp/op-repro.cpp` + `oprepro.flag`: runner headless plain-ORT — stesso payload fp32 su sessione CPU e DML, livello di ottimizzazione da `LocalState\repro-opt.txt` (disable|basic|extended|all), output fp32 grezzi + marker. Riusabile per qualunque futura caccia a kernel DML.
- `scripts/make-op-repro.py` (single-op, `--scale`), `scripts/make-chain-repro.py` (stack decoder-shaped da 25 nodi), `scripts/validate-op-repro.sh` (driver per-variante, `OPT_LEVEL`/`TOLERANCE` da env).
- Sezione "Repro campaign" in `docs/dml-rmsnorm-fix-runbook.md` coi risultati.

## Esito (Series S, build 1.3.0.58x, 2026-07-19)

**Ogni probe plain-ORT MATCHA** (CPU-vs-DML NMSE ≤ 2e-06):

| probe | opt | esito |
|---|---|---|
| simplified / skip / layernorm single-op, scala 2 | disable + all | MATCH |
| idem scala 30 / 100 (Σx² ≫ fp16 max) | disable | MATCH |
| catena 25 nodi (LN→MatMul→skip residual ×8, eps/shape reali) | disable + extended + all | MATCH |

→ Il kernel `(Skip)SimplifiedLayerNormalization` (MVN2 `UseMean=false`) è **corretto in isolamento** su questo driver, incluso il path di fusione DML_GRAPH. La corruzione (#91, NMSE 0.98) si manifesta **solo nel contesto runtime ORT-GenAI DML** — dove la decomposizione dei soli nodi RMSNorm la elimina (PR #108/#112). Il fix prodotto (graph surgery) resta quello giusto; l'eventuale fix upstream va cercato nell'interazione GenAI-DML, non nel kernel standalone.

Gotcha C++ documentati nel runbook: lifetime di `Ort::TypeInfo` vs la vista `GetTensorTypeAndShapeInfo()`, reserve dei buffer wrappati in `Ort::Value`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tools to generate reproducible normalization and decoder-chain test models.
  - Added automated CPU-versus-GPU validation for comparing outputs across supported Xbox execution environments.
  - Added a headless repro workflow for running targeted model tests without launching the full application.

- **Documentation**
  - Expanded the troubleshooting runbook with device-specific findings, validation results, repro guidance, and execution considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->