### PR TITLE
docs: refresh post-v1.4.0.0 state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ the "same identity, different contents" install block. Local builds leave `.0`.
 
 - **ORT GenAI path**: UWP inference is entirely under `#ifdef XLLAMA_USE_ORT` in `src/bridge/inference.cpp`. ORT types are wrapped in `include/xllama/ort_raii.h`. Linux path (`#else`) uses llama.cpp unchanged.
 
-- **No model in the MSIX**: the package is ~19 MB and ships no model. On first launch the app downloads the default chat model (`lfm25-350m` on unified builds; `smollm2-360m-cpu-int4` on ORT-only) from the GitHub Release `models-v1` catalogue (`uwp/models/manifest.json`) into `LocalState\models\`. Routing GPU (`smollm2-360m-dml-fp16`) is also on `models-v1` but is not auto-provisioned while #91 holds. Current console gate: `./scripts/validate-console.sh all`.
+- **No model in the MSIX**: the package is ~19 MB and ships no model. On first launch the app downloads the default chat model (`lfm25-350m` on unified builds; `smollm2-360m-cpu-int4` on ORT-only) from the GitHub Release `models-v1` catalogue (`uwp/models/manifest.json`) into `LocalState\models\`. Routing GPU (`smollm2-360m-dml-fp16-v2`, the #91 parity-validated graph) auto-downloads from `models-v1` when GPU routing is enabled. Current console gate: `./scripts/validate-console.sh all`.
 
 - **Shipping CI**: `build-uwp.yml` publishes `xllama-appx` as **unified + PatchedGenAI #2280 + PatchedOrt** (cached `onnxruntime.dll` + `onnxruntime-genai.dll` from `vendor-dlls-v1`; hashes in `vendor/onnxruntime-patched/SHA256SUMS` and `vendor/onnxruntime-genai-patched/SHA256SUMS`). `llamacpp` lane is bench-only. Rebuild from source only for pin refresh: `build-uwp-ort-patched.yml` (ORT, 1–3 h) / `build-uwp-patched.yml` (GenAI). Poll whether pins can drop: `scripts/check-vendor-nuget-status.sh`.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,8 +5,8 @@ performance belongs in `docs/benchmarks.md`.
 
 ## Current product state
 
-- Latest published release: **v1.3.0.0** (MSIX 1.3.0.560 — expanded product UI
-  and experimental Lane B on-device training).
+- Latest published release: **v1.4.0.0** (MSIX 1.4.0.588 — GPU text routing
+  re-enabled on the `-v2` DML asset, #91 root cause fixed).
 - Shipping artifact: unified ORT GenAI + llama.cpp, with pinned patched runtime
   DLLs while upstream fixes have not reached NuGet.
 - Default chat: `lfm25-350m`; balanced and quality tiers: LFM2.5-1.2B and

--- a/docs/technical-report.md
+++ b/docs/technical-report.md
@@ -50,18 +50,21 @@ Three hypotheses died against these numbers:
    66.3); the crossover exists only in prefill, where batch amortises dispatch
    (1.8× at ~1k tokens). The app therefore routes per-workload (long-prompt
    conversations → DML fp16, decode → CPU int4), sticky per conversation.
-   **Superseded by #91 (2026-07-16): DML text routing is disabled.** The logit-
-   parity harness showed the DML attention path computes numerically wrong
-   logits on the Series S GPU — GQA **and** MultiHeadAttention alike (NMSE ~1
-   vs the CPU reference, top-1 disagrees; fp16 AND int4; invariant to
-   graph/session/capture options; the same weights are correct on CPU EP and
-   on desktop-class CPU runs; SD-Turbo — decomposed attention, no contrib ops —
-   is correct on the same device). All tok/s numbers above are real, but the
-   GPU text output they measured was silently degraded. Text routing is forced
-   to CPU (`routing_policy.h kDmlTextLogitsBroken`) until
-   `scripts/validate-logit-parity.sh` passes on a DML text model, and the
-   GPU model is no longer auto-provisioned (#95). Diffusion routing is
-   unaffected. Upstream: microsoft/onnxruntime#29739 (driver),
+   **#91 interlude (2026-07-16 → 2026-07-19).** The logit-parity harness
+   showed the DML text path computes numerically wrong logits on the Series S
+   GPU (NMSE ~1 vs the CPU reference, top-1 disagrees; fp16 AND int4;
+   invariant to graph/session/capture options; the same weights are correct
+   on CPU EP and on desktop-class CPU runs), and text routing was force-gated
+   to CPU while three investigations chased the attention kernels. The real
+   culprit was the DML `(Skip)SimplifiedLayerNormalization` (RMSNorm)
+   lowering in the GenAI-DML context — attention was innocent — and the fix
+   is data-only: the `smollm2-360m-dml-fp16-v2` asset ships those 65 nodes
+   decomposed into primitives and passes `scripts/validate-logit-parity.sh`
+   (NMSE 1.72e-02, top-10 overlap 1.00). Routing is live again behind the
+   `dml_text_model_ok` per-model allowlist (`routing_policy.h`); diffusion
+   routing was never affected. Full postmortem:
+   `docs/dml-rmsnorm-fix-runbook.md`. Upstream:
+   microsoft/onnxruntime#29739 (kernel report),
    microsoft/onnxruntime-genai#2300 (capture opt-out tooling).
 2. **"DML int4 decode collapses because a kernel is missing."** Falsified by
    desk-check and confirmed on hardware: `MatMulNBits` _is_ on the GPU (compute


### PR DESCRIPTION
Aligns the three spots that still described the pre-release state:

- **ROADMAP**: latest published release is now v1.4.0.0 (MSIX 1.4.0.588) — the line pending since release day.
- **docs/technical-report.md**: the hypothesis-1 interlude still said DML text routing is disabled and blamed the attention path; replaced with the resolved #91 arc (RMSNorm culprit, `-v2` data-only fix, `dml_text_model_ok` allowlist, parity numbers, runbook pointer).
- **AGENTS.md**: `gpu_model` asset reference updated to `smollm2-360m-dml-fp16-v2` (auto-downloads when routing is enabled) instead of "not auto-provisioned while #91 holds".

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for GPU text routing to reflect automatic download of the validated `-v2` model asset.
  * Documented that GPU text routing has been re-enabled after resolving the underlying compatibility issue.
  * Updated the roadmap to list version 1.4.0.0 as the latest release.
  * Clarified that diffusion routing remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->