### PR TITLE
docs: ROADMAP Phase 11 — headless↔UI gap arc

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,6 +79,21 @@ pin constraints: [`docs/training-architecture.md`](docs/training-architecture.md
 - [ ] Widen the trainable filter beyond the last block when the llama.cpp pin
       gains backward support for the KV-cache `set_rows` write (or carry a patch).
 
+## Phase 11 — Close the headless ↔ UI gap (planned, blocked on Phase 10 gates)
+
+Gap analysis 2026-07-20: the training loop is half-invisible (UI captures
+preferences, but launch/progress/serving of the fine-tuned model are
+headless-only), and the test/API surfaces trail the UI.
+
+- [ ] In-app personalization arc: trigger training from Settings, surface
+      progress, serve `merged.gguf` from the model picker (#116) — after the
+      `DeviceGgmlPartialFt` flip.
+- [ ] Autopilot ops for routing / sampling / KV-reuse so the harness exercises
+      the real UI code paths (#117); console validation queued behind the
+      Phase 10 console gate.
+- [ ] LAN API parity (images, preferences, training status) — #118, low
+      priority while the API remains a demo.
+
 ## Upstream and vendor lifecycle
 
 Operational details live in `docs/vendor-lifecycle-plan.md`.


### PR DESCRIPTION
Adds the planned Phase 11 section from the 2026-07-20 gap analysis: in-app personalization loop (#116), autopilot settings ops (#117), LAN API parity (#118). Blocked-on relationships stated inline (Phase 10 gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase 11 to the roadmap, focused on closing the gap between headless workflows and the user interface.
  * Documented planned improvements for personalization, training progress, model serving, autopilot workflows, and LAN API support.
  * Added a gap analysis covering current UI visibility and headless-only capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->