### PR TITLE
test(#117): autopilot ops set_routing / set_sampling / set_kv_reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   3 GB gate), wall 446 s, marker reproduced end-to-end (prepare → train →
   export → merge → evaluate). Evidence:
   `bench/results/phase10-console-devtrain-result.json`.
+- **Autopilot ops for preferences: `set_routing`, `set_sampling`,
+  `set_kv_reuse`.** The Settings dialog is unreachable on a Dev Mode console
+  (no text input path), so these preferences had no automated coverage. The
+  three ops drive the real controller state and persist through
+  `SaveSettings()`. New `validate-console.sh settings` gate seeds a known
+  baseline, replays the ops and asserts all seven values in `settings.json`
+  (validated on Xbox Series S, MSIX 1.4.0.606).
 
 ### Fixed
 

--- a/include/xllama/training_params.h
+++ b/include/xllama/training_params.h
@@ -52,7 +52,7 @@ enum class TrainingCapability {
     RuntimeAdapterLoadOrtGenAI, // OgaLoadAdapter — designed; DML blocked on pin
     DeviceOrtOnDeviceTraining,  // ORT ODT package — research
     DeviceLlamaFinetune,        // llama-finetune full FT — rejected (RAM class)
-    DeviceGgmlPartialFt,        // in-process ggml-opt partial FT — experimental
+    DeviceGgmlPartialFt,        // in-process ggml-opt partial FT — available (Lane B gates PASS)
     DevicePreferenceCapture,    // LocalState JSONL — available
 };
 

--- a/include/xllama/training_params.h
+++ b/include/xllama/training_params.h
@@ -52,7 +52,8 @@ enum class TrainingCapability {
     RuntimeAdapterLoadOrtGenAI, // OgaLoadAdapter — designed; DML blocked on pin
     DeviceOrtOnDeviceTraining,  // ORT ODT package — research
     DeviceLlamaFinetune,        // llama-finetune full FT — rejected (RAM class)
-    DeviceGgmlPartialFt,        // in-process ggml-opt partial FT — available (Lane B gates PASS)
+    DeviceGgmlPartialFt,        // in-process ggml-opt partial FT — available when
+                                // XLLAMA_DEVICE_TRAIN is on (Lane B gates PASS), else designed
     DevicePreferenceCapture,    // LocalState JSONL — available
 };
 

--- a/scripts/validate-console.sh
+++ b/scripts/validate-console.sh
@@ -4,10 +4,11 @@
 #
 # Usage:
 #   source ~/.config/xllama/xbox-env
-#   ./scripts/validate-console.sh <routing|gguf|taesd|all>
+#   ./scripts/validate-console.sh <routing|settings|gguf|taesd|all>
 #
-# Requires: an installed xllama build with the autopilot (>= 1.1.3.0), the
-# relevant models already in LocalState (smollm2-360m-cpu-int4 for routing —
+# Requires: an installed xllama build with the autopilot (>= 1.1.3.0; the
+# settings ops need >= 1.4.0.606), the relevant models already in LocalState
+# (smollm2-360m-cpu-int4 for routing and settings —
 # the #91 gate forces CPU, so the dml-fp16 model is not needed nor provisioned
 # while it holds (#95) — lfm25-350m for gguf, sd-turbo-fp16 for taesd), and
 # XBOX_IP/USER/PASS env. Seed with scripts/provision-models.sh.
@@ -413,11 +414,113 @@ PY
 	return $verdict
 }
 
+# --- settings ops (routing / sampling / KV-reuse) --------------------------
+
+# The Settings dialog is unreachable in Dev Mode (no text input, #117), so the
+# only way to prove the three preference writers work end-to-end is to drive
+# them through the autopilot and read back the persisted settings.json.
+#
+# Deliberately separate from §2 routing: that gate seeds settings.json as a file
+# upload and asserts on routing *behaviour*; this one asserts that the in-app
+# ops actually mutate and persist state.
+validate_settings() {
+	echo "=== settings ops (set_routing / set_sampling / set_kv_reuse) ==="
+	if ! model_provisioned "smollm2-360m-cpu-int4"; then
+		echo "  FAIL: smollm2-360m-cpu-int4 is not in LocalState\\models\\"
+		echo "  Seed it first:  ./scripts/provision-models.sh smollm2-360m-cpu-int4"
+		echo "settings ops: FAIL"
+		return 1
+	fi
+	# Seed a baseline that differs from every target value below, so each op has
+	# to do real work — a no-op would leave the baseline behind and fail.
+	cat >"${TMPDIR_LOCAL}/settings.json" <<'JSON'
+{
+  "system_prompt": "You are a helpful AI assistant.",
+  "model": "smollm2-360m-cpu-int4",
+  "kv_reuse": true,
+  "routing": 2,
+  "gpu_model": "smollm2-360m-dml-fp16-v2",
+  "diffuse_taesd_vae": false,
+  "sampling": {"temperature": 0.8, "top_p": 0.9, "top_k": 40, "repetition_penalty": 1.1, "n_predict": 256}
+}
+JSON
+	upload_file "${TMPDIR_LOCAL}/settings.json"
+
+	local marker
+	marker=$(
+		run_autopilot 300 <<'JSON'
+{"total_timeout_s": 120, "actions": [
+  {"op": "set_routing", "routing": 0},
+  {"op": "set_sampling", "temperature": 0.55, "top_p": 0.8, "top_k": 20, "repetition_penalty": 1.25, "n_predict": 128},
+  {"op": "set_kv_reuse", "enabled": false},
+  {"op": "quit"}
+]}
+JSON
+	) || true
+	echo "  autopilot: ${marker}"
+	local log verdict=0
+	log=$(fetch_log)
+	[[ "$marker" == "ok" ]] || {
+		echo "  FAIL: autopilot did not finish ok"
+		verdict=1
+	}
+	local op
+	for op in set_routing set_sampling set_kv_reuse; do
+		if grep -aq "\[autopilot\] action .* ${op} end" "$log"; then
+			echo "  ok: ${op} dispatched"
+		else
+			echo "  FAIL: no '${op} end' line in the log"
+			verdict=1
+		fi
+	done
+
+	# Read back the persisted state — the ops call SaveSettings(), so every
+	# target value must be on disk after the app has quit.
+	fetch_file "settings.json" "${TMPDIR_LOCAL}/settings-after.json"
+	if ! python3 - "${TMPDIR_LOCAL}/settings-after.json" <<'PY'; then
+import json, sys
+try:
+    s = json.load(open(sys.argv[1]))
+except Exception as e:
+    print(f"  FAIL: settings.json unreadable after the run: {e}")
+    sys.exit(1)
+smp = s.get("sampling", {})
+# kind: "exact" for bool/int (identity-strict for bools), "near" for floats
+# (settings.json is written with %.2f, so compare with a tolerance).
+want = [
+    ("routing", s.get("routing"), 0, "exact"),
+    ("kv_reuse", s.get("kv_reuse"), False, "exact"),
+    ("temperature", smp.get("temperature"), 0.55, "near"),
+    ("top_p", smp.get("top_p"), 0.8, "near"),
+    ("top_k", smp.get("top_k"), 20, "exact"),
+    ("repetition_penalty", smp.get("repetition_penalty"), 1.25, "near"),
+    ("n_predict", smp.get("n_predict"), 128, "exact"),
+]
+rc = 0
+for name, got, exp, kind in want:
+    if kind == "exact":
+        ok = type(got) is type(exp) and got == exp
+    else:
+        ok = isinstance(got, (int, float)) and not isinstance(got, bool) \
+            and abs(got - exp) < 1e-4
+    print(f"  {'ok' if ok else 'FAIL'}: {name} = {got!r} (want {exp!r})")
+    if not ok:
+        rc = 1
+sys.exit(rc)
+PY
+		verdict=1
+	fi
+
+	[[ $verdict -eq 0 ]] && echo "settings ops: PASS" || echo "settings ops: FAIL"
+	return $verdict
+}
+
 # --- dispatch --------------------------------------------------------------
 
 CMD="${1:-}"
 case "$CMD" in
 routing) validate_routing ;;
+settings) validate_settings ;;
 gguf) validate_gguf ;;
 taesd) validate_taesd ;;
 all)
@@ -426,6 +529,7 @@ all)
 		echo "  WARN: smollm2-360m-cpu-int4 missing — launch the app once for catalogue download"
 	fi
 	validate_routing || rc=1
+	validate_settings || rc=1
 	validate_gguf || rc=1
 	validate_taesd || rc=1
 	echo
@@ -434,7 +538,7 @@ all)
 	exit $rc
 	;;
 *)
-	echo "Usage: $0 <routing|gguf|taesd|all>" >&2
+	echo "Usage: $0 <routing|settings|gguf|taesd|all>" >&2
 	exit 1
 	;;
 esac

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -2513,6 +2513,7 @@ bool MainPageController::ApParseScript(const std::string& json_utf8, std::vector
         }
         a.steps = (int)obj.GetNamedNumber(L"steps", 1);
         a.seed = (unsigned)obj.GetNamedNumber(L"seed", 42);
+        a.has_enabled = obj.HasKey(L"enabled");
         a.enabled = obj.GetNamedBoolean(L"enabled", false);
         a.port = (int)obj.GetNamedNumber(L"port", 11434);
         a.routing = (int)obj.GetNamedNumber(L"routing", -1);
@@ -2688,6 +2689,12 @@ void MainPageController::ApRun(std::vector<ApAction> actions, std::chrono::secon
                 throw std::runtime_error("action " + std::to_string(i) +
                                          " set_sampling: no sampling key (temperature/top_p/top_k/"
                                          "repetition_penalty/n_predict)");
+            // The other keys degrade safely downstream (temperature <= 0 falls back to
+            // greedy, top_k <= 0 disables filtering, repetition_penalty <= 0 is skipped,
+            // n_predict is capped), but top_p outside (0, 1] violates the GenAI contract.
+            if (a.top_p >= 0 && !(a.top_p > 0.0 && a.top_p <= 1.0))
+                throw std::runtime_error("action " + std::to_string(i) +
+                                         " set_sampling: 'top_p' must be in (0, 1]");
             ApDispatchSync([this, &a]() {
                 if (a.temperature >= 0)
                     m_temperature = (float)a.temperature;
@@ -2702,6 +2709,11 @@ void MainPageController::ApRun(std::vector<ApAction> actions, std::chrono::secon
                 SaveSettings();
             });
         } else if (a.op == "set_kv_reuse") {
+            // Require the key: 'enabled' defaults to false, so a typo'd or missing
+            // key would silently assert "KV reuse off" and pass.
+            if (!a.has_enabled)
+                throw std::runtime_error("action " + std::to_string(i) +
+                                         " set_kv_reuse: 'enabled' (bool) is required");
             ApDispatchSync([this, on = a.enabled]() {
                 m_kv_reuse = on;
                 SaveSettings();

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -2685,10 +2685,9 @@ void MainPageController::ApRun(std::vector<ApAction> actions, std::chrono::secon
         } else if (a.op == "set_sampling") {
             if (a.temperature < 0 && a.top_p < 0 && a.top_k < 0 && a.repetition_penalty < 0 &&
                 a.n_predict < 0)
-                throw std::runtime_error(
-                    "action " + std::to_string(i) +
-                    " set_sampling: no sampling key (temperature/top_p/top_k/"
-                    "repetition_penalty/n_predict)");
+                throw std::runtime_error("action " + std::to_string(i) +
+                                         " set_sampling: no sampling key (temperature/top_p/top_k/"
+                                         "repetition_penalty/n_predict)");
             ApDispatchSync([this, &a]() {
                 if (a.temperature >= 0)
                     m_temperature = (float)a.temperature;

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -2515,6 +2515,12 @@ bool MainPageController::ApParseScript(const std::string& json_utf8, std::vector
         a.seed = (unsigned)obj.GetNamedNumber(L"seed", 42);
         a.enabled = obj.GetNamedBoolean(L"enabled", false);
         a.port = (int)obj.GetNamedNumber(L"port", 11434);
+        a.routing = (int)obj.GetNamedNumber(L"routing", -1);
+        a.temperature = obj.GetNamedNumber(L"temperature", -1);
+        a.top_p = obj.GetNamedNumber(L"top_p", -1);
+        a.top_k = (int)obj.GetNamedNumber(L"top_k", -1);
+        a.repetition_penalty = obj.GetNamedNumber(L"repetition_penalty", -1);
+        a.n_predict = (int)obj.GetNamedNumber(L"n_predict", -1);
         int t = (int)obj.GetNamedNumber(L"timeout_s", 0);
         a.timeout = std::chrono::seconds(t);
         out.push_back(std::move(a));
@@ -2666,6 +2672,41 @@ void MainPageController::ApRun(std::vector<ApAction> actions, std::chrono::secon
                 (!a.enabled && state != ::xllama::api::ServerState::Stopped))
                 throw std::runtime_error("action " + std::to_string(i) +
                                          " set_api: lifecycle timeout");
+        } else if (a.op == "set_routing") {
+            // Same semantics as the Settings panel: per-conversation, applies from
+            // the next new/loaded chat (m_active_model stays sticky meanwhile).
+            if (a.routing < 0 || a.routing > 2)
+                throw std::runtime_error("action " + std::to_string(i) +
+                                         " set_routing: 'routing' must be 0..2");
+            ApDispatchSync([this, r = a.routing]() {
+                m_routing = r;
+                SaveSettings();
+            });
+        } else if (a.op == "set_sampling") {
+            if (a.temperature < 0 && a.top_p < 0 && a.top_k < 0 && a.repetition_penalty < 0 &&
+                a.n_predict < 0)
+                throw std::runtime_error(
+                    "action " + std::to_string(i) +
+                    " set_sampling: no sampling key (temperature/top_p/top_k/"
+                    "repetition_penalty/n_predict)");
+            ApDispatchSync([this, &a]() {
+                if (a.temperature >= 0)
+                    m_temperature = (float)a.temperature;
+                if (a.top_p >= 0)
+                    m_top_p = (float)a.top_p;
+                if (a.top_k >= 0)
+                    m_top_k = a.top_k;
+                if (a.repetition_penalty >= 0)
+                    m_repetition_penalty = (float)a.repetition_penalty;
+                if (a.n_predict >= 0)
+                    m_n_predict = a.n_predict;
+                SaveSettings();
+            });
+        } else if (a.op == "set_kv_reuse") {
+            ApDispatchSync([this, on = a.enabled]() {
+                m_kv_reuse = on;
+                SaveSettings();
+            });
         } else if (a.op == "generate_image") {
             if (!not_running())
                 throw std::runtime_error("action " + std::to_string(i) + " generate_image: busy");

--- a/uwp/MainPage.h
+++ b/uwp/MainPage.h
@@ -52,6 +52,8 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
         int steps{1};     // generate_image
         unsigned seed{42};
         bool enabled{false};             // set_api / set_kv_reuse
+        bool has_enabled{false};         // 'enabled' was present (set_kv_reuse requires it:
+                                         // the default would silently mean "disable")
         int port{11434};                 // set_api
         int routing{-1};                 // set_routing (0=CPU, 1=GPU, 2=auto)
         double temperature{-1};          // set_sampling; negative = leave unchanged

--- a/uwp/MainPage.h
+++ b/uwp/MainPage.h
@@ -46,12 +46,19 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
   private:
     // One parsed autopilot action (see ApParseScript in MainPage.cpp).
     struct ApAction {
-        std::string op;   // load_chat|send|new_chat|set_model|set_api|generate_image|rate|quit
+        std::string op;   // load_chat|send|new_chat|set_model|set_api|set_routing|set_sampling|
+                          // set_kv_reuse|generate_image|rate|quit
         std::wstring arg; // id / text / model name / image prompt / rate label
         int steps{1};     // generate_image
         unsigned seed{42};
-        bool enabled{false};             // set_api
+        bool enabled{false};             // set_api / set_kv_reuse
         int port{11434};                 // set_api
+        int routing{-1};                 // set_routing (0=CPU, 1=GPU, 2=auto)
+        double temperature{-1};          // set_sampling; negative = leave unchanged
+        double top_p{-1};                //
+        int top_k{-1};                   //
+        double repetition_penalty{-1};   //
+        int n_predict{-1};               //
         std::chrono::seconds timeout{0}; // 0 = per-op default
     };
     static bool ApParseScript(const std::string& json_utf8, std::vector<ApAction>& out,


### PR DESCRIPTION
Adds the three missing Settings ops to the autopilot driver so the harness can exercise the real UI code paths instead of mutating `settings.json` via Device Portal (#117):

- `{"op": "set_routing", "routing": 0|1|2}` — per-conversation, applies from the next new/loaded chat (same semantics as the panel)
- `{"op": "set_sampling", ...}` — any of `temperature` / `top_p` / `top_k` / `repetition_penalty` / `n_predict`; at least one required, absent keys unchanged
- `{"op": "set_kv_reuse", "enabled": bool}`

All three go through `SaveSettings()` like the panel's Save handler (which also invalidates the KV cache).

**Draft until console-validated**: the installed 1.4.0.588 must not be replaced before the Phase 10 Lane B console gate evidence is collected; will validate these ops on-device right after, then adopt them in `validate-console.sh` §2 (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added autopilot controls for routing, sampling parameters, and KV-cache reuse.
  * Settings changed through autopilot actions are saved for future chats.
  * Added validation support for confirming persisted settings values.

* **Documentation**
  * Updated the training capability status to indicate partial fine-tuning is available.
  * Documented the new autopilot settings operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->