### PR TITLE
docs: clear Lane B drift — DeviceGgmlPartialFt available everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 ## What is this
 
-`xllama` is a UWP application for Xbox Series S|X in Dev Mode that runs LLM chat and Stable-Diffusion image generation locally, with no cloud dependency and a gamepad-friendly UI. It also includes an opt-in, OpenAI-compatible [LAN endpoint](./docs/api-endpoint.md) and a dual-lane [training/personalization pillar](./docs/training-architecture.md): host PEFT LoRA plus an experimental in-process partial fine-tune that runs fully on the console (ggml-opt Lane B).
+`xllama` is a UWP application for Xbox Series S|X in Dev Mode that runs LLM chat and Stable-Diffusion image generation locally, with no cloud dependency and a gamepad-friendly UI. It also includes an opt-in, OpenAI-compatible [LAN endpoint](./docs/api-endpoint.md) and a dual-lane [training/personalization pillar](./docs/training-architecture.md): host PEFT LoRA plus an in-process partial fine-tune that runs fully on the console (ggml-opt Lane B, host + console gates PASS).
 
 The project started as a port of [`llama.cpp`](https://github.com/ggml-org/llama.cpp) (GGUF files, CPU-only), then migrated to **ONNX Runtime GenAI + DirectML**. The measured verdict is **per-workload** (see [docs/technical-report.md](./docs/technical-report.md)): the Zen 2 **CPU wins autoregressive decode** at this model scale (~66 tok/s, SmolLM2-360M int4), the RDNA 2 **GPU wins batch compute** — prefill at ~1k prompt tokens (1.8× faster) and image generation (**11.1×** on the diffusion workload: SD-Turbo 512×512 in ~7 s). GPU **text** routing is enabled for the parity-validated `smollm2-360m-dml-fp16-v2` asset only ([#91](https://github.com/gianlucamazza/xllama/issues/91): the DML `(Skip)SimplifiedLayerNormalization` kernel computes wrong results on the Series S GPU — fixed by decomposing those nodes into primitives, a data-only graph fix; see [docs/dml-rmsnorm-fix-runbook.md](./docs/dml-rmsnorm-fix-runbook.md)); diffusion stays on the GPU. The llama.cpp path serves Linux development, CI, and — in the `unified` UWP build — modern GGUF-only models (Qwen3.5, LFM2.5); for the same model, ORT stays the text backend (measured decode parity, better prefill).
 
@@ -40,7 +40,7 @@ The default chat model on the shipping **unified** build is **LFM2.5-350M Q4_K_M
 The LAN endpoint is experimental, unauthenticated, foreground-only and disabled
 by default. Personalization is operator-driven: preference samples remain in
 the AppContainer until explicitly pulled to a host for retraining — or consumed
-on-device by a Lane B `partial_ft` job (experimental, gates pending).
+on-device by a Lane B `partial_ft` job (available, host + console gates PASS).
 
 Goals:
 
@@ -324,8 +324,9 @@ See [ROADMAP.md](./ROADMAP.md). Headlines:
    and console validation are frozen complete.
 9. **Phase 9 — Personalization ops** ✅ Operator pull/retrain/publish loop
    and per-response preference UI delivered. See [ROADMAP.md](./ROADMAP.md).
-10. **Phase 10 — Device partial FT** 🧪 Experimental ggml-opt Lane B;
-    host and console marker gates are pending.
+10. **Phase 10 — Device partial FT** ✅ ggml-opt Lane B; host + console marker
+    gates PASS (Xbox Series S: peak_ws 1195 MB, marker reproduced) —
+    `DeviceGgmlPartialFt` available.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,18 +86,18 @@ pin constraints: [`docs/training-architecture.md`](docs/training-architecture.md
 - [ ] Widen the trainable filter beyond the last block when the llama.cpp pin
       gains backward support for the KV-cache `set_rows` write (or carry a patch).
 
-## Phase 11 — Close the headless ↔ UI gap (planned, blocked on Phase 10 gates)
+## Phase 11 — Close the headless ↔ UI gap (planned; Phase 10 gates now PASS, unblocked)
 
 Gap analysis 2026-07-20: the training loop is half-invisible (UI captures
 preferences, but launch/progress/serving of the fine-tuned model are
 headless-only), and the test/API surfaces trail the UI.
 
 - [ ] In-app personalization arc: trigger training from Settings, surface
-      progress, serve `merged.gguf` from the model picker (#116) — after the
-      `DeviceGgmlPartialFt` flip.
+      progress, serve `merged.gguf` from the model picker (#116) — now unblocked
+      (the `DeviceGgmlPartialFt` flip landed).
 - [ ] Autopilot ops for routing / sampling / KV-reuse so the harness exercises
-      the real UI code paths (#117); console validation queued behind the
-      Phase 10 console gate.
+      the real UI code paths (#117, PR #120 draft); console validation unblocked
+      now that the Phase 10 console gate has passed.
 - [ ] LAN API parity (images, preferences, training status) — #118, low
       priority while the API remains a demo.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,8 +27,8 @@ The shared core is platform-agnostic C++17; front-ends are thin:
 - **Host front-ends** — `xllama-cli` (inference + `--validate-train-job` /
   `--train-job`), doctest suite, `training/host/` PEFT runner.
 - **UWP app** (`uwp/`) — inference UI and headless bench/diffuse/membw/train
-  drivers. The llamacpp/unified variants compile the experimental ggml-opt
-  partial-FT engine; it is not part of the chat hot path.
+  drivers. The llamacpp/unified variants compile the ggml-opt partial-FT
+  engine (Lane B, gates PASS); it is not part of the chat hot path.
 
 Header modules (`include/xllama/`), all WinRT-free so they are host-testable:
 
@@ -180,7 +180,7 @@ First-class subsystem for **learning adapters and producing loadable weights**.
 │ TrainingJob (A or B)    │ ─────────────────► │ Inference Session        │
 │ host PEFT / partial FT  │                    │ Lane C serve             │
 └─────────────────────────┘                    └──────────────────────────┘
- Lane B = experimental last-block ggml-opt partial FT; console PASS pending
+ Lane B = last-block ggml-opt partial FT; host + console gates PASS (available)
 ```
 
 ### Contracts (C++)
@@ -194,11 +194,11 @@ First-class subsystem for **learning adapters and producing loadable weights**.
 
 ### Capability headline (see SSOT for full RE)
 
-| Lane                    | Status today                                                                |
-| ----------------------- | --------------------------------------------------------------------------- |
-| **A Host PEFT + merge** | **Available** (marker job PASS)                                             |
-| **B Device partial FT** | **Experimental** in llamacpp/unified builds; host and console gates pending |
-| **C Serve merged GGUF** | **Available**; runtime LoRA via `SessionParams.lora_path` / CLI `--lora`    |
+| Lane                    | Status today                                                               |
+| ----------------------- | -------------------------------------------------------------------------- |
+| **A Host PEFT + merge** | **Available** (marker job PASS)                                            |
+| **B Device partial FT** | **Available** in llamacpp/unified builds; host + console marker gates PASS |
+| **C Serve merged GGUF** | **Available**; runtime LoRA via `SessionParams.lora_path` / CLI `--lora`   |
 
 ### Personalization status (Phases 8–9)
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -274,7 +274,7 @@ latency/dispatch-bound per token rather than saturating aggregate DRAM bandwidth
 consistent with why more threads help prefill (batched) but not decode (M=1). Drop
 a `membw.flag` into `LocalState` to reproduce (`membw-result.csv`, 1t + full-width).
 
-## On-device training (Lane B) — host engine, preliminary
+## On-device training (Lane B) — host + console, gates PASS
 
 First measured numbers for the in-process ggml-opt partial-FT engine
 (`partial_ft`, docs/training-architecture.md §10). Raw:
@@ -296,15 +296,19 @@ Interpretation:
   (§13) — consistent with base f16 (~700 MB) + f32 subset/grads/AdamW
   (~150 MB) + activations/compute (~230 MB). `n_ctx_train` is the pressure
   knob if larger filters land.
-- **Time is**: fwd+bwd ≈ 60× slower than decode-only inference on the same
-  host. The Series S CPU (8× Zen 2) has comparable multicore throughput to
-  this 4c/8t host, so expect the same order on console (~epochs of tens of
-  minutes). For the console gate prefer **2–4 epochs** and/or
-  `n_ctx_train` 128; the loss trend above shows the marker job converging
-  well before epoch 8.
-- Scope: **host-only, preliminary** (epochs 1–2 of an 8-epoch run in
-  progress). Refresh the CSV row when the full run (wall total + marker eval)
-  and the console `device-train` run land.
+- **Time is**: fwd+bwd is much slower than decode-only inference. Note the host
+  epoch time above (~24.8 min) was the **thermally throttled** run
+  (`background.slice`, 1 core); the **Series S console is far faster** —
+  measured **~44–55 s/epoch** (8× Zen 2, not throttled). The earlier
+  "expect tens of minutes on console" guess was wrong: the console beats the
+  capped laptop by ~30×.
+- **Console gate (2026-07-20, MSIX 1.4.0.595): PASS.** 8 epochs, wall **446 s**
+  total (prepare + train + export + merge + evaluate), peak working set
+  **1195 MB** (< 3 GB ceiling), marker `XLLAMA-LORA-OK.` reproduced. Recipe:
+  LR **2e-4**, short marker target, evaluate at the **epoch-8 convergence
+  point** — the last-block FT has no LR decay, so the marker flickers OFF past
+  epoch 8 (more epochs is not safer). Raw:
+  `bench/results/phase10-console-devtrain-result.json`.
 
 Reproduce (host): `./build/linux-test/bin/xllama-cli --train-job
 training/jobs/smollm2-360m-marker-partialft.json`. Console:

--- a/docs/training-architecture.md
+++ b/docs/training-architecture.md
@@ -6,9 +6,9 @@
 > [uwp-constraints.md](uwp-constraints.md) §13. Host runner ops:
 > [`training/README.md`](../training/README.md).
 
-**Currency:** 2026-07-17. Host PEFT marker job **PASS**. Lane B device train
-**implemented (experimental)** — in-process ggml-opt partial FT
-(`src/bridge/device_train.cpp`); host and console marker gates pending.
+**Currency:** 2026-07-20. Host PEFT marker job **PASS**. Lane B device train
+**available** — in-process ggml-opt partial FT (`src/bridge/device_train.cpp`);
+host and console marker gates **PASS** (console peak_ws 1195 MB, wall 446 s).
 Design + pin constraints: §10. Roadmap: Phase 10.
 
 ### Exit criteria (Phase 8) — **MET**
@@ -25,7 +25,8 @@ Design + pin constraints: §10. Roadmap: Phase 10.
 **Frozen:** no further Phase 8 architecture work. Phase 9 delivered both the
 operator loop and per-response preference UI. **Phase 10 (Lane B, §10)
 supersedes the "training execution stays host-only" default**: an in-process
-engine now exists, honestly gated as `experimental` until console evidence.
+engine runs fully on the console, `available` with host + console marker-gate
+evidence (2026-07-20: peak_ws 1195 MB, wall 446 s).
 
 ## 1. Why a training pillar
 
@@ -168,8 +169,9 @@ Queryable from C++ / CLI (`xllama-cli --training-capabilities`):
 
 `training_device_supported(Device)` is compile-time: **true** on builds with
 the Lane B engine (`XLLAMA_DEVICE_TRAIN`: Linux CMake always; MSIX llamacpp /
-unified backends), false otherwise. `DeviceGgmlPartialFt` stays `experimental`
-until host and console `device-train` runs pass with measured RSS/wall evidence.
+unified backends), false otherwise. `DeviceGgmlPartialFt` is `available`: host
+and console `device-train` runs PASS with measured RSS/wall evidence (2026-07-20,
+console peak_ws 1195 MB, wall 446 s).
 
 ## 5. Stage machine and job schema
 
@@ -297,7 +299,8 @@ an engine change (ROADMAP Phase 10).
 
 The acceptance ceiling is 3 GB; `n_ctx_train` is the pressure knob. Host
 throughput and epoch timings: `docs/benchmarks.md` §"On-device training
-(Lane B)". Console `peak_ws_mb` lands with the `device-train` gate.
+(Lane B)". Console `peak_ws_mb` measured at the gate: **1195 MB** (wall 446 s,
+epochs 8), well under the 3 GB ceiling.
 
 ### Run it
 
@@ -313,10 +316,9 @@ bench/diffuse), job at `LocalState\training\job.json` (paths LocalState-
 relative), progress in `xllama.log`, completion marker
 `training\result.done`, artefacts under the job's `out_dir`.
 
-**Evidence:** the host marker run **PASSes** (2026-07-20, recipe below);
-console PASS is pending (Phase 10 checkboxes). Generated
-`training/out/.../result.json` files are local evidence, not committed product
-claims.
+**Evidence:** host and console marker runs both **PASS** (2026-07-20; recipe
+below). Console: MSIX 1.4.0.595, peak_ws 1195 MB, wall 446 s, marker reproduced
+— committed at `bench/results/phase10-console-devtrain-result.json`.
 
 **Converging recipe (host).** The first run (LR 5e-4, long marker) under-
 converged: the fine-tune learned the `XLLAMA-LORA` prefix but the tail `-OK`

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -366,8 +366,8 @@ the historical Phase 3.5 / Phase 5 evidence in `CHANGELOG.md` and
 `Microsoft.ML.OnnxRuntime.DirectML` 1.24.4 and
 `Microsoft.ML.OnnxRuntimeGenAI.DirectML` 0.14.1 — not an ORT **Training**
 package. Those pins provide no ORT train loop. The llamacpp/unified variants
-instead link the separate experimental ggml-opt partial-FT engine; it does not
-turn ORT GenAI into a training runtime.
+instead link the separate ggml-opt partial-FT engine (Lane B, gates PASS); it
+does not turn ORT GenAI into a training runtime.
 
 **ORT GenAI adapters ≠ training.** `strings` on the pinned
 `onnxruntime-genai.dll` exposes `OgaCreateAdapters` / `OgaLoadAdapter` /

--- a/training/README.md
+++ b/training/README.md
@@ -82,7 +82,7 @@ bg ./build/linux-test/bin/xllama-cli --train-job training/jobs/smollm2-360m-mark
 | Device partial FT | **available** in `XLLAMA_DEVICE_TRAIN` builds; host + console marker gates PASS |
 | Serve merged GGUF | **available**                                                                   |
 
-## Device partial fine-tuning (experimental)
+## Device partial fine-tuning (available)
 
 `method: "partial_ft"` uses the in-process ggml-opt engine on Linux and on
 llamacpp/unified UWP builds. The current llama.cpp pin only supports selected
@@ -94,14 +94,14 @@ Full `llama-finetune` and ORT ODT remain rejected. Validate the console path wit
 ./scripts/validate-console-training.sh device-train
 ```
 
-The **host marker gate PASSes** (2026-07-20): the greedy eval prompt reproduces
-`XLLAMA-LORA-OK.` at loss ~0.47. The recipe that converges is LR **2e-4** (5e-4
-oscillated and under-converged on the marker), the short `XLLAMA-LORA-OK.`
-target, and `checkpoint_every: 2` so a checkpoint can be marker-tested to
-early-stop (host converged by epoch 8 of 12). The **console gate is still
-pending**; the harness requires `result.json` wall time and `peak_ws_mb < 3072`
-(a 2-epoch console smoke measured **1195 MB**, well under the cap). Do not
-publish trained weights from this lane as validated product output yet. See
+**Host and console marker gates both PASS** (2026-07-20): the greedy eval prompt
+reproduces `XLLAMA-LORA-OK.` at loss ~0.47. The recipe that converges is LR
+**2e-4** (5e-4 oscillated and under-converged on the marker), the short
+`XLLAMA-LORA-OK.` target, and `checkpoint_every: 2` so a checkpoint can be
+marker-tested to early-stop (converges by epoch 8). Console gate (MSIX
+1.4.0.595): `result.json` wall 446 s, `peak_ws_mb` **1195** (< 3072 ceiling),
+marker reproduced end-to-end. Trained weights from this lane are not published
+as a product model — the marker is a canary, not a deliverable. See
 [`docs/training-architecture.md`](../docs/training-architecture.md) and
 [`docs/uwp-constraints.md`](../docs/uwp-constraints.md) §13.
 


### PR DESCRIPTION
Drift audit after the Phase 10 flip (#121/#122). Several docs still described on-device training as experimental / gated / pending, and one predicted the console would be much slower than it is.

**Fixed (stale → truth):**
- `README.md`, `docs/architecture.md`, `docs/training-architecture.md`, `docs/uwp-constraints.md`, `training/README.md`: device partial FT `experimental`/`gates pending`/`console PASS pending` → **available, host + console marker gates PASS**.
- `docs/benchmarks.md` §Lane B: replaced the wrong console prediction ('tens of minutes', '2-4 epochs') with measured numbers — console **~44-55 s/epoch** (the ~24.8 min host figure was the thermally-capped run), console gate PASS (446 s, 1195 MB, epoch-8). Regenerated the summary block (was missing the SmolLM2 DML int4 row → would have failed the CI verify).
- `ROADMAP.md`: Phase 11 'blocked on Phase 10 gates' → unblocked.

**Verified correct (no change):** every `1.4.0.595` mention is framed as the gate/test build, not published; published stays v1.4.0.0/1.4.0.588. No stale long-marker string, no `5e-4`-as-current, no `epochs 10`-as-console-default. Historical CHANGELOG [1.3.0.0]/[1.4.0.0] entries left as-is.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)