### PR TITLE
docs: README organization polish (TOC, Phase 11, training foothold)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,17 @@
 ## Table of Contents
 
 - [What is this](#what-is-this)
+- [Quick Start](#quick-start)
 - [About the name](#about-the-name)
 - [Why Xbox Series S](#why-xbox-series-s)
 - [Architecture](#architecture)
 - [Repository layout](#repository-layout)
 - [Build](#build)
 - [Models](#models)
+- [Training and personalization](#training-and-personalization)
 - [Limitations](#limitations)
 - [Roadmap](#roadmap)
+- [Technical report](#technical-report)
 - [Contributing](#contributing)
 - [Acknowledgements](#acknowledgements)
 - [License](#license)
@@ -295,6 +298,19 @@ See [docs/uwp-constraints.md](./docs/uwp-constraints.md) for the measured GPU bu
 
 ---
 
+## Training and personalization
+
+A dual-lane training pillar lets the app adapt models **on the device**, no cloud:
+
+- **Host PEFT LoRA** (Lane A) — full LoRA fine-tune off-device, merged to GGUF.
+- **On-device partial fine-tune** (Lane B) — an in-process ggml-opt last-block `partial_ft` that runs entirely on the Xbox. **Available**: host + console marker gates PASS (Series S: peak working set 1195 MB, well under the 3 GB budget; marker reproduced end-to-end).
+- **Serve merged GGUF** (Lane C) — load the fine-tuned model through the normal inference path, plus runtime LoRA.
+- **Preference capture** — the in-app Like/Dislike/Correct actions feed a retraining dataset (`training/samples.jsonl`).
+
+SSOT: [docs/training-architecture.md](./docs/training-architecture.md). Ops and job format: [training/README.md](./training/README.md). Surfacing this loop in the UI is [Phase 11](#roadmap).
+
+---
+
 ## Limitations
 
 - **File-size ceiling, not GPU memory**: the measured per-process GPU budget is **3801 MB** (package designated Game), and the Dev Mode disk allocation is raised to **90 GB** via Dev Home — what caps model choice now is the **2 GB ONNX protobuf / per-file limit** (self-contained `model.onnx` must stay under it; see [docs/uwp-constraints.md](./docs/uwp-constraints.md) §8–§9).
@@ -327,13 +343,17 @@ See [ROADMAP.md](./ROADMAP.md). Headlines:
 10. **Phase 10 — Device partial FT** ✅ ggml-opt Lane B; host + console marker
     gates PASS (Xbox Series S: peak_ws 1195 MB, marker reproduced) —
     `DeviceGgmlPartialFt` available.
+11. **Phase 11 — Headless ↔ UI gap** 🔜 Next: surface the on-device training
+    loop in the UI (trigger, progress, serve the personalized model), plus
+    autopilot/LAN-API parity. See [ROADMAP.md](./ROADMAP.md).
 
 ---
 
 ## Technical report
 
 The measured narrative (CPU/GPU verdicts, falsified hypotheses, diffusion on console)
-lives in [docs/technical-report.md](./docs/technical-report.md). Publication entrypoint:
+lives in [docs/technical-report.md](./docs/technical-report.md) — a **frozen v1.0
+snapshot** kept for its reasoning, not current metrics. Publication entrypoint:
 [Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76). Live numbers:
 [docs/benchmarks.md](./docs/benchmarks.md).
 

--- a/docs/training-architecture.md
+++ b/docs/training-architecture.md
@@ -51,7 +51,7 @@ path). No optimizer state lives inside the chat hot path.
            ┌─────────────────┼─────────────────┐
            ▼                 ▼                 ▼
     Lane A Host PEFT   Lane B Device train  Lane C Serve
-    IMPLEMENTED        IMPLEMENTED (exp.)   IMPLEMENTED
+    IMPLEMENTED        AVAILABLE (gates ✓)  IMPLEMENTED
     training/host/*    ggml-opt partial FT  Session + llama
     device=host        device_train.cpp     runtime LoRA
            │                 │                 ▲
@@ -229,16 +229,16 @@ and `from-console-samples` job live in
 
 ## 8. Decision log
 
-| Decision                                   | Rationale                                                                              |
-| ------------------------------------------ | -------------------------------------------------------------------------------------- |
-| Host PEFT first                            | RE shows inference-only NuGet; host PEFT proven PASS                                   |
-| Compile-gate `device=device`               | Only builds containing the bounded ggml-opt engine accept it                           |
-| Reject DeviceLlamaFinetune                 | ~24 GB class + WIP                                                                     |
-| Prefer merge GGUF over runtime LoRA for v1 | Zero Session change; same path as catalogue                                            |
-| ODT as research not default                | Package + format + console risk                                                        |
-| Lane B via ggml-opt, not ORT ODT           | Engine already linked in the MSIX; single GGUF format; no new NuGet pin                |
-| Lane B = last-block partial FT             | Pin limitation: KV-cache `set_rows` has no backward (§10); honest fail-fast in prepare |
-| `experimental`, not `available`            | Host and console evidence must pass before the status flips                            |
+| Decision                                           | Rationale                                                                                                    |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Host PEFT first                                    | RE shows inference-only NuGet; host PEFT proven PASS                                                         |
+| Compile-gate `device=device`                       | Only builds containing the bounded ggml-opt engine accept it                                                 |
+| Reject DeviceLlamaFinetune                         | ~24 GB class + WIP                                                                                           |
+| Prefer merge GGUF over runtime LoRA for v1         | Zero Session change; same path as catalogue                                                                  |
+| ODT as research not default                        | Package + format + console risk                                                                              |
+| Lane B via ggml-opt, not ORT ODT                   | Engine already linked in the MSIX; single GGUF format; no new NuGet pin                                      |
+| Lane B = last-block partial FT                     | Pin limitation: KV-cache `set_rows` has no backward (§10); honest fail-fast in prepare                       |
+| `experimental` → `available` (resolved 2026-07-20) | Host and console evidence had to pass before the flip; both gates PASS (console peak_ws 1195 MB, wall 446 s) |
 
 ## 9. Open spikes (kill criteria)
 


### PR DESCRIPTION
Follow-up from a fresh-eyes documentation-organization review after the Phase 10 flip. The docs were already well-structured (real SSOT discipline, complete index); these are the navigation gaps it found:

- **README TOC** was missing **Quick Start** and **Technical report** (both in the body, absent from the TOC — Quick Start is the most navigation-critical section).
- **On-device training** (just went experimental → available) had no front-door foothold: added a **Training and personalization** section that links the SSOTs (`docs/training-architecture.md`, `training/README.md`) + a TOC entry.
- **README roadmap** stopped at Phase 10; added the **Phase 11** headline so the front door matches ROADMAP's named next phase.
- **README technical-report** section now flags it as a frozen v1.0 snapshot (consistent with `docs/README.md` / `architecture.md`).
- **training-architecture.md**: the lane diagram still tagged Lane B `(exp.)` and the decision log still read `experimental, not available` — both now reflect the resolved flip.

All 15 README TOC anchors verified against the GitHub slug algorithm. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README navigation with a Quick Start section and revised roadmap entries.
  * Added guidance on training and personalization, including on-device adaptation and preference capture.
  * Clarified the technical report’s publication entry point and versioned snapshot.
  * Marked the Lane B training path as available, with documented host and console validation evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->