### PR TITLE
bench: instrument prompt length (n_prompt_tok + no silent truncation)

### DIFF
--- a/scripts/bench-xbox-ort.sh
+++ b/scripts/bench-xbox-ort.sh
@@ -354,8 +354,24 @@ fi
 echo ""
 echo "--- Computing median ---"
 RESULT_CSV="${OUT_CSV:-${REPO_ROOT}/bench/results/phase1-cpu.csv}"
-CSV_HEADER="model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,host,date"
+CSV_HEADER="model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,n_prompt_tok,host,date"
 [[ ! -f "$RESULT_CSV" ]] && printf '%s\n' "$CSV_HEADER" >"$RESULT_CSV"
+
+# Refuse to append to a file written under an older schema: the row arity would
+# not match its header, and csv.DictReader would silently misalign every field
+# after the mismatch (host/date landing under the wrong keys). Pick a new --out.
+assert_header_matches() {
+	local csv="$1" existing
+	existing=$(head -1 "$csv")
+	if [[ "$existing" != "$CSV_HEADER" ]]; then
+		echo "Error: $csv uses a different CSV schema." >&2
+		echo "  file:     $existing" >&2
+		echo "  expected: $CSV_HEADER" >&2
+		echo "Append to a new file with --out, or migrate the old one first." >&2
+		exit 1
+	fi
+}
+assert_header_matches "$RESULT_CSV"
 MEDIAN_TMP=$(mktemp)
 trap 'rm -f "$MEDIAN_TMP"; rm -rf "$TMPDIR_LOCAL"' EXIT
 

--- a/src/bridge/bench.cpp
+++ b/src/bridge/bench.cpp
@@ -98,9 +98,14 @@ void write_bench_csv(const InferenceParams& params, const InferenceResult& res,
     if (!fp)
         return;
 
+    // n_prompt_tok: the actual prefill token count. Without it a row cannot be
+    // interpreted — prompt_tok_s alone does not say at what prompt length it was
+    // measured, which is why the pre-2026-07 DML rows are not comparable. Placed
+    // before `host` so the positional parsing in bench-xbox-ort.sh ($3 backend,
+    // $7 decode_tok_s) keeps working.
     const char* header = "model,quant,backend,n_ctx,n_threads,"
                          "prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,"
-                         "gpu_mem_mb,gpu_budget_mb,host,date\n";
+                         "gpu_mem_mb,gpu_budget_mb,n_prompt_tok,host,date\n";
     fputs(header, fp);
 
     double prompt_tok_s = (res.n_p_eval > 0 && res.t_p_eval_ms > 0)
@@ -158,9 +163,9 @@ void write_bench_csv(const InferenceParams& params, const InferenceResult& res,
     const int used_threads = params.n_threads > 0
                                  ? params.n_threads
                                  : (is_llama ? detect_threads_llama() : detect_threads());
-    fprintf(fp, "%s,%s,%s,%d,%d,%.2f,%.2f,%zu,%.0f,%zu,%zu,%s,%s\n", model_name.c_str(),
+    fprintf(fp, "%s,%s,%s,%d,%d,%.2f,%.2f,%zu,%.0f,%zu,%zu,%d,%s,%s\n", model_name.c_str(),
             quant.c_str(), backend, params.n_ctx, used_threads, prompt_tok_s, decode_tok_s,
-            res.peak_ws_mb, res.t_load_ms, res.gpu_mem_mb, res.gpu_budget_mb,
+            res.peak_ws_mb, res.t_load_ms, res.gpu_mem_mb, res.gpu_budget_mb, res.n_p_eval,
             host_label ? host_label : "unknown", date_buf);
     fclose(fp);
 

--- a/tests/test_bench.cpp
+++ b/tests/test_bench.cpp
@@ -46,8 +46,10 @@ TEST_CASE("Bench CSV writer: basic output") {
     std::string row;
     std::getline(ifs, row);
     CHECK(row.find("test-model,Q4_K_M,cpu,2048,4,") == 0);
-    // Columns: ...,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,host,...
-    CHECK(row.find(",512,1000,0,0,linux-test") != std::string::npos);
+    // Columns: ...,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,n_prompt_tok,host,...
+    // n_prompt_tok must carry res.n_p_eval (10 here): without the real prefill
+    // token count a row cannot be compared against one taken at another length.
+    CHECK(row.find(",512,1000,0,0,10,linux-test") != std::string::npos);
 
     // Clean up
     std::remove(csv_path.c_str());
@@ -113,11 +115,12 @@ TEST_CASE("Bench CSV writer: gpu memory columns") {
 
     std::string header;
     std::getline(ifs, header);
-    CHECK(header.find(",gpu_mem_mb,gpu_budget_mb,host,date") != std::string::npos);
+    CHECK(header.find(",gpu_mem_mb,gpu_budget_mb,n_prompt_tok,host,date") != std::string::npos);
 
     std::string row;
     std::getline(ifs, row);
-    CHECK(row.find(",512,1000,300,768,linux-test") != std::string::npos);
+    // n_p_eval is left unset on this result, so n_prompt_tok is 0.
+    CHECK(row.find(",512,1000,300,768,0,linux-test") != std::string::npos);
 
     std::remove(csv_path.c_str());
     std::string done_path = xllama::resolve_local_path("bench-result.csv.done");

--- a/tests/test_bench.cpp
+++ b/tests/test_bench.cpp
@@ -10,6 +10,27 @@
 #include <cstdio>
 #include <fstream>
 #include <string>
+#include <vector>
+
+// The bench CSV is parsed positionally by scripts/bench-xbox-ort.sh ($3 backend,
+// $7 decode_tok_s) and by column name elsewhere, so both the field order and the
+// arity are a contract. Split rather than substring-match: find() would still
+// pass if a column were inserted or shifted somewhere else in the row.
+static std::vector<std::string> split_csv(const std::string& line) {
+    std::vector<std::string> out;
+    size_t start = 0;
+    for (size_t i = 0; i <= line.size(); ++i) {
+        if (i == line.size() || line[i] == ',') {
+            out.push_back(line.substr(start, i - start));
+            start = i + 1;
+        }
+    }
+    return out;
+}
+
+static const char* kExpectedHeader = "model,quant,backend,n_ctx,n_threads,prompt_tok_s,"
+                                     "decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,"
+                                     "n_prompt_tok,host,date";
 
 static xllama::InferenceParams make_params() {
     xllama::InferenceParams p;
@@ -41,15 +62,25 @@ TEST_CASE("Bench CSV writer: basic output") {
 
     std::string header;
     std::getline(ifs, header);
-    CHECK(header.find("model,quant,backend") == 0);
+    CHECK(header == kExpectedHeader);
 
     std::string row;
     std::getline(ifs, row);
-    CHECK(row.find("test-model,Q4_K_M,cpu,2048,4,") == 0);
-    // Columns: ...,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,n_prompt_tok,host,...
+    const std::vector<std::string> f = split_csv(row);
+    REQUIRE(f.size() == split_csv(kExpectedHeader).size());
+    CHECK(f[0] == "test-model");
+    CHECK(f[1] == "Q4_K_M");
+    CHECK(f[2] == "cpu");
+    CHECK(f[3] == "2048");
+    CHECK(f[4] == "4");
+    CHECK(f[7] == "512");  // peak_ws_mb
+    CHECK(f[8] == "1000"); // load_ms
+    CHECK(f[9] == "0");    // gpu_mem_mb
+    CHECK(f[10] == "0");   // gpu_budget_mb
     // n_prompt_tok must carry res.n_p_eval (10 here): without the real prefill
     // token count a row cannot be compared against one taken at another length.
-    CHECK(row.find(",512,1000,0,0,10,linux-test") != std::string::npos);
+    CHECK(f[11] == "10");
+    CHECK(f[12] == "linux-test");
 
     // Clean up
     std::remove(csv_path.c_str());
@@ -115,12 +146,18 @@ TEST_CASE("Bench CSV writer: gpu memory columns") {
 
     std::string header;
     std::getline(ifs, header);
-    CHECK(header.find(",gpu_mem_mb,gpu_budget_mb,n_prompt_tok,host,date") != std::string::npos);
+    CHECK(header == kExpectedHeader);
 
     std::string row;
     std::getline(ifs, row);
-    // n_p_eval is left unset on this result, so n_prompt_tok is 0.
-    CHECK(row.find(",512,1000,300,768,0,linux-test") != std::string::npos);
+    const std::vector<std::string> f = split_csv(row);
+    REQUIRE(f.size() == split_csv(kExpectedHeader).size());
+    CHECK(f[7] == "512");  // peak_ws_mb
+    CHECK(f[8] == "1000"); // load_ms
+    CHECK(f[9] == "300");  // gpu_mem_mb
+    CHECK(f[10] == "768"); // gpu_budget_mb
+    CHECK(f[11] == "0");   // n_prompt_tok — n_p_eval is left unset on this result
+    CHECK(f[12] == "linux-test");
 
     std::remove(csv_path.c_str());
     std::string done_path = xllama::resolve_local_path("bench-result.csv.done");

--- a/uwp/inference-bridge.cpp
+++ b/uwp/inference-bridge.cpp
@@ -128,18 +128,29 @@ void main_loop() {
     std::string user_prompt = "Hello from Xbox Series S. Tell me about your architecture.";
     {
         std::string prompt_path = resolve_local_path("prompt.txt");
+        // Text mode, as before: on Windows it folds CRLF to LF, so the prompt
+        // content (and the byte count logged below) is what the model will see.
         FILE* pf = _wfopen(utf8_to_wstring(prompt_path).c_str(), L"r");
         if (pf) {
-            char buf[8192] = {};
-            size_t n = fread(buf, 1, sizeof(buf) - 1, pf);
+            // Read the whole file. A fixed 8 KB buffer used to truncate silently
+            // at ~2k tokens, which is exactly the range a prompt-length sweep
+            // cares about: the bench would report a shorter prompt's throughput
+            // under the long prompt's label, with nothing in the log to say so.
+            std::string contents;
+            char chunk[8192];
+            size_t n;
+            while ((n = fread(chunk, 1, sizeof(chunk), pf)) > 0)
+                contents.append(chunk, n);
             fclose(pf);
-            if (n > 0) {
-                user_prompt = buf;
+            if (!contents.empty()) {
+                user_prompt = std::move(contents);
                 // Strip trailing whitespace/newlines
                 while (!user_prompt.empty() &&
                        (user_prompt.back() == '\n' || user_prompt.back() == '\r' ||
                         user_prompt.back() == ' '))
                     user_prompt.pop_back();
+                log_output("[xllama] bench: prompt.txt " + std::to_string(user_prompt.size()) +
+                           " bytes\n");
             }
         }
     }

--- a/uwp/inference-bridge.cpp
+++ b/uwp/inference-bridge.cpp
@@ -125,33 +125,17 @@ void main_loop() {
 
     // Read prompt from LocalFolder/prompt.txt, fallback to default.
     // SmolLM2-360M-Instruct uses ChatML format; bare text triggers EOS immediately.
+    // read_local_file reads to EOF; the hand-rolled reader this replaced used a
+    // fixed char buf[8192] and truncated silently at ~2k tokens — exactly the
+    // range a prompt-length sweep needs. The bench would then report a shorter
+    // prompt's throughput under the long prompt's label with nothing in the log.
     std::string user_prompt = "Hello from Xbox Series S. Tell me about your architecture.";
     {
-        std::string prompt_path = resolve_local_path("prompt.txt");
-        // Text mode, as before: on Windows it folds CRLF to LF, so the prompt
-        // content (and the byte count logged below) is what the model will see.
-        FILE* pf = _wfopen(utf8_to_wstring(prompt_path).c_str(), L"r");
-        if (pf) {
-            // Read the whole file. A fixed 8 KB buffer used to truncate silently
-            // at ~2k tokens, which is exactly the range a prompt-length sweep
-            // cares about: the bench would report a shorter prompt's throughput
-            // under the long prompt's label, with nothing in the log to say so.
-            std::string contents;
-            char chunk[8192];
-            size_t n;
-            while ((n = fread(chunk, 1, sizeof(chunk), pf)) > 0)
-                contents.append(chunk, n);
-            fclose(pf);
-            if (!contents.empty()) {
-                user_prompt = std::move(contents);
-                // Strip trailing whitespace/newlines
-                while (!user_prompt.empty() &&
-                       (user_prompt.back() == '\n' || user_prompt.back() == '\r' ||
-                        user_prompt.back() == ' '))
-                    user_prompt.pop_back();
-                log_output("[xllama] bench: prompt.txt " + std::to_string(user_prompt.size()) +
-                           " bytes\n");
-            }
+        std::string from_file = read_local_file("prompt.txt");
+        if (!from_file.empty()) {
+            user_prompt = std::move(from_file);
+            log_output("[xllama] bench: prompt.txt " + std::to_string(user_prompt.size()) +
+                       " bytes\n");
         }
     }
     // Read model directory/filename from LocalFolder/model.txt, fallback to default.


### PR DESCRIPTION
Prerequisites for measuring the DirectML prefill crossover. Neither is the measurement itself — both are about making the measurement *interpretable*.

**1. `n_prompt_tok` in the bench CSV.** `prompt_tok_s` alone does not say at what prompt length a row was taken, so no two rows are comparable. This is why `bench/results/phase2-dml.csv` cannot be re-read today, and why the "crossover between ~285 and ~1050 tok" behind the 600-token threshold in `routing_policy.h:20` is not reconstructible from the committed data. `res.n_p_eval` was already in hand in `write_bench_csv` and discarded.

Placed before `host` so the positional parsing in `bench-xbox-ort.sh` (`$3` backend, `$7` decode_tok_s) keeps working. The script now **refuses** to append to a file written under the old 13-column schema — the arity mismatch would make `csv.DictReader` silently misalign every field after the gap.

**2. No silent prompt truncation.** `uwp/inference-bridge.cpp` read `prompt.txt` into a fixed `char buf[8192]`, cutting at ~2k tokens with no diagnostic. A length sweep would have measured a shorter prompt under the long prompt's label. Now reads to EOF and logs the byte count.

Tests updated (`tests/test_bench.cpp` is the schema oracle and caught the change); 118/118 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark CSV results now include the prompt token count.
  * UWP prompt files can be longer than 8 KB without being truncated.

* **Bug Fixes**
  * Added validation to prevent appending benchmark results to CSV files with incompatible headers.
  * Improved handling of trailing whitespace in loaded prompts.

* **Tests**
  * Updated benchmark output checks for the new prompt-token column and CSV layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->