### PR TITLE
bench(#130): control n_ctx and n_predict from the console bench path

### DIFF
--- a/scripts/bench-prompt-sweep.sh
+++ b/scripts/bench-prompt-sweep.sh
@@ -5,6 +5,7 @@
 #   source ~/.config/xllama/xbox-env
 #   ./scripts/bench-prompt-sweep.sh [--models "a b"] [--tokens "150 300 ..."]
 #                                   [--runs N] [--out FILE]
+#                                   [--ctx N] [--n-predict N]
 #
 # Why this exists: the 600-token routing threshold (include/xllama/routing_policy.h)
 # is not a measured value. It is the midpoint between two sample points — 285 and
@@ -32,6 +33,8 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 MODELS="smollm2-360m-cpu-int4 smollm2-360m-dml-fp16-v2"
 TOKENS="150 300 550 800 1100 1600"
 RUNS=4
+CTX=0      # 0 = engine default; #130 varies it to test the band hypothesis
+NPREDICT=0 # 0 = engine default
 OUT="${REPO_ROOT}/bench/results/phase12-dml-crossover.csv"
 
 while [[ $# -gt 0 ]]; do
@@ -46,6 +49,14 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--runs)
 		RUNS="$2"
+		shift 2
+		;;
+	--ctx)
+		CTX="$2"
+		shift 2
+		;;
+	--n-predict)
+		NPREDICT="$2"
 		shift 2
 		;;
 	--out)
@@ -95,9 +106,12 @@ for model in $MODELS; do
 		echo "=========================================================="
 		echo "  $model @ target ${t} tok"
 		echo "=========================================================="
+		extra=()
+		((CTX > 0)) && extra+=(--ctx "$CTX")
+		((NPREDICT > 0)) && extra+=(--n-predict "$NPREDICT")
 		if ! "${SCRIPT_DIR}/bench-xbox-ort.sh" "$model" \
 			--prompt "${TMPDIR_LOCAL}/prompt-${t}.txt" \
-			--runs "$RUNS" --out "$OUT"; then
+			--runs "$RUNS" --out "$OUT" "${extra[@]+"${extra[@]}"}"; then
 			echo "  WARN: point failed ($model @ ${t} tok) — continuing" >&2
 			FAILED=$((FAILED + 1))
 		fi

--- a/scripts/bench-xbox-ort.sh
+++ b/scripts/bench-xbox-ort.sh
@@ -32,6 +32,8 @@ set -euo pipefail
 
 MODEL_NAME="${1:-smollm2-360m-cpu-int4}"
 N_THREADS=0
+N_CTX=0     # 0 = engine default (2048)
+N_PREDICT=0 # 0 = engine default (512)
 N_RUNS=3
 PROMPT_FILE=""
 OUT_CSV=""
@@ -42,6 +44,14 @@ while [[ $# -gt 0 ]]; do
 	case "$1" in
 	--threads)
 		N_THREADS="${2:?--threads requires a value}"
+		shift 2
+		;;
+	--ctx)
+		N_CTX="${2:?--ctx requires a value}"
+		shift 2
+		;;
+	--n-predict)
+		N_PREDICT="${2:?--n-predict requires a value}"
 		shift 2
 		;;
 	--runs)
@@ -80,6 +90,8 @@ CURL_AUTH=(--basic -u "${XBOX_USER}:${XBOX_PASS}" -k -sS)
 echo "=== xllama bench-xbox-ort ==="
 echo "  Model:   $MODEL_NAME"
 echo "  Threads: ${N_THREADS:-auto}"
+echo "  n_ctx:   $([[ $N_CTX -gt 0 ]] && echo "$N_CTX" || echo "default")"
+echo "  n_predict: $([[ $N_PREDICT -gt 0 ]] && echo "$N_PREDICT" || echo "default")"
 echo "  Runs:    $N_RUNS (run 1 warmup, dropped from median)"
 echo "  Xbox:    $XBOX_IP"
 
@@ -282,6 +294,9 @@ printf '%s' "$MODEL_NAME" >"${TMPDIR_LOCAL}/model.txt"
 
 # bench_threads.txt — tells inference-bridge what n_threads to write in CSV (v0.3.1+)
 printf '%d' "$N_THREADS" >"${TMPDIR_LOCAL}/bench_threads.txt"
+# 0 = leave the engine default; #130 varies these to test the band hypothesis.
+printf '%d' "$N_CTX" >"${TMPDIR_LOCAL}/bench_ctx.txt"
+printf '%d' "$N_PREDICT" >"${TMPDIR_LOCAL}/bench_npredict.txt"
 
 # bench.flag — consumed by app on each start; must be re-uploaded per run
 printf 'bench' >"${TMPDIR_LOCAL}/bench.flag"
@@ -319,6 +334,8 @@ for ((run = 1; run <= N_RUNS; run++)); do
 	upload_to_localstate "${TMPDIR_LOCAL}/prompt.txt"
 	upload_to_localstate "${TMPDIR_LOCAL}/model.txt"
 	upload_to_localstate "${TMPDIR_LOCAL}/bench_threads.txt"
+	upload_to_localstate "${TMPDIR_LOCAL}/bench_ctx.txt"
+	upload_to_localstate "${TMPDIR_LOCAL}/bench_npredict.txt"
 
 	echo "  Starting app..."
 	restart_app

--- a/scripts/profile-dml-run.sh
+++ b/scripts/profile-dml-run.sh
@@ -245,6 +245,12 @@ while IFS= read -r name; do
 done < <(list_files "$MODEL_DIR")
 delete_file "" "bench-result.csv"
 delete_file "" "bench-result.csv.done"
+# main_loop treats a present bench_turns.txt as a switch into the multi-turn KV
+# bench, which returns early and writes bench-kv-result.csv instead — the poll
+# below would then hang for its full timeout with no indication why. One left by
+# scripts/bench-xbox-kv.sh is enough to do it. bench-xbox-ort.sh clears it for
+# the same reason.
+delete_file "" "bench_turns.txt"
 
 # Append-only log: remember current size to slice only the new tail later.
 download_file "" "xllama.log" "${TMPDIR_LOCAL}/xllama_before.log"

--- a/uwp/inference-bridge.cpp
+++ b/uwp/inference-bridge.cpp
@@ -38,18 +38,24 @@ std::string read_local_file(const char* name) {
     return out;
 }
 
+// Small integer knob from a LocalState file; |fallback| when absent or unparsable.
+int read_local_int(const char* name, int fallback) {
+    const std::string s = read_local_file(name);
+    return s.empty() ? fallback : std::atoi(s.c_str());
+}
+
 // Multi-turn TTFT bench: measures turn-2 prefill with KV reuse (append only the
 // new turn) against the cold baseline (full re-prefill of the 2-turn context),
 // on the same persistent Session. The ratio is the KV-reuse win. Writes
 // bench-kv-result.csv (+ .done) and logs the numbers.
 void run_kv_bench(const std::string& model_name, const std::string& sys, const std::string& u1,
-                  const std::string& u2, int n_threads, const char* host) {
+                  const std::string& u2, int n_threads, int n_ctx, const char* host) {
     // KV-reuse now works on both backends: ORT-GenAI (persistent generator) and
     // GGUF/llama.cpp (persistent llama_context in LlamaSession). No early skip.
     std::string err;
     ::xllama::SessionParams sp;
     sp.model_path = model_name;
-    sp.n_ctx = 2048;
+    sp.n_ctx = n_ctx > 0 ? n_ctx : 2048;
     sp.n_threads = n_threads;
     auto sess = ::xllama::Session::create(sp, &err);
     if (!sess) {
@@ -157,19 +163,14 @@ void main_loop() {
         }
     }
 
-    // Read optional bench_threads.txt — written by bench-xbox-ort.sh per variant.
-    // Used both to set params.n_threads (CSV tracking) and to label the host column.
-    int bench_threads = 0;
-    {
-        std::string tpath = resolve_local_path("bench_threads.txt");
-        FILE* tf = _wfopen(utf8_to_wstring(tpath).c_str(), L"r");
-        if (tf) {
-            char buf[16] = {};
-            if (fread(buf, 1, sizeof(buf) - 1, tf) > 0)
-                bench_threads = std::atoi(buf);
-            fclose(tf);
-        }
-    }
+    // Optional numeric knobs from LocalState, written by the bench scripts.
+    // bench_threads.txt also labels the host column; bench_ctx.txt and
+    // bench_npredict.txt exist because #130 needs to vary n_ctx and n_predict:
+    // the DirectML prefill band's edges sit near n_ctx/2 and n_ctx - n_predict,
+    // and that hypothesis is only falsifiable if both are controllable here.
+    const int bench_threads = read_local_int("bench_threads.txt", 0);
+    const int bench_ctx = read_local_int("bench_ctx.txt", 0);
+    const int bench_npredict = read_local_int("bench_npredict.txt", 0);
 
     // Multi-turn TTFT bench (Stage 2b): if bench_turns.txt is present it holds the
     // turn-2 user prompt; prompt.txt supplies turn 1. Measures the KV-reuse win
@@ -184,7 +185,7 @@ void main_loop() {
                 snprintf(host_buf2, sizeof(host_buf2), "xbox-series-s");
             log_output("[xllama] kv-bench model: " + model_name + "\n");
             run_kv_bench(model_name, "You are a helpful AI assistant.", user_prompt, turn2,
-                         bench_threads, host_buf2);
+                         bench_threads, bench_ctx, host_buf2);
             return;
         }
     }
@@ -200,7 +201,10 @@ void main_loop() {
     InferenceParams params;
     params.model_path = model_name;
     params.prompt = prompt;
-    params.n_predict = 512;
+    // 0 = keep the default (n_predict 512, n_ctx from InferenceParams).
+    params.n_predict = bench_npredict > 0 ? bench_npredict : 512;
+    if (bench_ctx > 0)
+        params.n_ctx = bench_ctx;
     params.n_threads = bench_threads;           // 0 = auto; set by bench-xbox-ort.sh
     params.stop_sequences = fmt.stop_sequences; // clean stop for Gemma's <end_of_turn>
 


### PR DESCRIPTION
Phase 1 of #130 — instrumentation only, no measurement yet.

## Why

The DirectML prefill band found in #129 has edges near `n_ctx/2` (1024) and `n_ctx - n_predict` (1536), which fits the data exactly:

| prompt tok | 791 | 1098 | 1289 | 1384 | 1480 | 1574 | 1671 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| prefill | 1.77 s | 3.80 s | **10.4 s** | 6.67 s | 6.51 s | 2.47 s | 2.45 s |

**H1: the band is `[n_ctx/2, n_ctx - n_predict]`.** It is falsifiable — move `n_ctx` and `n_predict` and the edges must move with them; if they stay at 1024–1536 in absolute terms, H1 is dead and the band is a fixed-length artefact.

Neither parameter was controllable from the console bench path: `n_predict` was hardcoded to 512 (`uwp/inference-bridge.cpp`) and `n_ctx` was never set, taking the `InferenceParams` default of 2048. This is the same class of instrumentation gap as `n_prompt_tok` and `n_gen_tok` in #129 — the experiment could not be run, not because it was hard, but because the knob did not exist.

## What

- `bench_ctx.txt` / `bench_npredict.txt` in LocalState, 0 = keep the default. Read via a new `read_local_int` helper that also replaces the hand-rolled `bench_threads.txt` reader.
- `--ctx` / `--n-predict` on `bench-xbox-ort.sh` and `bench-prompt-sweep.sh`.
- `run_kv_bench` took `n_ctx` as a hardcoded 2048; it is now a parameter. Leaving it would mean a KV run silently ignoring a `bench_ctx.txt` that the single-turn path honours.

## Bug fix — a hazard I introduced in #129

`profile-dml-run.sh` never cleared `bench_turns.txt`. `main_loop` treats its presence as a switch into the multi-turn KV bench, which returns early and writes `bench-kv-result.csv` instead of `bench-result.csv` — so the profiler polls until its 300 s timeout and fails with nothing pointing at the cause. Adding `bench-xbox-kv.sh` in #129 made it easy to leave one behind. `bench-xbox-ort.sh` already cleared it for this exact reason.

Tests: 119/119.

Planned next: sweep at `n_ctx` 1536 (H1 predicts the band moves to [768, 1024]) and at `n_predict` 256 (predicts the upper edge moves to 1792). Both keep memory at or below current — raising `n_ctx` would risk the DML allocator OOM, since the working set already peaks at 2869 MB of a 3801 MB budget.