### PR TITLE
fix(#133): auto GPU routing was unreachable — the context trimmer capped it out

### DIFF
--- a/include/xllama/routing_policy.h
+++ b/include/xllama/routing_policy.h
@@ -4,10 +4,45 @@
 // and KV reuse at the UI layer; this header encodes the token threshold only.
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <string_view>
 
 namespace xllama {
+
+// ---------------------------------------------------------------------------
+// Prompt budget
+// ---------------------------------------------------------------------------
+// The context trimmer (MainPageController::BuildPrompt) and auto routing both
+// bound the same quantity — how many tokens a turn may carry — but the trimmer
+// runs first, so its ceiling is the hard limit. If token_threshold ever rises
+// above it, decide_routing() can never see a count above the threshold and auto
+// GPU routing becomes unreachable. That is #133: the 600 -> 1550 retune in #129
+// crossed the ceiling and silently disabled the feature, because nothing here
+// related the two numbers. assert in tests/test_routing_policy.cpp now does.
+//
+// The trimmer has no tokenizer available at the point it runs, so it estimates
+// from character count. Measured 2026-07-21 on the console with the SmolLM2
+// tokenizer: 7100 chars of English prose -> 1329 real tokens = 5.34 chars/token
+// (bench/prompts/standard-512.txt gives 4.84 with its ChatML markup counted).
+// The previous divisor of 4 overestimated tokens by ~30%, so the trimmer cut at
+// ~1348 real tokens while its comment claimed 1800 — that gap is what put the
+// ceiling underneath the threshold.
+//
+// 5.0 is deliberately below the measured 5.34: underestimating chars-per-token
+// means overestimating tokens, which trims early rather than late. Overflow is
+// caught downstream by the max_length clamp in run_inference, so erring this way
+// costs context, not correctness. Non-Latin scripts tokenize far denser and this
+// estimate does not model them.
+inline constexpr double kEstimatedCharsPerToken = 5.0;
+
+// Token budget for the prompt itself, sized against n_ctx 2048 with ~250 tokens
+// left for generation.
+inline constexpr int kMaxPromptTokens = 1800;
+
+inline constexpr int estimate_tokens_from_chars(std::size_t chars) {
+    return static_cast<int>(static_cast<double>(chars) / kEstimatedCharsPerToken);
+}
 
 enum class RoutingMode {
     CpuOnly = 0,
@@ -34,9 +69,17 @@ struct RoutingSettings {
     //                the context leaves room for at most 474, so the prefill win
     //                cannot be amortised away.
     //
-    // 1550 therefore keeps GPU routing to the only band where it is unconditionally
-    // better, and steers clear of the pathological region. Re-measure when the
-    // asset, the model, or n_ctx changes — this number is not a general law.
+    // 1550 keeps GPU routing to the only band where it is unconditionally better
+    // and steers clear of the pathological region — but it must also stay below
+    // kMaxPromptTokens, or the trimmer cuts the turn down before routing sees it
+    // (#133). Re-measure when the asset, the model, or n_ctx changes; this number
+    // is not a general law.
+    //
+    // #130 caveat: the "1100-1500" band above is stated in prompt length, which
+    // is not the variable the code controls. Recast against max_length =
+    // min(n_ctx, n_prompt + n_predict), every fast point is one where that clamp
+    // saturates and every slow one is where it does not. The band is in
+    // max_length, not prompt tokens, so this whole calibration is provisional.
     int token_threshold = 1550;
     std::string cpu_model;
     std::string gpu_model;

--- a/scripts/validate-console.sh
+++ b/scripts/validate-console.sh
@@ -51,6 +51,19 @@ if ! [[ "$ROUTING_THRESHOLD" =~ ^[0-9]+$ ]]; then
 	echo "Error: could not read token_threshold from include/xllama/routing_policy.h" >&2
 	exit 1
 fi
+# The decoy must clear the routing threshold in REAL tokens while staying under
+# the context trimmer's budget in ESTIMATED tokens — BuildPrompt runs first and
+# drops any turn over budget, which is #133. Both constants come from the same
+# header so the decoy tracks a retune of either.
+TRIM_BUDGET=$(sed -n 's/.*kMaxPromptTokens = \([0-9]\+\);.*/\1/p' \
+	"${REPO_ROOT}/include/xllama/routing_policy.h" | head -n1)
+EST_CHARS_PER_TOK=$(sed -n 's/.*kEstimatedCharsPerToken = \([0-9.]\+\);.*/\1/p' \
+	"${REPO_ROOT}/include/xllama/routing_policy.h" | head -n1)
+if ! [[ "$TRIM_BUDGET" =~ ^[0-9]+$ ]] || [[ -z "$EST_CHARS_PER_TOK" ]]; then
+	echo "Error: could not read kMaxPromptTokens / kEstimatedCharsPerToken from" \
+		"include/xllama/routing_policy.h" >&2
+	exit 1
+fi
 
 TMPDIR_LOCAL=$(mktemp -d)
 VAE_CACHE="" # set by validate_taesd; read by its EXIT trap (must be global)
@@ -202,27 +215,46 @@ JSON
 	# wrapper so the stored user content is plain prose. Merge it into the
 	# device's existing chat index rather than clobbering it.
 	#
-	# The decoy must exceed ROUTING_THRESHOLD, and long-1k.txt alone is only
-	# ~1000 tokens — enough for the old 600 but not for 1550, so the prose is
-	# repeated until it clears the threshold with margin. This gate broke exactly
-	# once (threshold retuned 600 -> 1550 in #129 while the decoy stayed fixed);
-	# both the assertion and the decoy now derive from ROUTING_THRESHOLD, so a
-	# future retune cannot silently invalidate it again.
+	# The decoy is squeezed between two constants pulling opposite ways:
+	#   - it must exceed ROUTING_THRESHOLD in REAL tokens, or routing stays on CPU;
+	#   - it must stay under TRIM_BUDGET in ESTIMATED tokens, or BuildPrompt drops
+	#     the whole turn before routing ever counts it (#133 — and because a single
+	#     oversized turn is dropped entirely, the prompt collapses to ~22 tokens).
+	# Size it just under the trimmer's ceiling and let the assertion below check,
+	# against the console's own tokenizer, that it landed above the threshold.
+	# This gate broke once already (threshold retuned 600 -> 1550 in #129 while the
+	# decoy stayed fixed), so every number here derives from the header.
 	local esca_id="ap-routing-longctx"
 	fetch_file "index.json" "${TMPDIR_LOCAL}/existing-index.json" "chats"
-	python3 - "$REPO_ROOT" "$TMPDIR_LOCAL" "$esca_id" "$ROUTING_THRESHOLD" <<'PY'
+	python3 - "$REPO_ROOT" "$TMPDIR_LOCAL" "$esca_id" "$ROUTING_THRESHOLD" \
+		"$TRIM_BUDGET" "$EST_CHARS_PER_TOK" <<'PY'
 import json, re, sys
-repo, tmp, cid, threshold = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
+repo, tmp, cid = sys.argv[1], sys.argv[2], sys.argv[3]
+threshold, trim_budget, est_cpt = int(sys.argv[4]), int(sys.argv[5]), float(sys.argv[6])
 body = open(f"{repo}/bench/prompts/long-1k.txt").read()
 m = re.search(r'<\|im_start\|>user\n(.*?)(?:<\|im_end\|>|$)', body, re.S)
 user = (m.group(1) if m else body).strip()
-# ~1.3 tokens per English word; aim 40% above the threshold so tokenizer
-# variation between models cannot drop the turn back onto the CPU side.
+# Real chars-per-token measured on console with the SmolLM2 tokenizer: 7100
+# chars -> 1329 tokens.
+REAL_CPT = 5.34
+# The reachable band in REAL tokens is bounded below by the routing threshold and
+# above by whatever survives the trimmer. Aim at its MIDPOINT rather than near
+# either edge — with the shipping constants the band is only ~135 tokens wide, so
+# there is no comfortable side to hug. That narrowness is itself a finding: see
+# #133 and the pending threshold re-derivation in #130.
+lo = threshold
+hi = trim_budget * est_cpt / REAL_CPT
+target_chars = int((lo + hi) / 2 * REAL_CPT)
 words = user.split()
-target_words = int(threshold * 1.4 / 1.3)
-if len(words) < target_words:
-    words = (words * (target_words // len(words) + 1))[:target_words]
-    user = " ".join(words)
+while len(" ".join(words)) < target_chars:
+    words = words * 2
+user = " ".join(words)[:target_chars]
+est = int(len(user) / est_cpt)
+if est >= trim_budget:
+    sys.exit(f"  decoy estimate {est} >= trimmer budget {trim_budget} — would be dropped")
+if int(len(user) / 5.34) <= threshold:
+    sys.exit(f"  decoy cannot clear threshold {threshold} without exceeding the "
+             f"trimmer budget {trim_budget} — see #133")
 ts = 1
 conv = {"id": cid, "title": "routing A/B (long context)", "messages": [
     {"role": "user", "content": user, "ts": ts, "partial": False},
@@ -240,7 +272,8 @@ except Exception:
 idx = [e for e in idx if e.get("id") != cid]
 idx.insert(0, entry)
 open(f"{tmp}/index.json", "w").write(json.dumps(idx, ensure_ascii=False))
-print(f"  decoy user chars: {len(user)} (~{len(user)//4} tok); index entries: {len(idx)}")
+print(f"  decoy: {len(user)} chars, trimmer estimate {est} tok (budget {trim_budget}), "
+      f"~{int(len(user)/5.34)} real tok (threshold {threshold}); index entries: {len(idx)}")
 PY
 	upload_file "${TMPDIR_LOCAL}/${esca_id}.json" "chats"
 	upload_file "${TMPDIR_LOCAL}/index.json" "chats"
@@ -278,6 +311,16 @@ JSON
 	cpu_line=$(grep -aE 'routing: auto .* cpu \([0-9]+ tok' "$log" | head -1 || true)
 	if [[ -z "$gpu_line" ]]; then
 		echo "  FAIL: no 'auto -> gpu' routing line — long turn did not route to the DML model"
+		# Diagnose the #133 failure mode specifically: if the decoy turn was
+		# trimmed, the CPU line reports a token count far below the decoy's size
+		# and there is a "context trimmed" line. Without this, the symptom
+		# ("no gpu line") points at routing when the cause is the trimmer.
+		if grep -aq 'context trimmed' "$log"; then
+			echo "  cause: BuildPrompt trimmed the decoy turn before routing saw it (#133)"
+			grep -a 'context trimmed' "$log" | tail -1 | sed 's/^/    /'
+		elif [[ -n "$cpu_line" ]]; then
+			echo "  the long turn was counted as: ${cpu_line}"
+		fi
 		verdict=1
 	else
 		local gtok

--- a/tests/test_routing_policy.cpp
+++ b/tests/test_routing_policy.cpp
@@ -115,6 +115,33 @@ TEST_CASE("routing: auto boundary is strictly above the threshold") {
     CHECK(decide_routing(s, 1201, false, true).use_gpu);
 }
 
+TEST_CASE("routing: the threshold stays reachable under the context trimmer") {
+    // #133. BuildPrompt trims oldest turns while its estimate exceeds
+    // kMaxPromptTokens, and it runs BEFORE routing — so a turn longer than that
+    // budget never reaches decide_routing() at its full length. If the threshold
+    // is at or above the budget, auto GPU routing is unreachable for every input
+    // and the feature is dead without any test failing. That is exactly what the
+    // 600 -> 1550 retune in #129 did, and it stayed invisible until a console run.
+    //
+    // The margin below is not decoration: the trimmer measures an ESTIMATE while
+    // routing measures REAL tokens, so they disagree by however much the
+    // chars-per-token constant is off. Leave room for that disagreement.
+    CHECK(RoutingSettings{}.token_threshold < kMaxPromptTokens);
+    CHECK(kMaxPromptTokens - RoutingSettings{}.token_threshold >= 100);
+
+    // The estimator underestimates tokens per char on purpose (see the header):
+    // 5000 chars of prose is ~940 real tokens, and estimating 1000 trims early
+    // rather than overflowing n_ctx.
+    CHECK(estimate_tokens_from_chars(5000) == 1000);
+    CHECK(estimate_tokens_from_chars(0) == 0);
+
+    // The measured console datapoint that found the bug: 7100 chars tokenized to
+    // 1329 real tokens. The estimate must not sit so far above that number that
+    // the trimmer cuts a turn routing would have sent to the GPU.
+    CHECK(estimate_tokens_from_chars(7100) == 1420);
+    CHECK(estimate_tokens_from_chars(7100) < kMaxPromptTokens);
+}
+
 TEST_CASE("routing: gguf disables routing") {
     RoutingSettings s;
     s.mode = RoutingMode::Auto;

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -645,10 +645,12 @@ winrt::fire_and_forget MainPageController::ShowCorrectionDialog(size_t assistant
 }
 
 std::string MainPageController::BuildPrompt(const std::string& user_text, int* out_dropped) const {
-    // Estimate token count (heuristic: chars/4). Trim oldest turns if over limit.
-    // Threshold aligned with n_ctx=2048: 1800 estimated tokens + ~250 generation buffer.
-    constexpr int kMaxEstimatedTokens = 1800;
-    // Collect turns (skip system which always stays)
+    // Estimate token count from characters — no tokenizer is loaded at this
+    // point — and trim oldest turns if over budget. Both the estimator and the
+    // budget live in routing_policy.h next to token_threshold: the trimmer runs
+    // before routing, so its ceiling silently bounds what routing can ever see
+    // (#133). Collect turns (skip system which always stays).
+    constexpr int kMaxEstimatedTokens = ::xllama::kMaxPromptTokens;
     std::vector<size_t> turn_starts; // index of first User message in each turn
     for (size_t i = 0; i < m_current.messages.size(); ++i) {
         if (m_current.messages[i].role == xllama::ui::MessageRole::User)
@@ -666,7 +668,7 @@ std::string MainPageController::BuildPrompt(const std::string& user_text, int* o
                 chars += (int)m_current.messages[i + 1].content.size(); // assistant
         }
         chars += (int)user_text.size(); // new user message
-        return chars / 4;
+        return ::xllama::estimate_tokens_from_chars(static_cast<size_t>(chars));
     };
 
     size_t first_turn = 0;
@@ -2241,7 +2243,7 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
             if (EnsureSession(rs.cpu_model, nullptr))
                 n_tok = m_session->count_tokens(full_prompt);
             else
-                n_tok = static_cast<int>(full_prompt.size() / 4);
+                n_tok = ::xllama::estimate_tokens_from_chars(full_prompt.size());
         }
 
         // #91/#95: for a gpu_model that is not a parity-validated DML text asset,


### PR DESCRIPTION
Closes #133.

## What was wrong

`BuildPrompt` (context trimmer) and `decide_routing` (auto routing) bound the same quantity — tokens in a turn — in different units, and nothing in the codebase related them. The trimmer runs first, so its ceiling silently bounds what routing can ever see.

- Trimmer: estimated `chars / 4`, dropped oldest turns above `kMaxEstimatedTokens = 1800`.
- Routing: real tokenizer count against `token_threshold = 1550`.

English prose measures ~5.34 chars/token, so `chars / 4` overestimated by ~30%: the trimmer actually cut at **~1348 real tokens**, below the 1550 threshold. Auto routing could never reach the GPU.

## Evidence

Measured on console, MSIX 1.4.0.624, with a decoy sized to sit just under the trimmer's ceiling:

```
decoy 7100 chars  -> BuildPrompt estimate 1775 tok (below 1800, NOT trimmed)
[xllama] routing: auto -> cpu (1329 tok, threshold 1550, model=smollm2-360m-cpu-int4)
[xllama] chat turn: reuse=0 prefill=1329 tok decode=18 tok kv_len=1347
```

The turn survived the trimmer intact and still counted only 1329 real tokens. When the decoy was larger, the trimmer dropped the single oversized turn *entirely* and the prompt collapsed to 22 tokens — which is what the failing gate first showed.

Introduced by the 600 -> 1550 retune in #129. It stayed invisible because no test related the constants; `scripts/validate-console.sh routing` caught it the first time it ran after that retune.

## Changes

- `include/xllama/routing_policy.h` — `kEstimatedCharsPerToken` (5.0) and `kMaxPromptTokens` (1800) live next to `token_threshold`, with the measurement recorded. 5.0 is deliberately below the observed 5.34: underestimating chars-per-token means trimming early, which costs context, whereas the other direction risks `n_ctx` overflow.
- `uwp/MainPage.cpp` — trimmer and the routing fallback estimate both use `estimate_tokens_from_chars`.
- `tests/test_routing_policy.cpp` — pins `token_threshold < kMaxPromptTokens` with a 100-token margin, since the two sides measure estimated vs real tokens and disagree by whatever the constant is off by. **Verified the guard fires**: setting the threshold to 1750 fails the test with `CHECK( 50 >= 100 )`.
- `scripts/validate-console.sh` — the decoy derives from both constants and targets the midpoint of the reachable band; the failure path now names the trimmer explicitly instead of leaving "no gpu line" pointing at routing.

## What this does not fix

The reachable band is only **~135 real tokens wide** (1550 to ~1685) even after the fix. That is thin enough to be fragile against tokenizer differences between models. The threshold itself is under re-derivation in #130: the DirectML slowdown it was calibrated against tracks `max_length = min(n_ctx, n_prompt + n_predict)`, not prompt length — every fast point in the sweep is one where that clamp saturates.

## Verification

- Host tests 120/120, 1109 assertions.
- Console re-run of `validate-console.sh routing` pending an MSIX from this branch — the trimmer change ships in the app, so the gate cannot confirm the fix until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt-length estimation when exact tokenization is unavailable.
  * Preserved routing decisions more reliably after long prompts are trimmed.
  * Updated prompt trimming to use a consistent token ceiling and estimation method.
  * Enhanced routing validation diagnostics for trimmed context and missing GPU-routing results.

* **Tests**
  * Added coverage confirming token estimation accuracy and routing thresholds remain reachable after prompt trimming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->