### PR TITLE
fix(#130): the DirectML prefill collapse is in max_length, not prompt length

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,8 +83,10 @@ pin constraints: [`docs/training-architecture.md`](docs/training-architecture.md
       `bench/results/phase10-console-devtrain-result.json`. (Eval fix: the
       device merged model loads by absolute path; the last-block fine-tune has
       no LR decay, so evaluate at the epoch-8 convergence point, not later.)
-- [ ] Widen the trainable filter beyond the last block when the llama.cpp pin
-      gains backward support for the KV-cache `set_rows` write (or carry a patch).
+- [ ] **Blocked** — widen the trainable filter beyond the last block. Waits on
+      the llama.cpp pin gaining backward support for the KV-cache `set_rows`
+      write, or on us carrying a patch. Not actionable as it stands; listed so
+      the gap is visible, not as work anyone can pick up.
 
 ## Phase 11 — Close the headless ↔ UI gap (planned; Phase 10 gates now PASS, unblocked)
 
@@ -104,6 +106,38 @@ headless-only), and the test/API surfaces trail the UI.
 - [ ] LAN API parity (images, preferences, training status) — #118, low
       priority while the API remains a demo.
 
+## Phase 12 — DirectML routing calibration (in progress)
+
+A measurement campaign on the shipping `-v2` asset, prompted by the question of
+whether DirectML is worth routing to at all. Evidence under
+`bench/results/phase12-*.csv`; analysis in `docs/uwp-constraints.md` §5b/§5c.
+
+- [x] Instrument the bench path so a row can be interpreted: `n_prompt_tok` and
+      `n_gen_tok` (#128), then `max_length` — without the variable under study a
+      row carries no information, which cost one throwaway dataset to learn
+      twice. `n_ctx` / `n_predict` controllable from the console (#131).
+- [x] Prompt-length sweep, 10 lengths x 2 backends (#129). Found a reproducible
+      DirectML prefill collapse and retuned `token_threshold` 600 -> 1550 on it.
+- [x] **Root-caused (#130):** the collapse tracks `max_length`, not prompt
+      length. One byte-identical 1289-token prompt varying only `n_predict`
+      swings prefill 130 -> 611 tok/s; a control at `n_ctx` 3072 with
+      `max_length` held fixed reproduces the slow figure, so `n_ctx` has no
+      effect of its own. `Session::generate` now saturates `max_length` at
+      `n_ctx` — faster and less memory. The sweep's numbers stand; the reading
+      that produced 1550 does not.
+- [x] **Fixed (#133):** the 1550 retune put `token_threshold` above the context
+      trimmer's real-token ceiling, so auto GPU routing was unreachable for every
+      input. The two constants now live together with a test pinning the
+      relation. Found by running the console routing gate, which had not been
+      run since the retune.
+- [ ] Re-derive `token_threshold` on the corrected model. It is still calibrated
+      against prompt length, and the reachable band under the trimmer is only
+      ~135 tokens wide — thin enough to be fragile across tokenizers.
+- [ ] Explain the `max_length` valley. Suspected shape-bucketed DirectML kernel
+      selection; the per-node profiler cannot localise it alone (the graph is one
+      `DmlFusedNode_0_0` at 96% of kernel time, §12). Not distinguished yet:
+      per-process lazy kernel compilation, WDDM residency on absolute bytes.
+
 ## Upstream and vendor lifecycle
 
 Operational details live in `docs/vendor-lifecycle-plan.md`.
@@ -114,8 +148,10 @@ Operational details live in `docs/vendor-lifecycle-plan.md`.
 - [x] Lift the DML text gate (#110): `dml_text_model_ok` allowlist behind
       `token_threshold`, `-v2` asset published on models-v1
       (`docs/dml-rmsnorm-fix-runbook.md`).
-- [ ] Upstream the RMSNorm kernel finding (#111) — fork/analyze/fix where
-      needed, minimal single-op repro; re-test at every GameOS/driver update.
+- [~] Upstream the RMSNorm kernel finding (#111 — **closed**; the repro and
+  analysis are done and the workaround ships). What remains is not a task but
+  a standing watch: re-test at every GameOS/driver update, since a driver fix
+  would let `dml_text_model_ok` widen beyond the single `-v2` allowlist entry.
 - [ ] Re-evaluate fused low-bit DirectML GEMM only after upstream capability
       changes; it is not a local application task.
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -28,8 +28,10 @@ appear in the consolidated comparison.
   - `gpu_mem_mb` / `gpu_budget_mb`: per-process GPU memory CurrentUsage/Budget after model load (`QueryVideoMemoryInfo`, LOCAL segment); 0 on CPU-only runs and Linux builds
   - `n_prompt_tok`: prefill token count actually measured. Without it a row cannot be compared with one taken at another prompt length — the reason the pre-2026-07 DirectML rows are not re-readable.
   - `n_gen_tok`: tokens actually generated. **Not** the requested `n_predict`: generation is capped by the context window (`prompt + new <= n_ctx`) and can stop early on EOG. A 1574-token prompt at `n_ctx` 2048 caps new tokens at 474 and generated 277.
-- **CSV schema**: `model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,n_prompt_tok,n_gen_tok,host,date`
-  Rows written before 2026-07-21 have 13 columns and no prompt/generated counts; rows in `phase12-dml-crossover.csv` carry `n_prompt_tok` but leave `n_gen_tok` empty (the console build that produced them predates that column). `bench-xbox-ort.sh` refuses to append to a file whose header does not match, so mixed-arity files cannot be created by accident.
+- **CSV schema**: `model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,n_prompt_tok,n_gen_tok,max_length,host,date`
+  Rows written before 2026-07-21 have 13 columns and no prompt/generated counts; rows in `phase12-dml-crossover.csv` carry `n_prompt_tok` but leave `n_gen_tok` empty (the console build that produced them predates that column). `bench-xbox-ort.sh` refuses to append to a file whose header does not match, and now also rejects a row whose **field count** disagrees with the schema — an MSIX older than the header writes fewer fields, and appending them under the current header shifts every column silently. That happened on 2026-07-21 with 1.4.0.615.
+
+  `max_length` (added 2026-07-21) is `min(n_ctx, n_prompt_tok + n_predict)`, the value actually requested of the engine. On DirectML it is the variable that governs prefill throughput — see #130 and `docs/uwp-constraints.md` §5c — so a row without it cannot be interpreted, and `n_ctx` does not substitute for it.
 
 **Backend field values**:
 

--- a/bench/results/phase12-maxlen-band.csv
+++ b/bench/results/phase12-maxlen-band.csv
@@ -1,0 +1,9 @@
+model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,n_prompt_tok,n_gen_tok,max_length,host,date
+smollm2-360m-dml-fp16-v2,fp16,ort-genai-dml,2048,8,510.89,9.75,1905,2828,793,3801,1289,7,1297,xbox-series-s,2026-07-21T11:41:14Z
+smollm2-360m-dml-fp16-v2,fp16,ort-genai-dml,2048,8,472.28,34.78,1906,2833,793,3801,1289,110,1400,xbox-series-s,2026-07-21T11:41:47Z
+smollm2-360m-dml-fp16-v2,fp16,ort-genai-dml,2048,8,149.63,36.25,1897,2811,793,3801,1289,213,1545,xbox-series-s,2026-07-21T11:42:35Z
+smollm2-360m-dml-fp16-v2,fp16,ort-genai-dml,2048,8,194.95,36.12,1969,2843,793,3801,1289,213,1650,xbox-series-s,2026-07-21T11:43:23Z
+smollm2-360m-dml-fp16-v2,fp16,ort-genai-dml,2048,8,131.09,34.40,1970,2786,793,3801,1289,213,1801,xbox-series-s,2026-07-21T11:44:17Z
+smollm2-360m-dml-fp16-v2,fp16,ort-genai-dml,2048,8,211.79,34.30,2483,2861,793,3801,1289,252,1950,xbox-series-s,2026-07-21T11:45:04Z
+smollm2-360m-dml-fp16-v2,fp16,ort-genai-dml,2048,8,611.68,33.42,1970,2809,793,3801,1289,213,2048,xbox-series-s,2026-07-21T11:45:49Z
+smollm2-360m-dml-fp16-v2,fp16,ort-genai-dml,3072,8,131.09,34.46,1971,2831,793,3801,1289,213,1801,xbox-series-s,2026-07-21T11:46:57Z

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -1,6 +1,6 @@
 # UWP Constraints
 
-> **SSOT for UWP/AppContainer constraints** (numbered §1–§13, plus §5b on prefill vs prompt length): the measured GPU
+> **SSOT for UWP/AppContainer constraints** (numbered §1–§13, plus §5b/§5c on DirectML prefill): the measured GPU
 > budget (3801 MB), the 2 GB per-file limit, disk budget, no-mmap, `887A0036`,
 > `weakly_canonical`, thread cap, and the DirectML low-bit GEMM analysis. Other
 > docs link to a `§n` here rather than restating these.
@@ -131,6 +131,13 @@ reproduced. Raw rows: `bench/results/phase12-dml-crossover.csv`.
 | 1574       | 196         | **636**     | 2.47 s           | 975 tok           | **474**        |
 | 1671       | —           | 681         | 2.45 s           | —                 | 377            |
 
+> **Superseded in part by §5c (2026-07-21, same day).** Finding 1 below reads the
+> anomaly as a band in _prompt length_. It is not: a controlled experiment holding
+> the prompt byte-identical and varying only `n_predict` showed the controlling
+> variable is `max_length`. The measurements in this table are correct; the
+> interpretation of finding 1, and the threshold in finding 3 that follows from
+> it, are not. Read §5c before using either.
+
 Three findings:
 
 1. **There is a pathological band, roughly 1100–1500 tokens.** GPU prefill time
@@ -161,6 +168,58 @@ now controllable from the console bench path (`bench_ctx.txt` /
 uses to test whether the band's edges track `n_ctx`. Note also that `n_gen_tok`
 is blank for these rows: the column was added after they were taken
 (`src/bridge/bench.cpp`), so turn times here are derived from the rates.
+
+### §5c — The anomaly is in `max_length`, not prompt length (2026-07-21)
+
+§5b read the slowdown as a band in prompt length. A controlled experiment says
+otherwise. One prompt file, 1289 tokens, **byte-identical across every run**;
+`n_ctx` 2048 unless stated; only `n_predict` varied, which moves
+`max_length = min(n_ctx, n_prompt_tok + n_predict)`. Median of 2 runs after a
+dropped warmup; pairs reproduced to three digits.
+
+| `max_length` | `n_ctx`  | GPU prefill | time   | peak WS |
+| ------------ | -------- | ----------- | ------ | ------- |
+| 1297         | 2048     | 515 tok/s   | 2.50 s | 1906 MB |
+| 1400         | 2048     | 475         | 2.71 s | 1907 MB |
+| 1545         | 2048     | **170**     | 7.58 s | 1906 MB |
+| 1650         | 2048     | 215         | 6.00 s | 1970 MB |
+| 1801         | 2048     | **130**     | 9.92 s | 1969 MB |
+| 1801         | **3072** | 132         | 9.77 s | 1972 MB |
+| 1950         | 2048     | 212         | 6.08 s | 2483 MB |
+| 2048         | 2048     | **611**     | 2.11 s | 1968 MB |
+
+1. **The prompt never changed, so this is not a prompt-length effect.** A 4.7×
+   swing in prefill throughput on identical input tokens.
+2. **`n_ctx` has no effect of its own.** The control row — `n_ctx` 3072 holding
+   `max_length` at 1801 — reproduces the 2048 row exactly (132 vs 130 tok/s).
+   This matches the code: on the ORT path `params.n_ctx` appears in exactly one
+   place, the `min()` that computes `max_length` (`src/bridge/inference.cpp`,
+   `src/bridge/session.cpp`). It is never passed to ORT GenAI as a context size;
+   the model's real context is `context_length: 8192` in `genai_config.json`.
+3. **The valley is interior, with both edges clean.** Fast at 1297–1400, fast
+   again at 2048, slowest near 1800. It is a dip, not a step.
+4. **It is not memory pressure, and saturating is not expensive.** The fastest
+   row (2048) has a _smaller_ working set than the 1950 row (1968 vs 2483 MB).
+5. **The shipping default sat inside the valley.** `n_predict` 256 on a
+   1289-token prompt gives `max_length` 1545 — 170 tok/s where 611 was available.
+
+**Consequence.** `Session::generate` now requests the full `m_n_ctx` as
+`max_length` and bounds generation with the `n_predict` cap in `run_decode` —
+which is what the KV-reuse chat path already did, so the two paths are now
+symmetric. This is a straight win: faster and no more memory.
+
+`run_inference` (CLI and bench) deliberately keeps the old `min()`. It is the
+instrument that found this, and sweeping `max_length` independently of `n_ctx`
+is the only way to re-measure the valley on a new asset or driver.
+
+The mechanism remains **unknown** — suspected shape-bucketed kernel selection in
+DirectML, which the per-node profiler (§11) cannot localise on its own because
+the graph collapses into a single `DmlFusedNode_0_0` at 96% of kernel time.
+Because §5b's finding 3 rests on the prompt-length reading, `token_threshold`
+(1550) is calibrated on a misattributed variable and is under re-derivation; it
+also has to stay below the context trimmer's budget, which is #133.
+
+Raw rows: `bench/results/phase12-maxlen-band.csv`.
 
 ### §5 (continued) — disk, availability and the App/Game lever
 

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -179,29 +179,36 @@ dropped warmup; pairs reproduced to three digits.
 
 | `max_length` | `n_ctx`  | GPU prefill | time   | peak WS |
 | ------------ | -------- | ----------- | ------ | ------- |
-| 1297         | 2048     | 515 tok/s   | 2.50 s | 1906 MB |
-| 1400         | 2048     | 475         | 2.71 s | 1907 MB |
-| 1545         | 2048     | **170**     | 7.58 s | 1906 MB |
-| 1650         | 2048     | 215         | 6.00 s | 1970 MB |
-| 1801         | 2048     | **130**     | 9.92 s | 1969 MB |
-| 1801         | **3072** | 132         | 9.77 s | 1972 MB |
-| 1950         | 2048     | 212         | 6.08 s | 2483 MB |
-| 2048         | 2048     | **611**     | 2.11 s | 1968 MB |
+| 1297         | 2048     | 511 tok/s   | 2.52 s | 1905 MB |
+| 1400         | 2048     | 472         | 2.73 s | 1906 MB |
+| 1545         | 2048     | **150**     | 8.61 s | 1897 MB |
+| 1650         | 2048     | 195         | 6.61 s | 1969 MB |
+| 1801         | 2048     | **131**     | 9.83 s | 1970 MB |
+| 1801         | **3072** | 131         | 9.83 s | 1971 MB |
+| 1950         | 2048     | 212         | 6.09 s | 2483 MB |
+| 2048         | 2048     | **612**     | 2.11 s | 1970 MB |
 
-1. **The prompt never changed, so this is not a prompt-length effect.** A 4.7×
-   swing in prefill throughput on identical input tokens.
+Taken twice, two hours apart, on two different MSIX builds (1.4.0.624 and
+1.4.0.628); every point reproduced. The table is the second set — the one whose
+rows carry `max_length` as a column. The first set is not committed: it predates
+that column, so its rows differ only in `prompt_tok_s` and cannot be told apart.
+That is the same defect `n_prompt_tok` fixed in #128, and the reason to
+re-measure rather than annotate by hand.
+
+1. **The prompt never changed, so this is not a prompt-length effect.** A 4.1×
+   swing in prefill throughput on identical input tokens (511 → 131 → 612).
 2. **`n_ctx` has no effect of its own.** The control row — `n_ctx` 3072 holding
-   `max_length` at 1801 — reproduces the 2048 row exactly (132 vs 130 tok/s).
-   This matches the code: on the ORT path `params.n_ctx` appears in exactly one
+   `max_length` at 1801 — reproduces the 2048 row to the digit (131.09 tok/s in
+   both). This matches the code: on the ORT path `params.n_ctx` appears in exactly one
    place, the `min()` that computes `max_length` (`src/bridge/inference.cpp`,
    `src/bridge/session.cpp`). It is never passed to ORT GenAI as a context size;
    the model's real context is `context_length: 8192` in `genai_config.json`.
 3. **The valley is interior, with both edges clean.** Fast at 1297–1400, fast
    again at 2048, slowest near 1800. It is a dip, not a step.
 4. **It is not memory pressure, and saturating is not expensive.** The fastest
-   row (2048) has a _smaller_ working set than the 1950 row (1968 vs 2483 MB).
+   row (2048) has a _smaller_ working set than the 1950 row (1970 vs 2483 MB).
 5. **The shipping default sat inside the valley.** `n_predict` 256 on a
-   1289-token prompt gives `max_length` 1545 — 170 tok/s where 611 was available.
+   1289-token prompt gives `max_length` 1545 — 150 tok/s where 612 was available.
 
 **Consequence.** `Session::generate` now requests the full `m_n_ctx` as
 `max_length` and bounds generation with the `n_predict` cap in `run_decode` —

--- a/include/xllama/inference_params.h
+++ b/include/xllama/inference_params.h
@@ -80,6 +80,13 @@ struct InferenceResult {
     bool ended_with_stop = false; // true = stopped on a stop sequence; false = n_predict/EOS cap.
                                   // Lets a KV-reuse caller know whether the closing <|im_end|>
                                   // is already in the KV cache when building the next turn's delta.
+    // #130: the max_length actually requested of the engine. On DirectML this is
+    // the variable that controls prefill throughput — a 1289-token prompt runs at
+    // 130 tok/s at max_length 1801 and 611 tok/s at 2048, unchanged otherwise —
+    // so a bench row that omits it cannot be interpreted, the same way a row
+    // without n_prompt_tok could not (#128). Derived, not independently settable:
+    // min(n_ctx, n_prompt_tok + n_predict) on the stateless path. 0 = N/A (GGUF).
+    int max_length = 0;
     size_t peak_ws_mb = 0;
     size_t gpu_mem_mb = 0;    // per-process GPU CurrentUsage after model load (0 = N/A)
     size_t gpu_budget_mb = 0; // OS-granted GPU budget for this process (0 = N/A)

--- a/scripts/bench-xbox-ort.sh
+++ b/scripts/bench-xbox-ort.sh
@@ -308,6 +308,10 @@ printf 'bench' >"${TMPDIR_LOCAL}/bench.flag"
 # ---------------------------------------------------------------------------
 declare -a CSV_ROWS=()
 
+# Defined before the run loop, not just before the median: each downloaded row is
+# checked against this schema's field count as it arrives (see below).
+CSV_HEADER="model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,n_prompt_tok,n_gen_tok,max_length,host,date"
+
 SAMPLER_PID=""
 if [[ "$GPU_SAMPLE" == "true" ]]; then
 	echo "  Starting GPU sampler (systemperf)..."
@@ -351,6 +355,21 @@ for ((run = 1; run <= N_RUNS; run++)); do
 	download_from_localstate "bench-result.csv" "$local_csv"
 	data_row=$(tail -n +2 "$local_csv" 2>/dev/null | head -1)
 	if [[ -n "$data_row" ]]; then
+		# The device writes the row; this script owns the header. A build older
+		# than the current schema emits fewer fields and they get appended under
+		# our header anyway, shifting every column silently (a 14-field row from a
+		# pre-n_gen_tok build puts `host` under n_gen_tok and `date` under host).
+		# assert_header_matches only guards the local file, so nothing else here
+		# would notice. Observed 2026-07-21 with MSIX 1.4.0.615.
+		n_fields=$(awk -F, '{print NF}' <<<"$data_row")
+		want_fields=$(awk -F, '{print NF}' <<<"$CSV_HEADER")
+		if ((n_fields != want_fields)); then
+			echo "Error: the console wrote a ${n_fields}-field row; this script expects ${want_fields}." >&2
+			echo "  row:    $data_row" >&2
+			echo "  header: $CSV_HEADER" >&2
+			echo "The installed MSIX is older than the CSV schema — redeploy before benchmarking." >&2
+			exit 1
+		fi
 		CSV_ROWS+=("$data_row")
 		echo "  Row: $data_row"
 	else
@@ -373,7 +392,6 @@ fi
 echo ""
 echo "--- Computing median ---"
 RESULT_CSV="${OUT_CSV:-${REPO_ROOT}/bench/results/phase1-cpu.csv}"
-CSV_HEADER="model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,n_prompt_tok,n_gen_tok,host,date"
 [[ ! -f "$RESULT_CSV" ]] && printf '%s\n' "$CSV_HEADER" >"$RESULT_CSV"
 
 # Refuse to append to a file written under an older schema: the row arity would

--- a/scripts/profile-dml-run.sh
+++ b/scripts/profile-dml-run.sh
@@ -251,6 +251,14 @@ delete_file "" "bench-result.csv.done"
 # scripts/bench-xbox-kv.sh is enough to do it. bench-xbox-ort.sh clears it for
 # the same reason.
 delete_file "" "bench_turns.txt"
+# Same class of hazard, and quieter: bench-xbox-ort.sh --ctx / --n-predict leave
+# bench_ctx.txt and bench_npredict.txt behind, and main_loop honours whatever it
+# finds. A profile run after a sweep would silently inherit that sweep's n_ctx
+# and n_predict — no error, just a profile of the wrong configuration. Neither
+# file is ever deleted by the bench script (it only overwrites them), so clearing
+# them here is the only thing that makes a profile run self-contained.
+delete_file "" "bench_ctx.txt"
+delete_file "" "bench_npredict.txt"
 
 # Append-only log: remember current size to slice only the new tail later.
 download_file "" "xllama.log" "${TMPDIR_LOCAL}/xllama_before.log"

--- a/src/bridge/bench.cpp
+++ b/src/bridge/bench.cpp
@@ -107,9 +107,16 @@ void write_bench_csv(const InferenceParams& params, const InferenceResult& res,
     // 1574-token prompt at n_ctx 2048 caps new tokens at 474 and generated 277.
     // Placed before `host` so the positional parsing in bench-xbox-ort.sh
     // ($3 backend, $7 decode_tok_s) keeps working.
+    // max_length: #130. On DirectML this is what actually governs prefill
+    // throughput — the same 1289-token prompt runs at 130 tok/s with max_length
+    // 1801 and 611 tok/s with 2048. n_ctx does not capture it (a control run at
+    // n_ctx 3072 holding max_length at 1801 reproduced the slow figure), and
+    // neither do n_prompt_tok and n_gen_tok, since generation can stop early on
+    // EOG well below the cap. Appended before `host` for the same reason as the
+    // token counts: bench-xbox-ort.sh parses $3 and $7 positionally.
     const char* header = "model,quant,backend,n_ctx,n_threads,"
                          "prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,"
-                         "gpu_mem_mb,gpu_budget_mb,n_prompt_tok,n_gen_tok,host,date\n";
+                         "gpu_mem_mb,gpu_budget_mb,n_prompt_tok,n_gen_tok,max_length,host,date\n";
     fputs(header, fp);
 
     double prompt_tok_s = (res.n_p_eval > 0 && res.t_p_eval_ms > 0)
@@ -167,10 +174,10 @@ void write_bench_csv(const InferenceParams& params, const InferenceResult& res,
     const int used_threads = params.n_threads > 0
                                  ? params.n_threads
                                  : (is_llama ? detect_threads_llama() : detect_threads());
-    fprintf(fp, "%s,%s,%s,%d,%d,%.2f,%.2f,%zu,%.0f,%zu,%zu,%d,%d,%s,%s\n", model_name.c_str(),
+    fprintf(fp, "%s,%s,%s,%d,%d,%.2f,%.2f,%zu,%.0f,%zu,%zu,%d,%d,%d,%s,%s\n", model_name.c_str(),
             quant.c_str(), backend, params.n_ctx, used_threads, prompt_tok_s, decode_tok_s,
             res.peak_ws_mb, res.t_load_ms, res.gpu_mem_mb, res.gpu_budget_mb, res.n_p_eval,
-            res.n_eval, host_label ? host_label : "unknown", date_buf);
+            res.n_eval, res.max_length, host_label ? host_label : "unknown", date_buf);
     fclose(fp);
 
     // Write done marker

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -178,6 +178,7 @@ InferenceResult run_inference_ort(const InferenceParams& params) {
         // routed turn exceeded max_length 768 before generating a single token).
         const int max_len =
             std::min(params.n_ctx, static_cast<int>(n_prompt_tok) + params.n_predict);
+        res.max_length = max_len;
         {
             char pbuf[128];
             snprintf(pbuf, sizeof(pbuf), "[xllama] prompt=%zu tok, max_length=%d (new≤%d)\n",

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -200,12 +200,27 @@ class OrtSession final : public Session {
                   "OgaTokenizerEncode");
         int n_prompt_tok = static_cast<int>(OgaSequencesGetSequenceCount(seqs.get(), 0));
 
-        // Size max_length from the ACTUAL prompt, clamped to the model context.
-        // The old fixed "n_predict + 512" headroom was structurally too small for
-        // routed turns: routing sends >600-token prompts to the GPU, so a 959-tok
-        // turn hit "input_ids size (959) ... exceeds max length (768)".
-        const int max_len = std::min(m_n_ctx, n_prompt_tok + gp.n_predict);
-        OgaGeneratorParamsPtr gparams = make_params(gp, max_len);
+        // #130: request the FULL context as max_length and bound generation with
+        // the n_predict cap in run_decode — exactly what generate_chat already
+        // does. The obvious alternative, max_length = min(n_ctx, prompt +
+        // n_predict), is what this used to do, and on DirectML it is 3-4x slower.
+        //
+        // Measured 2026-07-21, Series S, one byte-identical 1289-token prompt,
+        // only n_predict varied (bench/results/phase12-maxlen-band.csv):
+        //
+        //   max_length  1297  1400  1545  1650  1801  1950  2048
+        //   prefill t/s   515   475   170   215   130   212   611
+        //
+        // There is a valley in max_length between ~1400 and n_ctx, deepest near
+        // 1800, with both edges clean. The prompt never changed, so this is not a
+        // prompt-length effect. A control run at n_ctx 3072 holding max_length at
+        // 1801 reproduced the slow figure (132 t/s), so n_ctx has no effect of its
+        // own — max_length alone controls it. Saturating also costs LESS memory
+        // here (1968 MB against 2483 at max_length 1950).
+        //
+        // The shipping default (n_predict 256) landed at 1545 — inside the valley.
+        // Mechanism still unknown; suspected shape-bucketed DML kernel selection.
+        OgaGeneratorParamsPtr gparams = make_params(gp, m_n_ctx);
         OgaGenerator* raw_gen = nullptr;
         oga_check(OgaCreateGenerator(m_model.get(), gparams.get(), &raw_gen), "OgaCreateGenerator");
         OgaGeneratorPtr gen(raw_gen);
@@ -214,7 +229,16 @@ class OrtSession final : public Session {
             gp.on_status("generating");
         auto t0 = std::chrono::steady_clock::now();
         oga_check(OgaGenerator_AppendTokenSequences(gen.get(), seqs.get()), "AppendTokenSequences");
-        run_decode(gen.get(), stream.get(), gp, res, t0, n_prompt_tok, 0);
+        // Reproduce the old allowance exactly. The previous max_length of
+        // min(n_ctx, prompt + n_predict) permitted min(n_ctx - prompt, n_predict)
+        // new tokens; max_length is no longer the bound, so the cap has to carry
+        // that arithmetic or a long prompt would now generate past the context.
+        // Clamped to >= 1 because run_decode treats a cap of 0 as "no cap": a
+        // prompt at or beyond the context would otherwise flip from a hard stop
+        // to unbounded generation. Such a prompt fails inside ORT first
+        // ("input_ids size exceeds max length"), which is the intended error.
+        const int n_predict_cap = std::max(1, std::min(m_n_ctx - n_prompt_tok, gp.n_predict));
+        run_decode(gen.get(), stream.get(), gp, res, t0, n_prompt_tok, n_predict_cap);
         log_gen(res, false);
     }
 

--- a/tests/test_bench.cpp
+++ b/tests/test_bench.cpp
@@ -30,7 +30,7 @@ static std::vector<std::string> split_csv(const std::string& line) {
 
 static const char* kExpectedHeader = "model,quant,backend,n_ctx,n_threads,prompt_tok_s,"
                                      "decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,"
-                                     "n_prompt_tok,n_gen_tok,host,date";
+                                     "n_prompt_tok,n_gen_tok,max_length,host,date";
 
 static xllama::InferenceParams make_params() {
     xllama::InferenceParams p;
@@ -81,7 +81,8 @@ TEST_CASE("Bench CSV writer: basic output") {
     // token count a row cannot be compared against one taken at another length.
     CHECK(f[11] == "10"); // n_prompt_tok = res.n_p_eval
     CHECK(f[12] == "20"); // n_gen_tok  = res.n_eval
-    CHECK(f[13] == "linux-test");
+    CHECK(f[13] == "0");  // max_length — unset on this result (GGUF path)
+    CHECK(f[14] == "linux-test");
 
     // Clean up
     std::remove(csv_path.c_str());
@@ -138,6 +139,10 @@ TEST_CASE("Bench CSV writer: gpu memory columns") {
     res.peak_ws_mb = 512;
     res.gpu_mem_mb = 300;
     res.gpu_budget_mb = 768;
+    // #130: max_length governs DirectML prefill throughput, so a row without it
+    // cannot be interpreted. Assert a non-zero value reaches the CSV — asserting
+    // only the GGUF-path 0 above would pass even if the field were never wired.
+    res.max_length = 1801;
 
     xllama::write_bench_csv(params, res, "linux-test");
 
@@ -153,13 +158,14 @@ TEST_CASE("Bench CSV writer: gpu memory columns") {
     std::getline(ifs, row);
     const std::vector<std::string> f = split_csv(row);
     REQUIRE(f.size() == split_csv(kExpectedHeader).size());
-    CHECK(f[7] == "512");  // peak_ws_mb
-    CHECK(f[8] == "1000"); // load_ms
-    CHECK(f[9] == "300");  // gpu_mem_mb
-    CHECK(f[10] == "768"); // gpu_budget_mb
-    CHECK(f[11] == "0");   // n_prompt_tok — n_p_eval is left unset on this result
-    CHECK(f[12] == "20");  // n_gen_tok
-    CHECK(f[13] == "linux-test");
+    CHECK(f[7] == "512");   // peak_ws_mb
+    CHECK(f[8] == "1000");  // load_ms
+    CHECK(f[9] == "300");   // gpu_mem_mb
+    CHECK(f[10] == "768");  // gpu_budget_mb
+    CHECK(f[11] == "0");    // n_prompt_tok — n_p_eval is left unset on this result
+    CHECK(f[12] == "20");   // n_gen_tok
+    CHECK(f[13] == "1801"); // max_length
+    CHECK(f[14] == "linux-test");
 
     std::remove(csv_path.c_str());
     std::string done_path = xllama::resolve_local_path("bench-result.csv.done");


### PR DESCRIPTION
Addresses #130.

## The reframing

#129 read the DirectML slowdown as a band in **prompt length** and calibrated `token_threshold = 1550` on that reading. A controlled experiment shows the controlling variable is `max_length`.

One prompt file, 1289 tokens, **byte-identical across every run**. `n_ctx` 2048 unless stated. Only `n_predict` varied, which moves `max_length = min(n_ctx, n_prompt_tok + n_predict)`. Median of 2 runs after a dropped warmup; pairs reproduced to three digits.

| `max_length` | `n_ctx` | GPU prefill | time | peak WS |
| --- | --- | --- | --- | --- |
| 1297 | 2048 | 515 tok/s | 2.50 s | 1906 MB |
| 1400 | 2048 | 475 | 2.71 s | 1907 MB |
| 1545 | 2048 | **170** | 7.58 s | 1906 MB |
| 1650 | 2048 | 215 | 6.00 s | 1970 MB |
| 1801 | 2048 | **130** | 9.92 s | 1969 MB |
| 1801 | **3072** | 132 | 9.77 s | 1972 MB |
| 1950 | 2048 | 212 | 6.08 s | 2483 MB |
| 2048 | 2048 | **611** | 2.11 s | 1968 MB |

1. **The prompt never changed** — a 4.7x swing in prefill throughput on identical input tokens. Not a prompt-length effect.
2. **`n_ctx` has no effect of its own.** The control row (`n_ctx` 3072 holding `max_length` at 1801) reproduces the 2048 row. This matches the code: on the ORT path `params.n_ctx` appears in exactly one place, the `min()` computing `max_length`, and is never passed to GenAI as a context size — the model's real context is `context_length: 8192` in `genai_config.json`.
3. **The valley is interior**, deepest near 1800, both edges clean. A dip, not a step.
4. **Not memory pressure, and saturating is not expensive**: the fastest row has a *smaller* working set than the 1950 row.
5. **The shipping default sat inside it** — `n_predict` 256 on a 1289-token prompt gives 1545, so 170 tok/s where 611 was available.

## Changes

- `src/bridge/session.cpp` — the stateless path requests the full `m_n_ctx` as `max_length` and bounds generation with the `n_predict` cap in `run_decode`, which is what `generate_chat` already did. The two paths are now symmetric. The cap reproduces the old allowance exactly, `min(n_ctx - prompt, n_predict)`, clamped to >= 1 because `run_decode` reads 0 as "no cap" — without that clamp an over-long prompt would flip from a hard stop to unbounded generation.
- `src/bridge/inference.cpp` keeps the old `min()` **on purpose**: it is the instrument that found this, and sweeping `max_length` independently of `n_ctx` is how the valley gets re-measured on a new asset or driver. It now records `max_length` in the result.
- `max_length` becomes a bench CSV column. The eight rows this experiment produced differ only in `prompt_tok_s` — the variable under study was not recorded, so they are uninterpretable, exactly the problem `n_prompt_tok` fixed in #128. The bench test asserts a non-zero value reaches the file, not only the GGUF-path 0.
- `scripts/bench-xbox-ort.sh` rejects a device row whose field count disagrees with the schema. A 14-field row from an older MSIX was appended under the 15-field header this morning and every column shifted silently; `assert_header_matches` only guards the local file.
- `scripts/profile-dml-run.sh` clears `bench_ctx.txt` / `bench_npredict.txt`. The bench script only ever overwrites them, so a profile run after a sweep silently inherited that sweep's configuration.
- `docs/uwp-constraints.md` — new §5c; §5b carries a superseded banner over the finding that was misread (its measurements stand, its interpretation does not).

## What is still open

The **mechanism** is unknown — suspected shape-bucketed kernel selection in DirectML. The per-node profiler cannot localise it alone: the graph collapses into a single `DmlFusedNode_0_0` at 96% of kernel time (§12).

`token_threshold` is still calibrated on the misattributed variable and needs re-deriving. It also has to stay under the context trimmer's budget — see #133, merged separately.

## Verification

- Host tests 120/120, 1111 assertions. Note the `session.cpp` change is inside `XLLAMA_USE_ORT` and is **not** compiled by the Linux test build — the Windows CI lane is what covers it.
- `bench/results/phase12-maxlen-band.csv` is pending: the raw rows above were taken before `max_length` was a column, so they are being re-measured on an MSIX from this branch rather than annotated by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `max_length` to benchmark results for improved DirectML performance analysis.
  * Updated generation behavior to preserve output limits while using the full context window for improved consistency.

* **Bug Fixes**
  * Prevented benchmark data corruption when result files use an unexpected column count.
  * Ensured profiling runs do not inherit stale context or generation settings.

* **Documentation**
  * Documented the relationship between DirectML performance and `max_length`, including updated findings and roadmap status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->