### PR TITLE
fix(#125): the CLI and the GUI ran different samplers

### DIFF
--- a/include/xllama/inference_params.h
+++ b/include/xllama/inference_params.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "xllama/sampling.h"
+
 #include <atomic>
 #include <functional>
 #include <string>
@@ -24,12 +26,28 @@ struct InferenceParams {
     // sets prefill throughput on the Zen 2 CPU — the sweep knob for TTFT tuning.
     int n_batch = 0;
     int n_ubatch = 0;
-    float temperature = 0.8f;
-    uint32_t seed = 0xFFFFFFFF; // 0xFFFFFFFF = LLAMA_DEFAULT_SEED
+    // Sampling. Defaults come from xllama/sampling.h so the CLI/bench surface
+    // cannot drift from the GUI/API surface (GenerateParams) the way it did
+    // before #125, when this path had no top_p / top_k / repetition_penalty at
+    // all and silently ran a different sampler.
+    float temperature = sampling_defaults::kTemperature;
+    float top_p = sampling_defaults::kTopP;
+    int top_k = sampling_defaults::kTopK;
+    float repetition_penalty = sampling_defaults::kRepetitionPenalty;
+    uint32_t seed = sampling_defaults::kSeed;
 
     // Deterministic decode: pick argmax instead of sampling. Prerequisite for
     // cross-backend logit parity (llama.cpp vs ORT must agree token-for-token).
     bool greedy = false;
+
+    SamplingConfig sampling() const {
+        return SamplingConfig{temperature, top_p, top_k, repetition_penalty, seed, greedy};
+    }
+
+    // CLI --chat / --system: system message for the chat template. Empty = the
+    // built-in default. The GUI and the LAN API have always made this
+    // configurable; the CLI hardcoded it (#125).
+    std::string system_prompt;
 
     // Logit-parity harness: when non-empty, dump the last prefill-token logit
     // vector (float32, vocab_size values) to this path plus a "<path>.json"

--- a/include/xllama/sampling.h
+++ b/include/xllama/sampling.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 Venere Labs
+// SPDX-License-Identifier: MIT
+// Sampling defaults shared by every surface, and the one place the llama.cpp
+// sampler chain is assembled.
+//
+// #125: InferenceParams (CLI, bench) and GenerateParams (GUI, LAN API) each
+// carried their own sampling fields and each built their own chain. They had
+// drifted into two different samplers: the CLI ran temp -> dist only, with no
+// top_p, top_k or repetition penalty at all, so a generation seen in the GUI
+// could not be reproduced from the command line. Nothing detected it because
+// every marker gate runs --greedy, which bypasses sampling entirely.
+//
+// The defaults below are the single source; both structs initialise from them
+// and tests/test_sampling.cpp pins that they agree. The chain builder is shared
+// for the same reason: the stage ORDER is part of the behaviour, not a detail.
+#pragma once
+
+#include <cstdint>
+
+namespace xllama {
+namespace sampling_defaults {
+
+inline constexpr float kTemperature = 0.8f;
+inline constexpr float kTopP = 0.9f;
+inline constexpr int kTopK = 40;
+inline constexpr float kRepetitionPenalty = 1.1f;
+// Window the repetition penalty looks back over. Not exposed as a flag —
+// llama.cpp's own default is 64 and no surface has ever varied it.
+inline constexpr int kPenaltyLastN = 64;
+inline constexpr uint32_t kSeed = 0xFFFFFFFF; // LLAMA_DEFAULT_SEED
+
+} // namespace sampling_defaults
+
+// The sampling knobs, in one shape. Both InferenceParams and GenerateParams
+// expose these values; this struct is what crosses the boundary when one surface
+// hands its configuration to another (CLI -> run_inference, API -> Session).
+struct SamplingConfig {
+    float temperature = sampling_defaults::kTemperature;
+    float top_p = sampling_defaults::kTopP;
+    int top_k = sampling_defaults::kTopK;
+    float repetition_penalty = sampling_defaults::kRepetitionPenalty;
+    uint32_t seed = sampling_defaults::kSeed;
+    // Deterministic decode: argmax instead of sampling. Prerequisite for
+    // cross-backend logit parity (llama.cpp and ORT must agree token-for-token).
+    bool greedy = false;
+
+    // Argmax is also what temperature 0 means, and the full chain must NOT run
+    // in that case: the repetition penalty reweighs prompt tokens BEFORE the
+    // temp stage's argmax and can flip the top token (observed on device —
+    // LFM2.5 answered "User\n\n<|end|>" at temperature 0 through the endpoint
+    // while pure argmax on the same prompt answered "Hello!").
+    bool is_greedy() const {
+        return greedy || temperature <= 0.0f;
+    }
+};
+
+} // namespace xllama

--- a/include/xllama/session.h
+++ b/include/xllama/session.h
@@ -40,11 +40,17 @@ struct SessionParams {
 struct GenerateParams {
     std::string prompt;
     int n_predict = 96;
-    float temperature = 0.8f;
-    float top_p = 0.9f;
-    int top_k = 40;
-    float repetition_penalty = 1.1f;
-    uint32_t seed = 0xFFFFFFFF;
+    // Shared with InferenceParams via xllama/sampling.h — see #125. The two
+    // surfaces ran different samplers until these were made one source.
+    float temperature = sampling_defaults::kTemperature;
+    float top_p = sampling_defaults::kTopP;
+    int top_k = sampling_defaults::kTopK;
+    float repetition_penalty = sampling_defaults::kRepetitionPenalty;
+    uint32_t seed = sampling_defaults::kSeed;
+
+    SamplingConfig sampling() const {
+        return SamplingConfig{temperature, top_p, top_k, repetition_penalty, seed, false};
+    }
 
     // Stop sequences: checked as substrings of accumulated output.
     // Generation stops and the matching sequence is stripped.

--- a/src/bridge/cli.cpp
+++ b/src/bridge/cli.cpp
@@ -22,6 +22,13 @@ static void print_help(const char* prog) {
                  "  -t, --threads <N>    Thread count; 0 = auto (default: 0)\n"
                  "      --temp <float>   Sampling temperature (default: 0.8)\n"
                  "      --seed <int>     RNG seed; 0 = random (default: 0)\n"
+                 "      --top-p <float>  Nucleus sampling cutoff (default: 0.9)\n"
+                 "      --top-k <N>      Top-k cutoff (default: 40)\n"
+                 "      --repetition-penalty <float>\n"
+                 "                       Repetition penalty over the last 64 tokens\n"
+                 "                       (default: 1.1); 0 disables the stage\n"
+                 "      --system <text>  System message for --chat (default: the built-in\n"
+                 "                       \"You are a helpful AI assistant.\")\n"
                  "      --chat           Wrap the prompt with the model's chat template\n"
                  "                       (ChatML, Gemma, Llama 3 or Phi 3 by model name;\n"
                  "                       Qwen no-think suffix) and stop on its stop token\n"
@@ -59,26 +66,31 @@ bool parse_cli_args(int argc, char** argv, InferenceParams& out) {
     optind = 1; // reset getopt_long state for re-entrant use
     opterr = 0; // silence getopt error messages
 
-    static const struct option long_opts[] = {{"model", required_argument, nullptr, 'm'},
-                                              {"prompt", required_argument, nullptr, 'p'},
-                                              {"n-predict", required_argument, nullptr, 'n'},
-                                              {"ctx", required_argument, nullptr, 'c'},
-                                              {"threads", required_argument, nullptr, 't'},
-                                              {"temp", required_argument, nullptr, 1},
-                                              {"seed", required_argument, nullptr, 2},
-                                              {"chat", no_argument, nullptr, 3},
-                                              {"batch", required_argument, nullptr, 4},
-                                              {"ubatch", required_argument, nullptr, 5},
-                                              {"membw", no_argument, nullptr, 6},
-                                              {"greedy", no_argument, nullptr, 7},
-                                              {"dump-logits", required_argument, nullptr, 8},
-                                              {"validate-train-job", required_argument, nullptr, 9},
-                                              {"train-job", required_argument, nullptr, 10},
-                                              {"training-capabilities", no_argument, nullptr, 11},
-                                              {"lora", required_argument, nullptr, 12},
-                                              {"lora-scale", required_argument, nullptr, 13},
-                                              {"help", no_argument, nullptr, 'h'},
-                                              {nullptr, 0, nullptr, 0}};
+    static const struct option long_opts[] = {
+        {"model", required_argument, nullptr, 'm'},
+        {"prompt", required_argument, nullptr, 'p'},
+        {"n-predict", required_argument, nullptr, 'n'},
+        {"ctx", required_argument, nullptr, 'c'},
+        {"threads", required_argument, nullptr, 't'},
+        {"temp", required_argument, nullptr, 1},
+        {"seed", required_argument, nullptr, 2},
+        {"chat", no_argument, nullptr, 3},
+        {"batch", required_argument, nullptr, 4},
+        {"ubatch", required_argument, nullptr, 5},
+        {"membw", no_argument, nullptr, 6},
+        {"greedy", no_argument, nullptr, 7},
+        {"dump-logits", required_argument, nullptr, 8},
+        {"validate-train-job", required_argument, nullptr, 9},
+        {"train-job", required_argument, nullptr, 10},
+        {"training-capabilities", no_argument, nullptr, 11},
+        {"lora", required_argument, nullptr, 12},
+        {"lora-scale", required_argument, nullptr, 13},
+        {"top-p", required_argument, nullptr, 14},
+        {"top-k", required_argument, nullptr, 15},
+        {"repetition-penalty", required_argument, nullptr, 16},
+        {"system", required_argument, nullptr, 17},
+        {"help", no_argument, nullptr, 'h'},
+        {nullptr, 0, nullptr, 0}};
 
     int opt;
     while ((opt = getopt_long(argc, argv, "m:p:n:c:t:h", long_opts, nullptr)) != -1) {
@@ -138,6 +150,18 @@ bool parse_cli_args(int argc, char** argv, InferenceParams& out) {
             break;
         case 13:
             out.lora_scale = static_cast<float>(std::atof(optarg));
+            break;
+        case 14:
+            out.top_p = static_cast<float>(std::atof(optarg));
+            break;
+        case 15:
+            out.top_k = std::atoi(optarg);
+            break;
+        case 16:
+            out.repetition_penalty = static_cast<float>(std::atof(optarg));
+            break;
+        case 17:
+            out.system_prompt = optarg;
             break;
         case 'h':
             print_help(argv[0]);

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -198,11 +198,26 @@ InferenceResult run_inference_ort(const InferenceParams& params) {
                   "SetSearchNumber temperature");
         // Greedy (argmax) decode is deterministic — the prerequisite for logit parity
         // against the llama.cpp reference. do_sample=false + top_k=1 pins the choice.
-        if (params.greedy || params.temperature <= 0.0f) {
+        if (params.sampling().is_greedy()) {
             oga_check(OgaGeneratorParamsSetSearchBool(gparams.get(), "do_sample", false),
                       "SetSearchBool do_sample");
             oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "top_k", 1.0),
                       "SetSearchNumber top_k");
+        } else {
+            // #125: set these explicitly. Leaving them unset does not mean
+            // "our defaults" — it means whatever genai_config.json ships with,
+            // which is a third sampler configuration nobody chose. Session does
+            // the same, so the two ORT surfaces now agree.
+            oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "top_p",
+                                                        static_cast<double>(params.top_p)),
+                      "SetSearchNumber top_p");
+            oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "top_k",
+                                                        static_cast<double>(params.top_k)),
+                      "SetSearchNumber top_k");
+            oga_check(
+                OgaGeneratorParamsSetSearchNumber(gparams.get(), "repetition_penalty",
+                                                  static_cast<double>(params.repetition_penalty)),
+                "SetSearchNumber repetition_penalty");
         }
         // --- generator ---
         OgaGenerator* raw_gen = nullptr;
@@ -396,6 +411,8 @@ InferenceResult run_inference_ort(const InferenceParams& params) {
 #ifdef XLLAMA_USE_LLAMA
 
     #include "llama.h"
+
+    #include "sampler_chain.h" // shared sampler chain (#125); needs llama.h
     #include "xllama/llama_raii.h"
 
     #include <vector>
@@ -555,14 +572,12 @@ InferenceResult run_inference_llama(const InferenceParams& params) {
 
     const llama_sampler_chain_params sparams = llama_sampler_chain_default_params();
     LlamaSamplerPtr sampler(llama_sampler_chain_init(sparams));
-    // Greedy (argmax) decode is deterministic — the prerequisite for logit parity.
-    // Also selected implicitly at temperature 0, where sampling is degenerate.
-    if (params.greedy || params.temperature <= 0.0f) {
-        llama_sampler_chain_add(sampler.get(), llama_sampler_init_greedy());
-    } else {
-        llama_sampler_chain_add(sampler.get(), llama_sampler_init_temp(params.temperature));
-        llama_sampler_chain_add(sampler.get(), llama_sampler_init_dist(params.seed));
-    }
+    // Shared with Session — see src/bridge/sampler_chain.h. Before #125 this
+    // path built temp -> dist and nothing else: no top_k, no top_p, no
+    // repetition penalty, so a CLI run could not reproduce a GUI generation
+    // even given identical flags. Greedy (including temperature 0) is handled
+    // inside the builder.
+    add_sampler_stages(sampler.get(), params.sampling());
 
     int n_generated = 0;
     const auto t_gen0 = std::chrono::steady_clock::now();

--- a/src/bridge/sampler_chain.h
+++ b/src/bridge/sampler_chain.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 Venere Labs
+// SPDX-License-Identifier: MIT
+// Internal: the llama.cpp sampler chain, assembled in exactly one place.
+// Needs llama.h, so it stays out of the public include/ tree.
+#pragma once
+
+#include "llama.h"
+#include "xllama/sampling.h"
+
+namespace xllama {
+
+// Add the sampling stages to |chain| in the order that defines our behaviour.
+// ORDER MATTERS and is why this is shared rather than copied: penalties must see
+// raw logits, top_k narrows before top_p renormalises, and temp applies last
+// before the distribution draw. run_inference (CLI, bench) and Session (GUI, LAN
+// API) built two different orders before #125.
+inline void add_sampler_stages(llama_sampler* chain, const SamplingConfig& sc) {
+    if (sc.is_greedy()) {
+        llama_sampler_chain_add(chain, llama_sampler_init_greedy());
+        return;
+    }
+    if (sc.repetition_penalty > 0.0f) {
+        llama_sampler_chain_add(chain,
+                                llama_sampler_init_penalties(sampling_defaults::kPenaltyLastN,
+                                                             sc.repetition_penalty, 0.0f, 0.0f));
+    }
+    llama_sampler_chain_add(chain, llama_sampler_init_top_k(sc.top_k));
+    llama_sampler_chain_add(chain, llama_sampler_init_top_p(sc.top_p, 1));
+    llama_sampler_chain_add(chain, llama_sampler_init_temp(sc.temperature));
+    llama_sampler_chain_add(chain, llama_sampler_init_dist(sc.seed));
+}
+
+} // namespace xllama

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -376,6 +376,8 @@ std::unique_ptr<Session> create_ort(const SessionParams& sp, std::string* err) {
 #ifdef XLLAMA_USE_LLAMA
 
     #include "llama.h"
+
+    #include "sampler_chain.h" // shared sampler chain (#125); needs llama.h
     #include "xllama/llama_raii.h"
 
     #include <vector>
@@ -487,24 +489,10 @@ class LlamaSession final : public Session {
 
         const llama_sampler_chain_params sparams = llama_sampler_chain_default_params();
         LlamaSamplerPtr sampler(llama_sampler_chain_init(sparams));
-        if (gp.temperature <= 0.0f) {
-            // temperature 0 (API "deterministic" request / logit parity): pure
-            // argmax. The full chain must NOT run here — the default
-            // repetition_penalty (1.1) reweighs prompt tokens BEFORE the temp
-            // stage's argmax and can flip the top token (observed on-device:
-            // LFM2.5 answered "User\n\n<|end|>" at temp 0 via the endpoint while
-            // pure argmax on the same prompt answers "Hello!").
-            llama_sampler_chain_add(sampler.get(), llama_sampler_init_greedy());
-        } else {
-            if (gp.repetition_penalty > 0.0f) {
-                llama_sampler_chain_add(sampler.get(), llama_sampler_init_penalties(
-                                                           64, gp.repetition_penalty, 0.0f, 0.0f));
-            }
-            llama_sampler_chain_add(sampler.get(), llama_sampler_init_top_k(gp.top_k));
-            llama_sampler_chain_add(sampler.get(), llama_sampler_init_top_p(gp.top_p, 1));
-            llama_sampler_chain_add(sampler.get(), llama_sampler_init_temp(gp.temperature));
-            llama_sampler_chain_add(sampler.get(), llama_sampler_init_dist(gp.seed));
-        }
+        // Shared with run_inference — see src/bridge/sampler_chain.h and #125.
+        // SamplingConfig::is_greedy() also covers temperature 0, where the full
+        // chain must not run (the repetition penalty can flip the argmax).
+        add_sampler_stages(sampler.get(), gp.sampling());
 
         int n_generated = 0;
         bool stopped_by_seq = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,11 +112,13 @@ int main(int argc, char** argv) {
     // CLI feeds the prompt verbatim and generates to n_predict.
     if (params.chat_template) {
         const xllama::ChatFormat fmt = xllama::chat_format_for(params.model_path);
-        // Seed the same default system prompt as the chat UI and the API
-        // endpoint: an empty system turn makes small instruct models hallucinate
-        // the next role instead of answering (see api-server.cpp).
-        params.prompt = fmt.render_prompt(/*system=*/"You are a helpful AI assistant.",
-                                          /*history=*/{}, params.prompt);
+        // --system overrides it; the default matches the chat UI and the API
+        // endpoint, because an empty system turn makes small instruct models
+        // hallucinate the next role instead of answering (see api-server.cpp).
+        const std::string system = params.system_prompt.empty()
+                                       ? std::string("You are a helpful AI assistant.")
+                                       : params.system_prompt;
+        params.prompt = fmt.render_prompt(system, /*history=*/{}, params.prompt);
         params.stop_sequences = fmt.stop_sequences;
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(xllama-tests
     test_chat_history.cpp
     test_diffusion.cpp
     test_routing_policy.cpp
+    test_sampling.cpp
     test_chat_prompt.cpp
     test_manifest_merge.cpp
     test_membw.cpp

--- a/tests/test_sampling.cpp
+++ b/tests/test_sampling.cpp
@@ -1,0 +1,172 @@
+// Copyright (c) 2024 Venere Labs
+// SPDX-License-Identifier: MIT
+// #125: the CLI/bench surface and the GUI/API surface ran different samplers.
+// These tests pin the things that made that possible.
+
+#include <doctest/doctest.h>
+
+#include <cstdlib>
+
+#include "xllama/cli.h"
+#include "xllama/inference.h"
+#include "xllama/inference_params.h"
+#include "xllama/sampling.h"
+#include "xllama/session.h"
+
+using namespace xllama;
+
+TEST_CASE("sampling: the two surfaces start from identical defaults") {
+    // InferenceParams drives run_inference (CLI, bench); GenerateParams drives
+    // Session (GUI, LAN API). They are separate structs for good reasons — one
+    // carries a model path and training flags, the other carries KV-reuse state
+    // — but a user changing top_p in the GUI and passing --top-p on the CLI must
+    // be configuring the same thing. Before #125 the CLI struct had no top_p at
+    // all, so the two could not even be compared.
+    const InferenceParams ip;
+    const GenerateParams gp;
+
+    CHECK(ip.temperature == gp.temperature);
+    CHECK(ip.top_p == gp.top_p);
+    CHECK(ip.top_k == gp.top_k);
+    CHECK(ip.repetition_penalty == gp.repetition_penalty);
+    CHECK(ip.seed == gp.seed);
+
+    // Pin the values themselves too. Equality alone would still pass if someone
+    // changed both structs together, which is exactly the silent behaviour
+    // change this test exists to make visible.
+    CHECK(ip.temperature == doctest::Approx(0.8f));
+    CHECK(ip.top_p == doctest::Approx(0.9f));
+    CHECK(ip.top_k == 40);
+    CHECK(ip.repetition_penalty == doctest::Approx(1.1f));
+}
+
+TEST_CASE("sampling: both surfaces project to the same SamplingConfig") {
+    InferenceParams ip;
+    ip.temperature = 0.55f;
+    ip.top_p = 0.8f;
+    ip.top_k = 20;
+    ip.repetition_penalty = 1.25f;
+    ip.seed = 1234;
+
+    GenerateParams gp;
+    gp.temperature = 0.55f;
+    gp.top_p = 0.8f;
+    gp.top_k = 20;
+    gp.repetition_penalty = 1.25f;
+    gp.seed = 1234;
+
+    const SamplingConfig a = ip.sampling();
+    const SamplingConfig b = gp.sampling();
+
+    CHECK(a.temperature == b.temperature);
+    CHECK(a.top_p == b.top_p);
+    CHECK(a.top_k == b.top_k);
+    CHECK(a.repetition_penalty == b.repetition_penalty);
+    CHECK(a.seed == b.seed);
+}
+
+TEST_CASE("sampling: temperature 0 is greedy, independently of the greedy flag") {
+    // The full chain must not run at temperature 0. The repetition penalty
+    // reweighs prompt tokens BEFORE the temp stage's argmax and can flip the top
+    // token — observed on device, where LFM2.5 answered "User\n\n<|end|>" at
+    // temperature 0 through the endpoint while pure argmax answered "Hello!".
+    SamplingConfig sc;
+    CHECK_FALSE(sc.is_greedy());
+
+    sc.temperature = 0.0f;
+    CHECK(sc.is_greedy());
+
+    sc.temperature = -1.0f; // nonsense input must not fall through to sampling
+    CHECK(sc.is_greedy());
+
+    sc.temperature = 0.8f;
+    sc.greedy = true;
+    CHECK(sc.is_greedy());
+}
+
+TEST_CASE("sampling: the CLI can express every value the GUI can") {
+    // Regression for the concrete complaint in #125: a generation observed in
+    // the GUI must be reproducible from the command line. Parse the flags and
+    // check they land where run_inference reads them.
+    InferenceParams p;
+    const char* argv[] = {"xllama-cli",
+                          "-m",
+                          "model.gguf",
+                          "-p",
+                          "hi",
+                          "--temp",
+                          "0.55",
+                          "--top-p",
+                          "0.8",
+                          "--top-k",
+                          "20",
+                          "--repetition-penalty",
+                          "1.25",
+                          "--seed",
+                          "7",
+                          "--system",
+                          "You are a terse assistant."};
+    REQUIRE(parse_cli_args(static_cast<int>(sizeof(argv) / sizeof(argv[0])),
+                           const_cast<char**>(argv), p));
+
+    CHECK(p.temperature == doctest::Approx(0.55f));
+    CHECK(p.top_p == doctest::Approx(0.8f));
+    CHECK(p.top_k == 20);
+    CHECK(p.repetition_penalty == doctest::Approx(1.25f));
+    CHECK(p.seed == 7u);
+    CHECK(p.system_prompt == "You are a terse assistant.");
+}
+
+// Opt-in end-to-end parity. Needs a GGUF model:
+//   XLLAMA_TEST_MODEL=/path/to/model.gguf ./xllama-tests
+// The unit tests above prove the two surfaces hold the same VALUES and call the
+// same chain builder. They cannot prove the two code paths feed it the same way
+// — for that the only honest check is running both and comparing the tokens.
+TEST_CASE("sampling: CLI and Session produce the same text (opt-in: XLLAMA_TEST_MODEL)") {
+    const char* model_env = std::getenv("XLLAMA_TEST_MODEL");
+    if (!model_env) {
+        MESSAGE("XLLAMA_TEST_MODEL not set — skipping CLI/Session parity");
+        return;
+    }
+
+    const std::string prompt = "The capital of France is";
+    const float temperature = 0.9f;
+    const float top_p = 0.8f;
+    const int top_k = 20;
+    const float rep = 1.3f;
+    const uint32_t seed = 42;
+    const int n_predict = 24;
+
+    InferenceParams ip;
+    ip.model_path = model_env;
+    ip.prompt = prompt;
+    ip.n_predict = n_predict;
+    ip.temperature = temperature;
+    ip.top_p = top_p;
+    ip.top_k = top_k;
+    ip.repetition_penalty = rep;
+    ip.seed = seed;
+    const InferenceResult cli = run_inference(ip);
+    REQUIRE(cli.success);
+
+    SessionParams sp;
+    sp.model_path = model_env;
+    std::string err;
+    auto session = Session::create(sp, &err);
+    REQUIRE_MESSAGE(session != nullptr, err);
+
+    GenerateParams gp;
+    gp.prompt = prompt;
+    gp.n_predict = n_predict;
+    gp.temperature = temperature;
+    gp.top_p = top_p;
+    gp.top_k = top_k;
+    gp.repetition_penalty = rep;
+    gp.seed = seed;
+    const InferenceResult gui = session->generate(gp);
+    REQUIRE(gui.success);
+
+    // This is the complaint in #125 stated as an assertion: a generation seen on
+    // one surface must be reproducible on the other.
+    CHECK(cli.output_text == gui.output_text);
+}


### PR DESCRIPTION
Closes #125.

## Worse than the issue described

The issue reads as missing flags. It is a different sampler.

`InferenceParams` (CLI, bench) and `GenerateParams` (GUI, LAN API) each carried their own sampling fields and each built their own llama.cpp chain:

```
run_inference:  temp -> dist
Session:        penalties -> top_k -> top_p -> temp -> dist
```

The CLI had no `top_p`, `top_k` or repetition penalty at all. Even passing identical values would not have reproduced a GUI generation, because the stages were not there. Same model, same prompt, same seed, same values:

```
CLI      " Paris, but if you were to visit, you would return home! Particularly beyond Thetatweil, Arc de"
Session  " Paris."
```

On the ORT side the CLI set neither `top_p` nor `top_k` outside greedy mode, so `genai_config.json`'s shipped values won — a third sampler configuration nobody chose. (The issue body says the CLI "uses the hardcoded defaults 0.9 / 40 / 1.1"; on the ORT path that was not true either.)

Nothing caught it because every marker gate runs `--greedy`, which bypasses sampling entirely.

## Changes

- **`include/xllama/sampling.h`** — the defaults in one place, plus `SamplingConfig` as the shape that crosses the boundary. Both structs initialise from it, so they cannot drift apart again.
- **`src/bridge/sampler_chain.h`** — the chain assembled once. The stage **order** is part of the behaviour (penalties see raw logits, `top_k` narrows before `top_p` renormalises, temp applies last), which is why this is shared rather than deduplicated for tidiness.
- **CLI** — `--top-p`, `--top-k`, `--repetition-penalty`, `--system`. `--system` also replaces the system prompt hardcoded in `src/main.cpp`.
- **ORT path** — sets the three search numbers explicitly instead of inheriting `genai_config.json`.

Note the issue body also refers to `SamplingParams` in `session.h`; the struct is `GenerateParams`.

## Verification

- Host tests **125/125**, 1136 assertions.
- New `tests/test_sampling.cpp`: the two surfaces' defaults agree *and* are pinned to their values (equality alone would still pass if both were changed together); both project to the same `SamplingConfig`; temperature 0 stays greedy including for negative input; the CLI parses every value through to where `run_inference` reads it.
- **Opt-in end-to-end parity** (`XLLAMA_TEST_MODEL=<model.gguf>`): runs `run_inference` and `Session::generate` with identical configuration and compares the text. It passes now, and **I verified it fails against the old chain** — the two outputs quoted above are its failure message.
- Manual check that the flags reach the sampler: same seed, `--top-k 1` → " Paris, and it is located in the northern part of the country", `--top-k 100` → "* A streetcar was invented in France", `--repetition-penalty 1.0` → "C: D: E". Before this change all three were identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)