### PR TITLE
test(#126): autopilot ops for the TAESD toggle and the system prompt

### DIFF
--- a/docs/console-validation-runbook.md
+++ b/docs/console-validation-runbook.md
@@ -26,12 +26,20 @@ hardware gates pass:
 
 - **routing** — auto A/B with the parity-validated `-v2` DML asset: the long
   (>1550 tok) turn routes to GPU, short turns to CPU (#91 lifted for that asset);
-- **settings** — the `set_routing` / `set_sampling` / `set_kv_reuse` autopilot
-  ops are dispatched and every resulting value is asserted against the persisted
-  `settings.json` (needs `smollm2-360m-cpu-int4` in LocalState and an app build
-  > = 1.4.0.606);
+- **settings** — the `set_routing` / `set_sampling` / `set_kv_reuse` /
+  `set_taesd` / `set_system_prompt` autopilot ops are dispatched and every
+  resulting value is asserted against the persisted `settings.json`. The
+  baseline is seeded with the opposite of each target, so an op that silently
+  does nothing fails rather than inheriting a value that already matched (needs
+  `smollm2-360m-cpu-int4` in LocalState; `set_taesd` / `set_system_prompt` need
+  an app build >= 1.4.0.632, the rest >= 1.4.0.606);
 - **GGUF chat** — the default LFM model loads through llama.cpp and generates;
-- **TAESD** — image generation completes through DirectML with the fast VAE;
+- **TAESD** — image generation completes through DirectML with the fast VAE.
+  This gate swaps `vae_decoder/model.onnx` from a local cache rather than
+  flipping the in-app toggle: the toggle makes the console download the asset
+  from the models-v1 release, which would make the gate slower and dependent on
+  console-side network. The toggle's own writer is covered by the `settings`
+  gate instead;
 - **API** — when included by the orchestrator, the LAN health/chat contract
   passes through `scripts/validate-api.sh`.
 

--- a/scripts/validate-console.sh
+++ b/scripts/validate-console.sh
@@ -492,7 +492,7 @@ PY
 # upload and asserts on routing *behaviour*; this one asserts that the in-app
 # ops actually mutate and persist state.
 validate_settings() {
-	echo "=== settings ops (set_routing / set_sampling / set_kv_reuse) ==="
+	echo "=== settings ops (routing / sampling / kv_reuse / taesd / system_prompt) ==="
 	if ! model_provisioned "smollm2-360m-cpu-int4"; then
 		echo "  FAIL: smollm2-360m-cpu-int4 is not in LocalState\\models\\"
 		echo "  Seed it first:  ./scripts/provision-models.sh smollm2-360m-cpu-int4"
@@ -521,6 +521,8 @@ JSON
   {"op": "set_routing", "routing": 0},
   {"op": "set_sampling", "temperature": 0.55, "top_p": 0.8, "top_k": 20, "repetition_penalty": 1.25, "n_predict": 128},
   {"op": "set_kv_reuse", "enabled": false},
+  {"op": "set_taesd", "enabled": true},
+  {"op": "set_system_prompt", "text": "You are a terse assistant."},
   {"op": "quit"}
 ]}
 JSON
@@ -533,7 +535,7 @@ JSON
 		verdict=1
 	}
 	local op
-	for op in set_routing set_sampling set_kv_reuse; do
+	for op in set_routing set_sampling set_kv_reuse set_taesd set_system_prompt; do
 		if grep -aq "\[autopilot\] action .* ${op} end" "$log"; then
 			echo "  ok: ${op} dispatched"
 		else
@@ -563,6 +565,9 @@ want = [
     ("top_k", smp.get("top_k"), 20, "exact"),
     ("repetition_penalty", smp.get("repetition_penalty"), 1.25, "near"),
     ("n_predict", smp.get("n_predict"), 128, "exact"),
+    # Seeded false / "You are a helpful AI assistant." above, so a no-op op fails.
+    ("diffuse_taesd_vae", s.get("diffuse_taesd_vae"), True, "exact"),
+    ("system_prompt", s.get("system_prompt"), "You are a terse assistant.", "exact"),
 ]
 rc = 0
 for name, got, exp, kind in want:

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -2516,6 +2516,7 @@ bool MainPageController::ApParseScript(const std::string& json_utf8, std::vector
         a.steps = (int)obj.GetNamedNumber(L"steps", 1);
         a.seed = (unsigned)obj.GetNamedNumber(L"seed", 42);
         a.has_enabled = obj.HasKey(L"enabled");
+        a.has_text = obj.HasKey(L"text");
         a.enabled = obj.GetNamedBoolean(L"enabled", false);
         a.port = (int)obj.GetNamedNumber(L"port", 11434);
         a.routing = (int)obj.GetNamedNumber(L"routing", -1);
@@ -2718,6 +2719,28 @@ void MainPageController::ApRun(std::vector<ApAction> actions, std::chrono::secon
                                          " set_kv_reuse: 'enabled' (bool) is required");
             ApDispatchSync([this, on = a.enabled]() {
                 m_kv_reuse = on;
+                SaveSettings();
+            });
+        } else if (a.op == "set_taesd") {
+            // Same guard as set_kv_reuse: 'enabled' defaults to false, so a
+            // missing or misspelled key would silently assert "TAESD off" and
+            // pass without the UI writer ever running.
+            if (!a.has_enabled)
+                throw std::runtime_error("action " + std::to_string(i) +
+                                         " set_taesd: 'enabled' (bool) is required");
+            ApDispatchSync([this, on = a.enabled]() {
+                m_diffuse_taesd = on;
+                SaveSettings();
+            });
+        } else if (a.op == "set_system_prompt") {
+            // Empty is a legitimate value here (it is what the dialog stores
+            // when the box is cleared), so require the key rather than treating
+            // an empty string as "not supplied".
+            if (a.arg.empty() && !a.has_text)
+                throw std::runtime_error("action " + std::to_string(i) +
+                                         " set_system_prompt: 'text' is required");
+            ApDispatchSync([this, text = ::xllama::wstring_to_utf8(a.arg)]() {
+                m_system_prompt = text;
                 SaveSettings();
             });
         } else if (a.op == "generate_image") {

--- a/uwp/MainPage.h
+++ b/uwp/MainPage.h
@@ -51,9 +51,11 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
         std::wstring arg; // id / text / model name / image prompt / rate label
         int steps{1};     // generate_image
         unsigned seed{42};
-        bool enabled{false};             // set_api / set_kv_reuse
-        bool has_enabled{false};         // 'enabled' was present (set_kv_reuse requires it:
-                                         // the default would silently mean "disable")
+        bool enabled{false};             // set_api / set_kv_reuse / set_taesd
+        bool has_enabled{false};         // 'enabled' was present (set_kv_reuse and set_taesd
+                                         // require it: the default would silently mean "disable")
+        bool has_text{false};            // 'text' was present (set_system_prompt requires it;
+                                         // clearing the prompt to "" is a legitimate value)
         int port{11434};                 // set_api
         int routing{-1};                 // set_routing (0=CPU, 1=GPU, 2=auto)
         double temperature{-1};          // set_sampling; negative = leave unchanged


### PR DESCRIPTION
Closes #126.

The last two settings whose UI writer had never run on device.

## Ops

Both dispatch through `ApDispatchSync` + `SaveSettings()`, the same path as `set_kv_reuse`.

- `set_taesd {"enabled": bool}` — carries `set_kv_reuse`'s required-key guard. `enabled` defaults to `false`, so a missing or misspelled key would silently assert "TAESD off" and pass without the writer ever running.
- `set_system_prompt {"text": "..."}` — needs the same guard for the opposite reason: clearing the prompt to `""` is a legitimate value the dialog can store, so an empty string cannot double as "not supplied". Hence the new `has_text`.

## Gate

`validate-console.sh settings` asserts both against the persisted `settings.json`, with the baseline seeded to the opposite value — that function already does this deliberately so an op that does nothing fails rather than inheriting a value that happened to match.

## One thing the issue asked for that I did not do

The issue proposed dropping the file-upload seeding from the `taesd` gate. Two corrections:

1. That gate never seeded `diffuse_taesd_vae` in `settings.json`. It swaps `models/sd-turbo-fp16/vae_decoder/model.onnx` from a local cache — a different mechanism than the issue describes.
2. Switching it to the toggle would be a regression in robustness, not an improvement: when `m_diffuse_taesd` is on, the app **downloads** the TAESD VAE from the models-v1 release and overwrites that same file itself. Driving the gate through the toggle would make it slower and dependent on console-side network.

The toggle's writer is now covered by the `settings` gate, which is what was actually missing. `docs/console-validation-runbook.md` records the reasoning so the next reader does not re-propose it.

## Verification

- Host tests 125/125 — but note these ops live in `uwp/MainPage.cpp`, which the Linux build does not compile. The Windows CI lane is the real check here.
- **Console validation pending**: needs an MSIX from this branch. The gate cannot confirm the ops until then, and I will not claim it has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)