### PR TITLE
docs: align the docs with §5d/§5e/§5f after the #130 re-derivation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ xllama/
 │   └── utf8_utils.h         # utf8 <-> wstring (Windows)
 ├── src/bridge/              # Shared implementation (Linux + UWP)
 │   ├── inference.cpp        # ORT GenAI and/or llama_decode (unified: runtime dispatch)
+│   ├── sampler_chain.h      # add_sampler_stages — the one llama.cpp sampler chain (#125)
 │   ├── session.cpp          # xllama::Session (OrtSession UWP + LlamaSession Linux)
 │   ├── bench.cpp            # bench CSV writer
 │   ├── platform.cpp         # log_output (writes xllama.log in UWP)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   of every target, replays the ops and asserts all nine values, so an op that
   silently does nothing fails rather than inheriting a matching baseline
   (validated on Xbox Series S, MSIX 1.4.0.633).
+- **Time-to-first-token surfaced in the UI (#139).** The app streams tokens, so
+  TTFT is the latency the user actually feels; it was measured
+  (`InferenceResult::t_p_eval_ms`) but never shown. The completion line now leads
+  with "N.Ns to first token"; the live tok/s counter measures decode from the
+  first token instead of from turn start (it was dividing decode tokens by prefill
+  time and under-reporting by more than half on long prompts); and the status
+  reads "reading prompt" during prefill instead of "generating", which was not yet
+  true. See `uwp-constraints.md §5d`.
 - **`max_length` in the bench CSV.** On DirectML it is the variable that governs
   prefill throughput, and `n_ctx` does not stand in for it — a control run at
   `n_ctx` 3072 holding `max_length` fixed reproduces the slow figure to the
@@ -66,6 +74,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   already did. The shipping default (`n_predict` 256) put a 1289-token prompt at
   `max_length` 1545 — inside the valley, 150 tok/s where 612 was available.
   Faster and, measured, slightly less memory.
+
+- **CPU threading recommendation 4 → 6 (`docs/recommended-config.md`, §5f).** The
+  previous 4 came from a 2026-05-23 sweep whose every row had `prompt_tok_s = 0`,
+  i.e. a decode optimum. Measuring prefill too, 6 leads by +8.5% at 1380 tokens
+  with no decode cost. `t8` is worse than the "bandwidth saturation" it was
+  recorded as — it takes prefill down 2.3× as well. Caveat in the doc: the shipped
+  asset sets **no** `intra_op_num_threads` at all, so neither value has ever been
+  in production.
 
 - **Device marker training recipe.** The host marker gate converges with
   learning rate 2e-4 (5e-4 oscillated and under-converged), the shortened

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 `xllama` is a UWP application for Xbox Series S|X in Dev Mode that runs LLM chat and Stable-Diffusion image generation locally, with no cloud dependency and a gamepad-friendly UI. It also includes an opt-in, OpenAI-compatible [LAN endpoint](./docs/api-endpoint.md) and a dual-lane [training/personalization pillar](./docs/training-architecture.md): host PEFT LoRA plus an in-process partial fine-tune that runs fully on the console (ggml-opt Lane B, host + console gates PASS).
 
-The project started as a port of [`llama.cpp`](https://github.com/ggml-org/llama.cpp) (GGUF files, CPU-only), then migrated to **ONNX Runtime GenAI + DirectML**. The measured verdict is **per-workload** (see [docs/technical-report.md](./docs/technical-report.md)): the Zen 2 **CPU wins autoregressive decode** at this model scale (~66 tok/s, SmolLM2-360M int4), the RDNA 2 **GPU wins batch compute** — prefill on long prompts (3.2× at ~1.6k tokens on the shipping `-v2` asset) and image generation (**11.1×** on the diffusion workload: SD-Turbo 512×512 in ~7 s). GPU **text** routing is enabled for the parity-validated `smollm2-360m-dml-fp16-v2` asset only ([#91](https://github.com/gianlucamazza/xllama/issues/91): the DML `(Skip)SimplifiedLayerNormalization` kernel computes wrong results on the Series S GPU — fixed by decomposing those nodes into primitives, a data-only graph fix; see [docs/dml-rmsnorm-fix-runbook.md](./docs/dml-rmsnorm-fix-runbook.md)); diffusion stays on the GPU. The llama.cpp path serves Linux development, CI, and — in the `unified` UWP build — modern GGUF-only models (Qwen3.5, LFM2.5); for the same model, ORT stays the text backend (measured decode parity, better prefill).
+The project started as a port of [`llama.cpp`](https://github.com/ggml-org/llama.cpp) (GGUF files, CPU-only), then migrated to **ONNX Runtime GenAI + DirectML**. The measured verdict is **per-workload** (see [docs/technical-report.md](./docs/technical-report.md)): the Zen 2 **CPU wins autoregressive decode** at this model scale (~66 tok/s, SmolLM2-360M int4), the RDNA 2 **GPU wins batch compute** — cold-process prefill on long prompts (3.2× at ~1.6k tokens on the shipping `-v2` asset, which buys first-turn TTFT but not multi-turn throughput; see [§5d](./docs/uwp-constraints.md)) and image generation (**11.1×** on the diffusion workload: SD-Turbo 512×512 in ~7 s). GPU **text** routing is enabled for the parity-validated `smollm2-360m-dml-fp16-v2` asset only ([#91](https://github.com/gianlucamazza/xllama/issues/91): the DML `(Skip)SimplifiedLayerNormalization` kernel computes wrong results on the Series S GPU — fixed by decomposing those nodes into primitives, a data-only graph fix; see [docs/dml-rmsnorm-fix-runbook.md](./docs/dml-rmsnorm-fix-runbook.md)); diffusion stays on the GPU. The llama.cpp path serves Linux development, CI, and — in the `unified` UWP build — modern GGUF-only models (Qwen3.5, LFM2.5); for the same model, ORT stays the text backend (measured decode parity, better prefill).
 
 The default chat model on the shipping **unified** build is **LFM2.5-350M Q4_K_M** (~219 MB, ~94 tok/s), downloaded on first launch from the GitHub Release model catalogue — the MSIX itself is ~19 MB and ships no model. ORT-only builds still default to SmolLM2-360M INT4.
 
@@ -103,10 +103,11 @@ release, [docs/using-the-app.md](./docs/using-the-app.md) for the app guide, and
 **Measured performance (Xbox Series S):** LFM2.5-350M is the fastest chat option
 at **94.2 tok/s**; the larger LFM catalogue tiers trade throughput for quality.
 KV-cache reuse improves measured turn-2 prefill by up to **20.0×**. GPU text
-routing is live for the parity-validated `-v2` DML asset (auto above 1550
-tokens, where prefill measures **636–681 tok/s** against the CPU's ~196 — #91
-postmortem; the threshold and the band below it come from the measured sweep in
-[docs/uwp-constraints.md §5b](./docs/uwp-constraints.md)); DirectML also
+routing is live for the parity-validated `-v2` DML asset, where it accelerates
+the **first-turn time-to-first-token** on a long prompt; from the second turn the
+CPU wins at every reachable length, because DirectML cannot reuse a KV cache and
+the CPU can (full verdict and the provisional routing threshold in
+[docs/uwp-constraints.md §5d](./docs/uwp-constraints.md)). DirectML also
 serves diffusion, with SD-Turbo at about **6.9 s** for 512×512. Raw evidence,
 atomic comparison rows and the generated dashboard are described in the
 **[benchmark SSOT](./docs/benchmarks.md)** and
@@ -140,8 +141,8 @@ atomic comparison rows and the generated dashboard are described in the
 │  │  GitHub Release catalogue             │
 │  ├─ per-model backend dispatch:          │
 │  │  • ORT chat → CPU EP (Zen 2)         │
-│  │  • long-prompt prefill → DML fp16    │
-│  │    (auto routing > 1550 tok, -v2)      │
+│  │  • long-prompt turn-1 TTFT → DML fp16 │
+│  │    (auto, -v2; §5d)                    │
 │  │  • GGUF chat → llama.cpp CPU +       │
 │  │    KV-reuse (unified build)           │
 │  └─ image gen → SD-Turbo on DirectML    │
@@ -235,6 +236,11 @@ cmake --build build/linux-release -j
 # Run with a model (llama.cpp / GGUF, Linux only)
 ./build/linux-release/bin/xllama-cli -m models/smollm2-360m.gguf -p "Hello"
 
+# Full sampling control, matching the GUI/API (one shared sampler since #125):
+#   --temp --top-p --top-k --repetition-penalty --seed --system --chat --greedy
+./build/linux-release/bin/xllama-cli -m models/smollm2-360m.gguf --chat \
+  -p "Hello" --top-p 0.9 --top-k 40 --repetition-penalty 1.1 --system "Be terse"
+
 # Unit tests
 cmake --preset linux-test
 cmake --build build/linux-test -j
@@ -280,21 +286,21 @@ Models come from the catalogue `uwp/models/manifest.json` (assets hosted on the 
 Catalogue overview (roles + sizes; **decode/prefill/RAM numbers live in
 [docs/benchmarks.md](./docs/benchmarks.md)**, the perf SSOT):
 
-| Model                      | Format        | Size    | Xbox UWP | Role                                                                             |
-| -------------------------- | ------------- | ------- | -------- | -------------------------------------------------------------------------------- |
-| LFM2.5-350M Q4_K_M         | GGUF          | 219 MB  | ✅       | **Default chat** on unified shipping; fastest+lightest                           |
-| LFM2.5-1.2B Q4_K_M         | GGUF          | 697 MB  | ✅       | Balanced chat: 37.9 tok/s, 811 MB peak, H9 6/8                                   |
-| LFM2-2.6B Q4_K_M           | GGUF          | 1.46 GB | ✅       | Quality chat: 18.4 tok/s, 1623 MB peak, H9 7/8                                   |
-| SmolLM2-360M-Instruct INT4 | ONNX GenAI    | 417 MB  | ✅       | ORT default / routing base (CPU)                                                 |
-| SmolLM2-360M fp16 DML v2   | ONNX GenAI    | ~725 MB | ✅       | Routing target (auto >1550 tok) — RMSNorm-decomposed graph, #91 parity-validated |
-| SmolLM2-1.7B-Instruct INT4 | ONNX GenAI    | 1.4 GB  | ✅       | Larger CPU chat (~20.6 tok/s; in-app `models-v1` download)                       |
-| Qwen3.5-0.8B Q4_K_M        | GGUF          | 508 MB  | ✅       | `unified` builds (llama.cpp)                                                     |
-| Gemma-3-270M Q4_K_M        | GGUF          | 253 MB  | ✅       | `unified` builds; fast, tiny                                                     |
-| Gemma-4-E2B Q3_K_S         | GGUF          | 2.45 GB | ✅       | `unified` builds; heavy/advanced                                                 |
-| Llama-3.2-3B Q3_K_S        | GGUF          | 1.54 GB | ✅       | `unified` builds; Phase 7 dense-3B comparator (CPU-only, advanced)               |
-| SD-Turbo fp16 (image)      | ONNX DirectML | 2.4 GB  | ✅       | Image gen ([diffusion/README.md](./diffusion/README.md))                         |
-| Phi-3.5-mini CPU INT4      | ONNX GenAI    | ~2.7 GB | ❌       | Not attempted (>2 GB single-file ONNX, §8)                                       |
-| Phi-3.5-mini Q3_K_S        | GGUF          | 1.68 GB | ⚠️       | H4 A/B measured 11.3 tok/s / 2453 MB; loses to `llama32-3b` — not catalogue      |
+| Model                      | Format        | Size    | Xbox UWP | Role                                                                                                 |
+| -------------------------- | ------------- | ------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| LFM2.5-350M Q4_K_M         | GGUF          | 219 MB  | ✅       | **Default chat** on unified shipping; fastest+lightest                                               |
+| LFM2.5-1.2B Q4_K_M         | GGUF          | 697 MB  | ✅       | Balanced chat: 37.9 tok/s, 811 MB peak, H9 6/8                                                       |
+| LFM2-2.6B Q4_K_M           | GGUF          | 1.46 GB | ✅       | Quality chat: 18.4 tok/s, 1623 MB peak, H9 7/8                                                       |
+| SmolLM2-360M-Instruct INT4 | ONNX GenAI    | 417 MB  | ✅       | ORT default / routing base (CPU)                                                                     |
+| SmolLM2-360M fp16 DML v2   | ONNX GenAI    | ~725 MB | ✅       | Routing target (first-turn TTFT, long prompts; §5d) — RMSNorm-decomposed graph, #91 parity-validated |
+| SmolLM2-1.7B-Instruct INT4 | ONNX GenAI    | 1.4 GB  | ✅       | Larger CPU chat (~20.6 tok/s; in-app `models-v1` download)                                           |
+| Qwen3.5-0.8B Q4_K_M        | GGUF          | 508 MB  | ✅       | `unified` builds (llama.cpp)                                                                         |
+| Gemma-3-270M Q4_K_M        | GGUF          | 253 MB  | ✅       | `unified` builds; fast, tiny                                                                         |
+| Gemma-4-E2B Q3_K_S         | GGUF          | 2.45 GB | ✅       | `unified` builds; heavy/advanced                                                                     |
+| Llama-3.2-3B Q3_K_S        | GGUF          | 1.54 GB | ✅       | `unified` builds; Phase 7 dense-3B comparator (CPU-only, advanced)                                   |
+| SD-Turbo fp16 (image)      | ONNX DirectML | 2.4 GB  | ✅       | Image gen ([diffusion/README.md](./diffusion/README.md))                                             |
+| Phi-3.5-mini CPU INT4      | ONNX GenAI    | ~2.7 GB | ❌       | Not attempted (>2 GB single-file ONNX, §8)                                                           |
+| Phi-3.5-mini Q3_K_S        | GGUF          | 1.68 GB | ⚠️       | H4 A/B measured 11.3 tok/s / 2453 MB; loses to `llama32-3b` — not catalogue                          |
 
 See [docs/uwp-constraints.md](./docs/uwp-constraints.md) for the measured GPU budget (3801 MB), the disk budget, and AppContainer workarounds.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,15 +32,16 @@ The shared core is platform-agnostic C++17; front-ends are thin:
 
 Header modules (`include/xllama/`), all WinRT-free so they are host-testable:
 
-| Header                             | Owns                                                                |
-| ---------------------------------- | ------------------------------------------------------------------- |
-| `session.h` / `inference_params.h` | `Session`/`SessionParams`, `InferenceParams/Result`, `Backend` enum |
-| `training.h` / `training_params.h` | `TrainingJob`/`TrainingResult`, stages, device gates, job JSON      |
-| `chat_prompt.h`                    | `ChatFormat`, `chat_format_for`, `apply_stop_sequences`             |
-| `routing_policy.h`                 | `decide_routing`, `kv_reuse_supported_for_model`                    |
-| `model_provision.h`                | `dir_satisfies_expected_files`, `normalize_model_path`              |
-| `manifest_merge.h`                 | `merge_manifest_entries` (per-entry catalogue override)             |
-| `membw.h`                          | `measure_membw` (STREAM-style bandwidth probe)                      |
+| Header                             | Owns                                                                         |
+| ---------------------------------- | ---------------------------------------------------------------------------- |
+| `session.h` / `inference_params.h` | `Session`/`SessionParams`, `InferenceParams/Result`, `Backend` enum          |
+| `sampling.h`                       | `SamplingConfig`, shared defaults; CLI/bench and GUI/API init from it (#125) |
+| `training.h` / `training_params.h` | `TrainingJob`/`TrainingResult`, stages, device gates, job JSON               |
+| `chat_prompt.h`                    | `ChatFormat`, `chat_format_for`, `apply_stop_sequences`                      |
+| `routing_policy.h`                 | `decide_routing`, `kv_reuse_supported_for_model`, prompt budget              |
+| `model_provision.h`                | `dir_satisfies_expected_files`, `normalize_model_path`                       |
+| `manifest_merge.h`                 | `merge_manifest_entries` (per-entry catalogue override)                      |
+| `membw.h`                          | `measure_membw` (STREAM-style bandwidth probe)                               |
 
 ## Inference backends and runtime dispatch
 
@@ -63,6 +64,14 @@ suffix / on-disk GGUF layout routes to llama.cpp, everything else to ORT GenAI
 (`session.cpp`, `inference.cpp`). So llama.cpp is both the host A/B benchmarking
 lane and a **shipping** text backend for the GGUF catalogue entries (LFM2.5,
 Qwen3.5, Gemma).
+
+Both backends **stream**: `GenerateParams::on_token` fires per detokenized piece
+inside the decode loop. The UI worker does not dispatch per token — it appends
+under a mutex and a 40 ms `DispatcherTimer` (`FlushTokenBuffer`) drains the buffer
+to the screen. Because the app streams, the latency that matters is
+**time-to-first-token**, not total turn time; `InferenceResult::t_p_eval_ms`
+carries it and `StartInference` surfaces it (`§5d`, #139). The LAN endpoint below
+is the one path that does **not** stream — it returns a completed response.
 
 ## Chat templates (`ChatFormat`)
 
@@ -89,17 +98,37 @@ re-prefilling the whole conversation:
   **20.02×** on the larger LFM models (`benchmarks.md`).
 
 Reuse is gated by `kv_reuse_supported_for_model()` (`routing_policy.h`), which
-excludes the DirectML EP (continuous decoding is CPU-only). It is **not** gated by
-backend — GGUF KV-reuse is on.
+excludes the DirectML EP (continuous decoding is CPU-only, verified — the reuse
+turn produces zero cached tokens on DML). It is **not** gated by backend — GGUF
+KV-reuse is on.
+
+The UI keeps **one** session at a time. `MainPageController::EnsureSession` resets
+the current session before creating another (`avoid 2× model in RAM`: the CPU and
+DML working sets, ~1.3 GB and ~2.9 GB, do not coexist in the budget). One
+consequence drives the routing verdict above: a GPU-routed turn loads the CPU
+model to tokenize for the routing decision, then destroys it to load DirectML, so
+that turn pays two model loads (§5d).
 
 ## Routing (`routing_policy.h`)
 
-`decide_routing()` picks the execution path per conversation (sticky — the KV cache
-is per-EP): decode-heavy chat stays on **CPU int4** (fastest decode), long prompts
-switch to **DML fp16** (prefill wins at scale). Routing is **ORT-only**; GGUF models
-are CPU-only, so routing is skipped for them. Tunable prefill batching for the
-llama.cpp path is exposed via `SessionParams.n_batch` / `n_ubatch`
-(`xllama-cli --batch/--ubatch`) — see `benchmarks.md` for the (flat) sweep.
+`decide_routing()` picks the execution path per conversation and is **sticky** —
+decided on the first turn, when the app cannot yet know whether the conversation
+will continue, and never revisited (the KV cache is per-EP). Decode-heavy chat
+stays on **CPU int4** (fastest decode); a long first-turn prompt can switch to
+**DML fp16**, which wins cold-process prefill and therefore first-turn TTFT. This
+does **not** mean the GPU is faster overall: DirectML cannot reuse a KV cache
+(`kv_reuse_supported_for_model` returns false for it) while the CPU can, so from
+the second turn the CPU wins at every reachable length — see `uwp-constraints.md
+§5d`. The threshold (`token_threshold`) is provisional and under re-derivation
+(§5c). Routing is **ORT-only**; GGUF models are CPU-only, so routing is skipped
+for them. Tunable prefill batching for the llama.cpp path is exposed via
+`SessionParams.n_batch` / `n_ubatch` (`xllama-cli --batch/--ubatch`) — see
+`benchmarks.md` for the (flat) sweep.
+
+Sampling is one code path for both surfaces: `SamplingConfig` and its defaults
+live in `sampling.h`, and the llama.cpp sampler chain is assembled in exactly one
+place, `src/bridge/sampler_chain.h` (`add_sampler_stages`), so the CLI/bench and
+GUI/API cannot drift into different samplers as they had before #125.
 
 ## Model catalogue, provisioning, and quant auto-upgrade
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -84,10 +84,15 @@ Notes:
   exonerated — see `dml-rmsnorm-fix-runbook.md`) is worked around by the
   RMSNorm-decomposed `smollm2-360m-dml-fp16-v2` graph, parity-validated
   on-console. `routing_policy.h` (`dml_text_model_ok`) allows GPU text routing
-  only for that asset; the 1550-token Auto switch applies. Its measured row is
-  236.7 prefill / 44.4 decode / 1268 MB — the old fused-RMSNorm rows (169.2/46.8
-  and 353.5/36.5, wrong text output) remain as historical throughput
-  measurements, never merged into one synthetic row.
+  only for that asset; the Auto switch applies at `token_threshold` (1550, but
+  **provisional and under re-derivation** — `uwp-constraints.md §5c/§5d`). Its
+  measured row is 236.7 prefill / 44.4 decode / 1268 MB. **The prefill number is
+  a cold-process figure** (§5e: DirectML warms up ~1.7× on the second call in a
+  process, so nothing in this repo reports warm prefill) and decode still loses
+  to CPU int4. What the GPU actually buys is first-turn TTFT on a long prompt;
+  from the second turn the CPU wins at every reachable length via KV reuse, which
+  DirectML cannot do (§5d). The old fused-RMSNorm rows (169.2/46.8 and 353.5/36.5,
+  wrong text output) remain as historical throughput measurements only.
 
 ## KV-cache reuse — both backends, CPU
 
@@ -229,11 +234,16 @@ dispatch overhead at this model scale; CPU `MatMulNBits` on AVX2 wins
 `dml_text_model_ok()` now excludes, and was an interpolation between two prompt
 lengths. The measured sweep on the shipping `-v2` asset
 (`bench/results/phase12-dml-crossover.csv`, `uwp-constraints.md §5b`) shows the
-prefill curve is **not monotone**: at ~1.1k tokens the GPU wins only 1.38×, at
-~1.3k it _loses_ (119 vs 203 tok/s), and it wins outright only above ~1550
-tokens (636 vs 196). Text routing is live for the `-v2` RMSNorm-decomposed asset
-(#91 postmortem) above that threshold. The decode conclusion above is unchanged;
-the prefill figure is superseded.
+prefill curve is **not monotone** — and the reading of that non-monotonicity in
+§5b was itself superseded. The controlling variable is `max_length`, not prompt
+length (§5c): the "loss at ~1.3k" was a `max_length` valley, and every prefill
+figure here is cold-process (§5e). More important, "wins outright above ~1550" is
+**retracted** (§5d): it is true for a single turn and false for the app, because
+DirectML cannot reuse a KV cache (verified: `prefill2_reuse_ms = 0.0`) while the
+CPU does, so from the second turn the CPU wins at every length the trimmer
+allows. The GPU's real use is first-turn TTFT. Text routing is live for the `-v2`
+asset (#91 postmortem); the threshold value is provisional. The decode conclusion
+above is unchanged.
 
 ### fp16 >2 GB external data — loads, but 1B fp16 OOMs GPU inference (2026-07-15)
 

--- a/docs/recommended-config.md
+++ b/docs/recommended-config.md
@@ -63,7 +63,7 @@ GGUF thread default: llama.cpp auto-detect is capped at **6** on console
 
 ## `genai_config.json` (on-device model dir)
 
-**CPU (bundled default)** — copy from [`bench/configs/genai_config-threads-4.json`](../bench/configs/genai_config-threads-4.json):
+**CPU (bundled default)** — copy from [`bench/configs/genai_config-threads-6.json`](../bench/configs/genai_config-threads-6.json):
 
 - `provider_options: []`
 - `intra_op_num_threads: 6` — **corrected 2026-07-21** (§5f). The previous 4 came
@@ -124,6 +124,10 @@ Two caveats on that number, both live:
 - It was calibrated against a DirectML slowdown believed to track prompt length.
   It tracks `max_length` instead (#130, `docs/uwp-constraints.md` §5c), so the
   value is provisional and under re-derivation.
+- It optimizes the **first turn only** (§5d). The GPU buys a faster first token
+  on a long prompt; from the second turn the CPU wins at every reachable length,
+  because DirectML cannot reuse a KV cache. Whether Auto is worth leaving on
+  depends on how single-turn your long-prompt conversations are.
 
 ## Image generation
 
@@ -175,7 +179,7 @@ ctest --test-dir build/linux-test --output-on-failure
 
    ```bash
    source ~/.config/xllama/xbox-env
-   ./scripts/validate-console.sh all   # routing + settings + GGUF + TAESD → ALL PASS (2026-07-16, 1.2.0.534)
+   ./scripts/validate-console.sh all   # routing + settings (9 values) + GGUF + TAESD → routing+settings PASS on 1.4.0.641, GGUF PASS on 1.4.0.633 (2026-07-22); TAESD not re-run
    ```
 
 5. Manual/debug path: [console-validation-runbook.md](./console-validation-runbook.md) per §

--- a/docs/technical-report.md
+++ b/docs/technical-report.md
@@ -50,10 +50,14 @@ Three hypotheses died against these numbers:
    66.3); the crossover exists only in prefill, where batch amortises dispatch.
    The 1.8×-at-~1k figure once quoted here came from the pre-#91 asset and a
    two-point interpolation; the measured sweep on the shipping `-v2` graph
-   (`bench/results/phase12-dml-crossover.csv`, docs/uwp-constraints.md §5b)
-   shows the prefill curve is not monotone and the GPU only wins outright above
-   ~1550 tokens. The app routes per-workload above that threshold, sticky per
-   conversation; decode always stays on CPU int4.
+   (`bench/results/phase12-dml-crossover.csv`) showed the prefill curve is not
+   monotone — and that this is a `max_length` effect, not prompt length
+   (docs/uwp-constraints.md §5c), with every DML prefill figure cold-process
+   (§5e). The GPU's prefill win buys a faster **first token**; it does not carry
+   the conversation, because DirectML cannot reuse a KV cache and the CPU can, so
+   from the second turn the CPU wins at every reachable length (§5d). The app
+   routes per-workload on the first turn, sticky per conversation; decode always
+   stays on CPU int4.
    **#91 interlude (2026-07-16 → 2026-07-19).** The logit-parity harness
    showed the DML text path computes numerically wrong logits on the Series S
    GPU (NMSE ~1 vs the CPU reference, top-1 disagrees; fp16 AND int4;

--- a/docs/using-the-app.md
+++ b/docs/using-the-app.md
@@ -58,12 +58,14 @@ once; the choice is stored with the conversation and appended to
   - **GPU only (DML)** — prefers DirectML when `gpu_model` is provisioned (e.g.
     `smollm2-360m-dml-fp16-v2` in LocalState); if `gpu_available` is false, falls
     back to the CPU model.
-  - **Auto (long prompts → GPU)** — long first prompts route to GPU fp16 only
-    when `gpu_available` is true and the prompt exceeds the token threshold
-    (above that threshold prefill is ~3.2× faster; below it the GPU loses, and
-    between roughly 1100 and 1500 tokens it is far slower — see
-    [docs/uwp-constraints.md §5b](./uwp-constraints.md)); short chats, or any turn with a
-    missing GPU model, stay on CPU. The choice is sticky per conversation.
+  - **Auto (long first prompt → GPU)** — a long first prompt routes to GPU fp16
+    when `gpu_available` is true and it exceeds the token threshold. What the GPU
+    buys there is a faster **first token** (cold-process prefill up to ~3.2×); it
+    does **not** make the conversation faster overall — the GPU cannot reuse a KV
+    cache, so from the second turn the CPU wins, and the routing choice is sticky
+    per conversation (decided once, on turn 1). Short chats, or any turn with a
+    missing GPU model, stay on CPU. The threshold is provisional and under
+    re-derivation — see [docs/uwp-constraints.md §5d](./uwp-constraints.md).
 - **LAN API** — enables or stops the OpenAI-compatible endpoint immediately,
   without restarting the app. The port must be 1025–49151 except 11443. The
   status line reports the active listener or bind error. The endpoint is


### PR DESCRIPTION
Documentation only. `uwp-constraints.md` (the SSOT) already carried the #130 corrections; a cross-checked audit found six other docs still stating the retracted version as current truth.

## The common thread

"Auto above 1550 tokens the GPU wins" appears across **README (×3), benchmarks.md (×2), architecture.md, using-the-app.md, and technical-report.md**. It is true for a single turn and false for the app: DirectML buys first-turn TTFT on a long prompt, but from the second turn the CPU wins at every reachable length because DirectML cannot reuse a KV cache and the CPU can (§5d). The prefill tok/s quoted are cold-process figures (§5e); the threshold is provisional (§5c).

Every touched spot now points to §5d rather than only §5b.

## Tier 1 — retracted claims stated as current

- **benchmarks.md** (the perf SSOT): the "wins outright above ~1550 (636 vs 196)" paragraph, and the `236.7` prefill routing note now annotated as cold-process.
- **README**: prose line 39, the routing paragraph, the architecture diagram, the model table.
- **architecture.md**: "long prompts switch to DML fp16 (prefill wins at scale)".
- **using-the-app.md**: "between 1100 and 1500 tokens it is far slower" — the last prompt-length-band framing outside the already-annotated §5b.
- **technical-report.md**: the same sentence. This file was outside the original audit scope; the verification grep caught it.

## Tier 2 — merged PRs missing doc coverage

- **CHANGELOG**: added TTFT (#139) and the 4→6 CPU-threads (§5f) entries.
- **architecture.md**: the shared sampler chain (#125) was entirely absent; added it, plus token streaming/TTFT and the `EnsureSession` single-session lifecycle that §5d's asymmetric-load result depends on.
- **AGENTS.md**: `sampler_chain.h` added to the file tree.
- **README**: new CLI sampling flags in the quick-start.

## Tier 3 — recommended-config.md inconsistencies

- The CPU config block said `6` but linked the `-4` config file → now links `genai_config-threads-6.json`.
- Added the §5d caveat to the routing section.
- Refreshed the stale `2026-07-16 / 1.2.0.534` validation stamp, and made it **honest about which gates ran on which build** (routing+settings on 1.4.0.641, GGUF on 1.4.0.633, TAESD not re-run) rather than claiming a blanket ALL PASS.

## Verification

- `grep` for the retracted phrasings across README/docs/CHANGELOG → only occurrences that explicitly retract or caveat them remain.
- `python3 scripts/generate-benchmark-summary.py --check` and `prettier --check` both clean.
- No code touched; host tests and CI unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live time-to-first-token (TTFT) information to the interface, including clearer prefill status messaging and timing counters.
* **Documentation**
  * Clarified automatic CPU/GPU routing, including first-turn GPU acceleration, CPU preference for subsequent turns, and KV-cache limitations.
  * Added a Linux CLI example covering sampling controls such as top-p, top-k, repetition penalty, seed, system prompts, and greedy mode.
  * Updated performance guidance, model descriptions, architecture details, benchmarks, and recommended CPU threading from 4 to 6 threads.
  * Expanded documentation for streaming behavior, routing decisions, and sampling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->