### PR TITLE
fix(#141): OrtSession ran the full sampler at temperature 0 + bench-script hygiene

### DIFF
--- a/include/xllama/inference_params.h
+++ b/include/xllama/inference_params.h
@@ -115,8 +115,10 @@ struct InferenceResult {
     // the variable that controls prefill throughput — a 1289-token prompt runs at
     // 130 tok/s at max_length 1801 and 611 tok/s at 2048, unchanged otherwise —
     // so a bench row that omits it cannot be interpreted, the same way a row
-    // without n_prompt_tok could not (#128). Derived, not independently settable:
-    // min(n_ctx, n_prompt_tok + n_predict) on the stateless path. 0 = N/A (GGUF).
+    // without n_prompt_tok could not (#128). Normally min(n_ctx, n_prompt_tok +
+    // n_predict) on the stateless path, but the bench can override it via
+    // max_length_override (#139) — whatever was actually requested is recorded
+    // here. 0 = N/A (GGUF, which does not set it).
     int max_length = 0;
     size_t peak_ws_mb = 0;
     size_t gpu_mem_mb = 0;    // per-process GPU CurrentUsage after model load (0 = N/A)

--- a/scripts/bench-xbox-kv.sh
+++ b/scripts/bench-xbox-kv.sh
@@ -133,6 +133,13 @@ for run in $(seq 1 "$RUNS"); do
 	echo "--- Run ${run} / ${RUNS} ---"
 	remove "bench-kv-result.csv"
 	remove "bench-kv-result.csv.done"
+	# Clear the standard-bench knobs: run_kv_bench is passed bench_ctx, so an
+	# --ctx sweep run just before this would silently hijack the KV bench's n_ctx.
+	# bench_npredict / bench_maxlen do not reach run_kv_bench, but clear them too
+	# so a KV run leaves the device in a known state for whatever runs next.
+	remove "bench_ctx.txt"
+	remove "bench_npredict.txt"
+	remove "bench_maxlen.txt"
 	# Append-only across restarts: clear it so the failure grep below sees only
 	# this run (a stale DirectML error would otherwise be attributed to it).
 	remove "xllama.log"

--- a/scripts/bench-xbox-ort.sh
+++ b/scripts/bench-xbox-ort.sh
@@ -5,10 +5,14 @@
 #   source ~/.config/xllama/xbox-env
 #   ./scripts/bench-xbox-ort.sh <model-dir-name> [--threads N] [--runs N] [--prompt file]
 #                                [--out FILE] [--gpu-sample] [--ctx N] [--n-predict N]
+#                                [--max-length N] [--keep-config]
 #
 # Arguments:
 #   model-dir-name   Model directory name in LocalState/models/ (e.g. smollm2-360m-cpu-int4)
-#   --threads N      Upload genai_config-threads-N.json and tag CSV row with t<N>
+#   --threads N      Upload genai_config-threads-N.json and tag CSV row with t<N>.
+#                    The device config is backed up and RESTORED on exit (a swap
+#                    left in place would silently affect every later run).
+#   --keep-config    Leave the --threads config on the device (skip the restore)
 #   --runs N         Number of bench runs (default: 3, warmup run 1 is dropped)
 #   --prompt file    Path to prompt file (default: bench/prompts/standard-512.txt)
 #   --out FILE       Results CSV to append the median row to
@@ -45,6 +49,7 @@ N_RUNS=3
 PROMPT_FILE=""
 OUT_CSV=""
 GPU_SAMPLE=false
+KEEP_CONFIG=false # --keep-config: leave a --threads genai_config.json on the device
 
 shift || true
 while [[ $# -gt 0 ]]; do
@@ -79,6 +84,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--gpu-sample)
 		GPU_SAMPLE=true
+		shift
+		;;
+	--keep-config)
+		KEEP_CONFIG=true
 		shift
 		;;
 	*)
@@ -136,7 +145,26 @@ echo "  PFN: $PFN"
 # Helpers
 # ---------------------------------------------------------------------------
 TMPDIR_LOCAL=$(mktemp -d)
-trap 'rm -rf "$TMPDIR_LOCAL"' EXIT
+MEDIAN_TMP=""     # set later; cleaned by the single EXIT trap below
+CONFIG_SWAPPED="" # set when --threads overwrites the device genai_config.json
+
+# One cleanup path for the whole script. --threads overwrites genai_config.json
+# on the device (models\<name>\); without a restore, the last thread variant
+# stays in force for every later run of the app and every bench that does not
+# pass --threads (observed: a t8 sweep left the console on t8). Mirror the
+# backup/restore that profile-dml-run.sh already does, and run it on ANY exit,
+# so a mid-run failure still restores. --keep-config opts out.
+cleanup() {
+	if [[ -n "$CONFIG_SWAPPED" && "$KEEP_CONFIG" != "true" ]]; then
+		echo "  Restoring original genai_config.json on the device..." >&2
+		upload_as "${TMPDIR_LOCAL}/genai_config_orig.json" "models\\${MODEL_NAME}" "genai_config.json" >/dev/null 2>&1 || true
+	elif [[ -n "$CONFIG_SWAPPED" ]]; then
+		echo "  --keep-config: t${N_THREADS} genai_config.json left on the device" >&2
+	fi
+	[[ -n "$MEDIAN_TMP" ]] && rm -f "$MEDIAN_TMP"
+	rm -rf "$TMPDIR_LOCAL"
+}
+trap cleanup EXIT
 
 _curl_post_file() {
 	local local_path="$1" path_param="$2" filename="${3:-}"
@@ -291,6 +319,16 @@ if [[ "$N_THREADS" -gt 0 ]] 2>/dev/null; then
 		if [[ -f "$THREADS_CONFIG" ]]; then
 			echo ""
 			echo "--- Uploading genai_config (intra_op_num_threads=${N_THREADS}) ---"
+			# Back up the device's current config FIRST, so the EXIT trap can put
+			# it back. Without this the swap is permanent (see cleanup()).
+			curl "${CURL_AUTH[@]}" -o "${TMPDIR_LOCAL}/genai_config_orig.json" \
+				"${BASE_URL}/api/filesystem/apps/file?knownfolderid=LocalAppData&packagefullname=${PFN}&path=%5CLocalState%5Cmodels%5C${MODEL_NAME}&filename=genai_config.json" \
+				2>/dev/null || true
+			if [[ -s "${TMPDIR_LOCAL}/genai_config_orig.json" ]]; then
+				CONFIG_SWAPPED=1
+			else
+				echo "Warning: could not back up the device genai_config.json — it will NOT be restored" >&2
+			fi
 			upload_as "$THREADS_CONFIG" "models\\${MODEL_NAME}" "genai_config.json"
 		else
 			echo "Warning: $THREADS_CONFIG not found — using existing genai_config.json on device" >&2
@@ -448,8 +486,7 @@ assert_header_matches() {
 	fi
 }
 assert_header_matches "$RESULT_CSV"
-MEDIAN_TMP=$(mktemp)
-trap 'rm -f "$MEDIAN_TMP"; rm -rf "$TMPDIR_LOCAL"' EXIT
+MEDIAN_TMP=$(mktemp) # cleaned by the single EXIT trap set near the top
 
 if ((${#CSV_ROWS[@]} == 0)); then
 	echo "Error: no successful runs collected." >&2

--- a/scripts/profile-dml-run.sh
+++ b/scripts/profile-dml-run.sh
@@ -252,13 +252,16 @@ delete_file "" "bench-result.csv.done"
 # the same reason.
 delete_file "" "bench_turns.txt"
 # Same class of hazard, and quieter: bench-xbox-ort.sh --ctx / --n-predict leave
-# bench_ctx.txt and bench_npredict.txt behind, and main_loop honours whatever it
-# finds. A profile run after a sweep would silently inherit that sweep's n_ctx
-# and n_predict — no error, just a profile of the wrong configuration. Neither
-# file is ever deleted by the bench script (it only overwrites them), so clearing
-# them here is the only thing that makes a profile run self-contained.
+# bench_ctx.txt, bench_npredict.txt and bench_maxlen.txt behind, and main_loop
+# honours whatever it finds. A profile run after a sweep would silently inherit
+# that sweep's n_ctx / n_predict / max_length — no error, just a profile of the
+# wrong configuration. max_length matters most: it is THE variable governing
+# DirectML prefill (#130/#135), so a stale one would characterize the wrong point
+# invisibly. The bench script only overwrites these, never deletes them, so
+# clearing them here is the only thing that makes a profile run self-contained.
 delete_file "" "bench_ctx.txt"
 delete_file "" "bench_npredict.txt"
+delete_file "" "bench_maxlen.txt"
 
 # Append-only log: remember current size to slice only the new tail later.
 download_file "" "xllama.log" "${TMPDIR_LOCAL}/xllama_before.log"

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -48,6 +48,8 @@ InferenceResult run_inference_llama(const InferenceParams& params);
     #include <windows.h>
     #include <eh.h>
     #include "ort_genai_c.h"
+
+    #include "ort_sampling.h" // shared ORT search-param builder (#125); needs ort_genai_c.h
     #include "xllama/ort_raii.h"
 // clang-format on
 
@@ -202,32 +204,11 @@ InferenceResult run_inference_ort(const InferenceParams& params) {
         oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "max_length",
                                                     static_cast<double>(max_len)),
                   "SetSearchNumber max_length");
-        oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "temperature",
-                                                    static_cast<double>(params.temperature)),
-                  "SetSearchNumber temperature");
-        // Greedy (argmax) decode is deterministic — the prerequisite for logit parity
-        // against the llama.cpp reference. do_sample=false + top_k=1 pins the choice.
-        if (params.sampling().is_greedy()) {
-            oga_check(OgaGeneratorParamsSetSearchBool(gparams.get(), "do_sample", false),
-                      "SetSearchBool do_sample");
-            oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "top_k", 1.0),
-                      "SetSearchNumber top_k");
-        } else {
-            // #125: set these explicitly. Leaving them unset does not mean
-            // "our defaults" — it means whatever genai_config.json ships with,
-            // which is a third sampler configuration nobody chose. Session does
-            // the same, so the two ORT surfaces now agree.
-            oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "top_p",
-                                                        static_cast<double>(params.top_p)),
-                      "SetSearchNumber top_p");
-            oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "top_k",
-                                                        static_cast<double>(params.top_k)),
-                      "SetSearchNumber top_k");
-            oga_check(
-                OgaGeneratorParamsSetSearchNumber(gparams.get(), "repetition_penalty",
-                                                  static_cast<double>(params.repetition_penalty)),
-                "SetSearchNumber repetition_penalty");
-        }
+        // Temperature + the greedy guard via the shared helper (ort_sampling.h),
+        // the same one OrtSession uses — so the two ORT surfaces cannot drift
+        // apart again the way they did before this fix. Greedy (incl. temp 0)
+        // pins argmax; it is the prerequisite for logit parity.
+        apply_ort_sampling(gparams.get(), params.sampling());
         // --- generator ---
         OgaGenerator* raw_gen = nullptr;
         oga_check(OgaCreateGenerator(model.get(), gparams.get(), &raw_gen), "OgaCreateGenerator");

--- a/src/bridge/ort_sampling.h
+++ b/src/bridge/ort_sampling.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2024 Venere Labs
+// SPDX-License-Identifier: MIT
+// Internal: the ORT GenAI search parameters, applied in exactly one place — the
+// twin of sampler_chain.h for the llama.cpp path. Needs the ORT C headers, so it
+// stays out of the public include/ tree.
+//
+// #125 unified the llama.cpp sampler chain but left the ORT search-parameter
+// config hand-duplicated across run_inference (CLI/bench) and OrtSession
+// (GUI/API). They then diverged: OrtSession dropped the greedy guard, so a
+// GUI/API user at temperature 0 on a routed DML model ran the full chain —
+// repetition penalty reweighing tokens before the argmax, which flips the top
+// token (observed: LFM2.5 answered "User\n\n<|end|>" at temp 0 through the
+// endpoint). This is that guard, in one place both callers use.
+#pragma once
+
+#include "ort_genai_c.h"
+#include "xllama/ort_raii.h"
+#include "xllama/sampling.h"
+
+namespace xllama {
+
+// Apply temperature and the sampling stages to |params|. The caller sets
+// max_length itself (it differs: derived on the stateless path, the context on
+// the chat path). Greedy — which includes temperature 0 (SamplingConfig::
+// is_greedy) — pins the choice with do_sample=false + top_k=1 and MUST skip the
+// reweighting stages. Otherwise the three search numbers are set EXPLICITLY:
+// leaving them unset does not mean "our defaults", it means whatever
+// genai_config.json ships with, a third configuration nobody chose.
+inline void apply_ort_sampling(OgaGeneratorParams* params, const SamplingConfig& sc) {
+    oga_check(OgaGeneratorParamsSetSearchNumber(params, "temperature",
+                                                static_cast<double>(sc.temperature)),
+              "SetSearchNumber temperature");
+    if (sc.is_greedy()) {
+        oga_check(OgaGeneratorParamsSetSearchBool(params, "do_sample", false),
+                  "SetSearchBool do_sample");
+        oga_check(OgaGeneratorParamsSetSearchNumber(params, "top_k", 1.0), "SetSearchNumber top_k");
+        return;
+    }
+    oga_check(OgaGeneratorParamsSetSearchNumber(params, "top_p", static_cast<double>(sc.top_p)),
+              "SetSearchNumber top_p");
+    oga_check(OgaGeneratorParamsSetSearchNumber(params, "top_k", static_cast<double>(sc.top_k)),
+              "SetSearchNumber top_k");
+    oga_check(OgaGeneratorParamsSetSearchNumber(params, "repetition_penalty",
+                                                static_cast<double>(sc.repetition_penalty)),
+              "SetSearchNumber repetition_penalty");
+}
+
+} // namespace xllama

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -54,6 +54,8 @@ std::unique_ptr<Session> create_llama(const SessionParams& sp, std::string* err)
 #include <windows.h>
 #include <eh.h>
 #include "ort_genai_c.h"
+
+#include "ort_sampling.h" // shared ORT search-param builder (#125); needs ort_genai_c.h
 #include "xllama/ort_raii.h"
 // clang-format on
 
@@ -109,18 +111,12 @@ class OrtSession final : public Session {
         oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "max_length",
                                                     static_cast<double>(max_length)),
                   "SetSearchNumber max_length");
-        oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "temperature",
-                                                    static_cast<double>(gp.temperature)),
-                  "SetSearchNumber temperature");
-        oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "top_p",
-                                                    static_cast<double>(gp.top_p)),
-                  "SetSearchNumber top_p");
-        oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "top_k",
-                                                    static_cast<double>(gp.top_k)),
-                  "SetSearchNumber top_k");
-        oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "repetition_penalty",
-                                                    static_cast<double>(gp.repetition_penalty)),
-                  "SetSearchNumber repetition_penalty");
+        // #125 follow-up: temperature and the greedy guard via the shared helper,
+        // so this path and run_inference cannot drift apart again. This is the
+        // fix for the greedy gap — make_params used to set the full chain
+        // unconditionally, running the repetition penalty before argmax at
+        // temperature 0.
+        apply_ort_sampling(gparams.get(), gp.sampling());
         return gparams;
     }
 


### PR DESCRIPTION
Closes #141. Found by a cross-checked drift audit after #134–#140. One behavioural bug, three operational fixes.

## The bug (#141)

`OrtSession::make_params` (GUI + LAN API) set `temperature`/`top_p`/`top_k`/`repetition_penalty` unconditionally — no greedy branch. At `temperature == 0` the repetition penalty runs before the argmax and flips the top token, so a deterministic request does not return the argmax. The GUI slider min is `0.0` and the API forwards `temperature`, so it is reachable. The CLI/bench ORT path and both llama.cpp paths already guarded this; `OrtSession` didn't.

Regression from #136, which unified the **llama.cpp** chain but left the **ORT** search params hand-duplicated across `run_inference_ort` and `make_params`. They diverged on exactly this guard, and my #136 comment "the two ORT surfaces now agree" was true only in the non-greedy branch.

**Fix**: the ORT twin of `sampler_chain.h` — a shared `apply_ort_sampling(OgaGeneratorParams*, const SamplingConfig&)` that both callers use, greedy branch inside. By construction the two surfaces can no longer diverge on the guard.

## Operational fixes (same audit)

- **`bench-xbox-ort.sh --threads` mutated the device permanently.** It overwrote the on-device `genai_config.json` with no restore; the last thread variant stayed in force for every later run — I hit exactly this (a t8 sweep left the console on t8). Now backs up and restores on any exit, mirroring `profile-dml-run.sh`; `--keep-config` opts out.
- **`profile-dml-run.sh` and `bench-xbox-kv.sh` didn't clear `bench_maxlen.txt`** (new in #139). A profile or KV run after a `--max-length` sweep would silently inherit it — and `max_length` is *the* DirectML prefill variable, so it would characterize the wrong point with no error.
- **`inference_params.h`**: the `InferenceResult::max_length` comment still said "not independently settable", false since #139's override — and it contradicted the `max_length_override` comment in the same file.

## Verification

- Host tests **125/125**. The ORT helper is not host-compiled (`ort_genai_c.h` is UWP-only), so the guarantee here is **by construction** — one shared function, exactly like `sampler_chain.h`. `is_greedy()`'s temp-0 contract is already pinned in `test_sampling.cpp`.
- `shellcheck` clean on all three scripts.
- The Windows CI `build (unified)` lane is what actually compiles `apply_ort_sampling` into `session.cpp` and `inference.cpp`.

## Not done here

The end-to-end proof (GUI at temp 0 returns the argmax on a routed DML model) needs the console and is a manual check; noted, not claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)