### PR TITLE
docs: record Phase 12 as concluded (product judgement, not pending re-derivation)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,11 +108,13 @@ headless-only), and the test/API surfaces trail the UI.
 - [ ] LAN API parity (images, preferences, training status) — #118, low
       priority while the API remains a demo.
 
-## Phase 12 — DirectML routing calibration (in progress)
+## Phase 12 — DirectML routing calibration (measurement done; one product call open)
 
 A measurement campaign on the shipping `-v2` asset, prompted by the question of
-whether DirectML is worth routing to at all. Evidence under
-`bench/results/phase12-*.csv`; analysis in `docs/uwp-constraints.md` §5b/§5c.
+whether DirectML is worth routing to at all. The measurement is done and the
+answer is a product judgement, not a constant: the GPU wins first-turn TTFT on a
+long prompt and the CPU wins from the second turn (§5d). Evidence under
+`bench/results/phase12-*.csv`; analysis in `docs/uwp-constraints.md` §5b–§5f.
 
 - [x] Instrument the bench path so a row can be interpreted: `n_prompt_tok` and
       `n_gen_tok` (#128), then `max_length` — without the variable under study a
@@ -138,13 +140,25 @@ whether DirectML is worth routing to at all. Evidence under
       `temp -> dist` while the GUI ran the full chain, so a generation seen on
       one could not be reproduced on the other. Defaults and the chain builder
       now have one home each.
-- [ ] Re-derive `token_threshold` on the corrected model. It is still calibrated
-      against prompt length, and the reachable band under the trimmer is only
-      ~135 tokens wide — thin enough to be fragile across tokenizers.
-- [ ] Explain the `max_length` valley. Suspected shape-bucketed DirectML kernel
-      selection; the per-node profiler cannot localise it alone (the graph is one
-      `DmlFusedNode_0_0` at 96% of kernel time, §12). Not distinguished yet:
-      per-process lazy kernel compilation, WDDM residency on absolute bytes.
+- [x] **Threshold re-derivation done (#139, §5d) — it is a product call, not a
+      constant.** The full criterion (adding the asymmetric model load and the
+      KV-reuse asymmetry the sweep omitted) shows there is no correct single
+      prompt-length threshold: DirectML wins turn 1 above ~1250 tokens and the
+      CPU wins from turn 2 at every reachable length. Whether Auto is worth
+      leaving on is "how single-turn are long-prompt conversations", which §5d
+      calls not measurable from here — so the UI now surfaces TTFT to make it
+      observable in real use. The shipping 1550 is left as-is, its rationale
+      corrected.
+- [x] **Threading corrected 4 → 6 (§5f).** The old recommendation was a
+      decode-only optimum; measuring prefill too puts 6 ahead, and `t8` is a trap
+      (it sinks prefill as well as decode). Caveat recorded: the shipped asset
+      sets no `intra_op_num_threads` at all.
+- [ ] Confirm the `max_length` valley mechanism. §5e gives **strong evidence for
+      per-process lazy kernel compilation** (DirectML warms 1.64×/1.72× on the
+      second call in a process; CPU control 1.00×), which is the leading
+      hypothesis over WDDM residency — but not yet a conclusive profile. The
+      per-node profiler cannot localise it alone (the graph is one
+      `DmlFusedNode_0_0` at 96% of kernel time, §12). Tracked in #130.
 
 ## Upstream and vendor lifecycle
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,8 +119,10 @@ stays on **CPU int4** (fastest decode); a long first-turn prompt can switch to
 does **not** mean the GPU is faster overall: DirectML cannot reuse a KV cache
 (`kv_reuse_supported_for_model` returns false for it) while the CPU can, so from
 the second turn the CPU wins at every reachable length — see `uwp-constraints.md
-§5d`. The threshold (`token_threshold`) is provisional and under re-derivation
-(§5c). Routing is **ORT-only**; GGUF models are CPU-only, so routing is skipped
+§5d`. The threshold (`token_threshold`) is calibrated on a misattributed
+variable (§5c); the re-derivation concluded a single prompt-length threshold is
+the wrong shape for the decision, so 1550 is left as-is with its rationale
+corrected. Routing is **ORT-only**; GGUF models are CPU-only, so routing is skipped
 for them. Tunable prefill batching for the llama.cpp path is exposed via
 `SessionParams.n_batch` / `n_ubatch` (`xllama-cli --batch/--ubatch`) — see
 `benchmarks.md` for the (flat) sweep.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -84,8 +84,9 @@ Notes:
   exonerated — see `dml-rmsnorm-fix-runbook.md`) is worked around by the
   RMSNorm-decomposed `smollm2-360m-dml-fp16-v2` graph, parity-validated
   on-console. `routing_policy.h` (`dml_text_model_ok`) allows GPU text routing
-  only for that asset; the Auto switch applies at `token_threshold` (1550, but
-  **provisional and under re-derivation** — `uwp-constraints.md §5c/§5d`). Its
+  only for that asset; the Auto switch applies at `token_threshold` (1550 — but a
+  single prompt-length threshold is the **wrong shape** for this decision, which
+  is a product judgement, `uwp-constraints.md §5d`). Its
   measured row is 236.7 prefill / 44.4 decode / 1268 MB. **The prefill number is
   a cold-process figure** (§5e: DirectML warms up ~1.7× on the second call in a
   process, so nothing in this repo reports warm prefill) and decode still loses

--- a/docs/recommended-config.md
+++ b/docs/recommended-config.md
@@ -122,12 +122,15 @@ Two caveats on that number, both live:
   between the 600 → 1550 retune and its fix. The usable band is roughly 1550 to
   1685 real tokens, about 135 wide.
 - It was calibrated against a DirectML slowdown believed to track prompt length.
-  It tracks `max_length` instead (#130, `docs/uwp-constraints.md` §5c), so the
-  value is provisional and under re-derivation.
+  It tracks `max_length` instead (#130, `docs/uwp-constraints.md` §5c). The
+  re-derivation (§5d) concluded there is **no correct single prompt-length
+  threshold** — see the next point — so 1550 is left as-is with its rationale
+  corrected, not swept for a better number.
 - It optimizes the **first turn only** (§5d). The GPU buys a faster first token
   on a long prompt; from the second turn the CPU wins at every reachable length,
-  because DirectML cannot reuse a KV cache. Whether Auto is worth leaving on
-  depends on how single-turn your long-prompt conversations are.
+  because DirectML cannot reuse a KV cache. So the value is a product judgement —
+  whether Auto is worth leaving on depends on how single-turn your long-prompt
+  conversations are, which is not measurable from a bench.
 
 ## Image generation
 

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -226,8 +226,10 @@ The mechanism remains **unknown** — suspected shape-bucketed kernel selection 
 DirectML, which the per-node profiler (§11) cannot localise on its own because
 the graph collapses into a single `DmlFusedNode_0_0` at 96% of kernel time.
 Because §5b's finding 3 rests on the prompt-length reading, `token_threshold`
-(1550) is calibrated on a misattributed variable and is under re-derivation; it
-also has to stay below the context trimmer's budget, which is #133.
+(1550) is calibrated on a misattributed variable. The re-derivation is in §5d,
+and its conclusion is that there is no correct single prompt-length threshold —
+the value is a product judgement, not a number to re-measure. It also has to stay
+below the context trimmer's budget, which is #133.
 
 Raw rows: `bench/results/phase12-maxlen-band.csv`.
 
@@ -296,8 +298,9 @@ not once per turn.
 
 ### §5f — CPU threading: prefill does not scale, and t8 is worse than recorded (2026-07-21)
 
-`intra_op_num_threads: 4` in `docs/recommended-config.md` came from a sweep whose
-every row has `prompt_tok_s = 0.00` — a **decode** optimum. Prefill had never
+`docs/recommended-config.md` previously recommended `intra_op_num_threads: 4`
+(now corrected to 6, below). That 4 came from a sweep whose every row has
+`prompt_tok_s = 0.00` — a **decode** optimum. Prefill had never
 been measured against threads, which mattered because prefill is what GPU routing
 exists to compensate for.
 

--- a/uwp/MainPage.h
+++ b/uwp/MainPage.h
@@ -202,11 +202,13 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     // Autoscroll state: true while the user has not scrolled up during streaming
     bool m_at_bottom{true};
 
-    // Sampling parameters (persisted in settings.json, exposed in Settings dialog)
-    float m_temperature{0.8f};
-    float m_top_p{0.9f};
-    int m_top_k{40};
-    float m_repetition_penalty{1.1f};
+    // Sampling parameters (persisted in settings.json, exposed in Settings dialog).
+    // Seeded from the single source in sampling.h (#125) so the GUI defaults
+    // cannot drift from the CLI/API defaults.
+    float m_temperature{::xllama::sampling_defaults::kTemperature};
+    float m_top_p{::xllama::sampling_defaults::kTopP};
+    int m_top_k{::xllama::sampling_defaults::kTopK};
+    float m_repetition_penalty{::xllama::sampling_defaults::kRepetitionPenalty};
     int m_n_predict{512};
 
     std::atomic<bool> m_abort{false};


### PR DESCRIPTION
Follow-up to the drift audit. PR-1 (#142) fixed the code/script drift; this is the tracking half.

## ROADMAP Phase 12

Was frozen at the mid-investigation state. Corrected to the final one:

- Header and §-pointer updated (§5b→§5b–§5f — the sections that actually answer the phase's question).
- **"Re-derive `token_threshold`"** checked and reframed. #139/§5d concluded there is **no correct single prompt-length threshold**: the GPU wins turn 1, the CPU wins turn 2+, so it is a product judgement (how single-turn are long-prompt conversations), which §5d calls not measurable from a bench. The *measurement* is done — that is what the checkbox tracked.
- Added the **§5f threads 4→6** outcome.
- The **valley checkbox** stays open but is corrected: §5e is now *strong evidence* for lazy kernel compilation (1.64×/1.72× DML warm-up, CPU control 1.00×), not two undistinguished hypotheses. Tracked in #130.

## Doc reframing

"provisional and under re-derivation" survived in `recommended-config.md`, `uwp-constraints.md §5c`, `benchmarks.md`, `architecture.md`. All four now say the same thing — the re-derivation concluded a single prompt-length threshold is the wrong shape, so 1550 is left as-is with its rationale corrected. **Zero** "under re-derivation" left in the tree.

`uwp-constraints.md §5f`: past-tensed the "recommended-config.md says 4" phrasing (it says 6 since #139).

## MainPage.h (the P3.2 tail of the audit)

The GUI sampling defaults were bare literals (`0.8f`/`0.9f`/`40`/`1.1f`) — exactly the multi-source pattern #125 set out to kill. Now seeded from `sampling_defaults::k*` (reachable via `session.h → inference_params.h → sampling.h`), so they cannot drift from the CLI/API defaults.

## Verification

`generate-benchmark-summary.py --check` and `prettier` clean; host tests 125/125 (MainPage.h is UWP-only, covered by the Windows CI lane); `grep "under re-derivation"` → none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)