### PR TITLE
docs: changelog + architecture drift from #141/#142

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **The GUI/API ran the full sampler at temperature 0 (#141).** `OrtSession::make_params`
+  set `temperature`/`top_p`/`top_k`/`repetition_penalty` unconditionally — no
+  greedy branch — so a `temperature == 0` request ran the repetition penalty
+  before the argmax and did not return the argmax token. The GUI slider min is
+  `0.0` and the LAN API forwards `temperature`, so it was reachable on a
+  DML-routed model. The CLI/bench ORT path and both llama.cpp paths already
+  guarded this via `SamplingConfig::is_greedy()`; `OrtSession` did not. It was a
+  regression from #136, which unified the llama.cpp chain but left the ORT search
+  params hand-duplicated across `run_inference_ort` and `make_params`, which then
+  diverged on exactly this guard. Fixed with the ORT twin of `sampler_chain.h` —
+  a shared `apply_ort_sampling()` both callers use, greedy branch inside — so the
+  two ORT surfaces can no longer diverge by construction. Verified on console
+  (temp 0, repetition penalty 2.0, DML-routed): the buggy build produced garbage
+  where the argmax was diverted, the fixed build returned the clean argmax.
+
 - **Auto GPU routing was unreachable.** `BuildPrompt` estimated tokens as
   `chars / 4` and dropped turns above 1800; `decide_routing` compared the real
   tokenizer count against 1550. English prose measures ~5.34 chars/token, so the
@@ -119,9 +134,18 @@ you would return home! Particularly beyond Thetatweil, Arc de"` against
   guarded the local file.
 
 - **`profile-dml-run.sh` inherited a previous sweep's configuration.**
-  `bench-xbox-ort.sh` only ever overwrites `bench_ctx.txt` / `bench_npredict.txt`,
-  never deletes them, so a profile run after a sweep silently profiled the wrong
-  `n_ctx` and `n_predict`.
+  `bench-xbox-ort.sh` only ever overwrites `bench_ctx.txt` / `bench_npredict.txt` /
+  `bench_maxlen.txt`, never deletes them, so a profile run after a sweep silently
+  profiled the wrong `n_ctx` / `n_predict` / `max_length`. The profiler and
+  `bench-xbox-kv.sh` now clear all three; `max_length` matters most, since it is
+  the DirectML prefill variable (#130). (Extended for `bench_maxlen.txt` in #142.)
+
+- **`bench-xbox-ort.sh --threads` mutated the device permanently.** It overwrote
+  the on-device `genai_config.json` with no restore, so the last thread variant
+  stayed in force for every later run of the app and every bench that did not
+  pass `--threads` — a t8 sweep left the console on t8. It now backs up and
+  restores on any exit, mirroring `profile-dml-run.sh`; `--keep-config` opts out
+  (#142).
 
 - **`deploy.sh pfn` returned an arbitrary package version.** It took the first
   match with no version ordering, and an MSIX upgrade can leave two versions of

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,10 +127,16 @@ for them. Tunable prefill batching for the llama.cpp path is exposed via
 `SessionParams.n_batch` / `n_ubatch` (`xllama-cli --batch/--ubatch`) — see
 `benchmarks.md` for the (flat) sweep.
 
-Sampling is one code path for both surfaces: `SamplingConfig` and its defaults
-live in `sampling.h`, and the llama.cpp sampler chain is assembled in exactly one
-place, `src/bridge/sampler_chain.h` (`add_sampler_stages`), so the CLI/bench and
-GUI/API cannot drift into different samplers as they had before #125.
+Sampling has one code path per backend, both fed by `SamplingConfig` and its
+defaults in `sampling.h`. The **llama.cpp** chain is assembled in exactly one
+place, `src/bridge/sampler_chain.h` (`add_sampler_stages`, #125); the **ORT
+GenAI** search params in one place, `src/bridge/ort_sampling.h`
+(`apply_ort_sampling`, #141) — including the greedy guard (temperature 0 pins the
+argmax and skips the repetition penalty). #125 unified only the llama.cpp side;
+the ORT params stayed hand-duplicated across `run_inference_ort` and
+`OrtSession::make_params` and drifted on that guard until #141 gave them a shared
+builder too. Now neither backend's two surfaces (CLI/bench vs GUI/API) can diverge
+by construction.
 
 ## Model catalogue, provisioning, and quant auto-upgrade
 


### PR DESCRIPTION
A read-only drift sweep on the frozen tree (HEAD f2cf518, after #141-#144 merged) found two doc gaps the previous audit predated. The rest — console runbook, knowledge notes, other sampler docs — verified clean.

## CHANGELOG [Unreleased]

- **Added the #141 OrtSession greedy fix.** The batch's only user-facing correctness fix (a `temperature == 0` request ran the repetition penalty before the argmax and did not return the argmax) had no `### Fixed` entry, while its llama.cpp twin (#136) did. Includes the console before/after.
- **Extended the `profile-dml-run.sh` entry** to include `bench_maxlen.txt` — the #139 knob it now also clears. The omission was on `max_length`, which the same changelog repeatedly calls *the* DirectML prefill variable.
- **Added the `bench-xbox-ort.sh --threads` restore line.** It mutated the device `genai_config.json` permanently; a t8 sweep left the console on t8.

## architecture.md

The sampling paragraph named only `sampler_chain.h` and claimed #125 closed sampler drift for both surfaces. After #142 there are two shared builders, and the ORT surface actually drifted (the greedy guard) until #141. Now names `ort_sampling.h` and attributes the two unifications correctly: #125 → llama.cpp, #141 → ORT.

Docs only; `generate-benchmark-summary.py --check` and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected temperature-zero behavior so requests use greedy sampling consistently across interfaces.
  * Fixed benchmarking and profiling workflows to properly reset context and length settings.
  * Updated thread-based benchmarking to preserve and restore device configuration by default.

* **Documentation**
  * Clarified sampling consistency and temperature-zero handling across supported backends.
  * Documented benchmarking configuration and restoration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->