### PR TITLE
docs: threads-6 as a tracked conditional item, not a floating caveat

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -149,10 +149,17 @@ long prompt and the CPU wins from the second turn (§5d). Evidence under
       calls not measurable from here — so the UI now surfaces TTFT to make it
       observable in real use. The shipping 1550 is left as-is, its rationale
       corrected.
-- [x] **Threading corrected 4 → 6 (§5f).** The old recommendation was a
-      decode-only optimum; measuring prefill too puts 6 ahead, and `t8` is a trap
-      (it sinks prefill as well as decode). Caveat recorded: the shipped asset
-      sets no `intra_op_num_threads` at all.
+- [x] **Threading recommendation corrected 4 → 6 in the docs (§5f).** The old
+      recommendation was a decode-only optimum; measuring prefill too puts 6
+      ahead, and `t8` is a trap (it sinks prefill as well as decode).
+- [ ] **Ship `intra_op_num_threads: 6` on the CPU asset — deferred, conditional.**
+      The shipped `smollm2-360m-cpu-int4` sets none, so the recommendation is
+      doc-only. Not shipped yet on purpose: the +8.5% is rigorous at one prompt
+      length (1380), below Phase 12's own bar (10 lengths, closing control), and
+      a republish now would move the baseline every Phase 12 measurement used
+      while #130 is open. Ship condition: a proper thread sweep (≥3 lengths incl.
+      short, 3 runs, closing control), ideally with the next models-v1 republish.
+      See `docs/recommended-config.md`.
 - [ ] Confirm the `max_length` valley mechanism. §5e gives **strong evidence for
       per-process lazy kernel compilation** (DirectML warms 1.64×/1.72× on the
       second call in a process; CPU control 1.00×), which is the leading

--- a/docs/recommended-config.md
+++ b/docs/recommended-config.md
@@ -74,7 +74,17 @@ GGUF thread default: llama.cpp auto-detect is capped at **6** on console
   — not the bandwidth saturation it was recorded as.
   ⚠️ The shipped `smollm2-360m-cpu-int4` asset currently sets **no**
   `intra_op_num_threads` at all, so neither this value nor the previous one is
-  in production. Applying it means republishing the asset on models-v1.
+  in production. Applying it means republishing the asset on models-v1 — a
+  publish, not a config edit. **Deferred on purpose, not forgotten**: the +8.5%
+  is measured with rigor at only one prompt length (1380, 3 runs interleaved);
+  792 is a single run (+3%) and t8 a single run. That is below the bar the rest
+  of Phase 12 held (10 lengths, closing control), so it does not yet earn a
+  production config change — and shipping it would move the baseline every
+  Phase 12 measurement was taken against while #130's mechanism is still open.
+  **Ship condition**: a proper thread sweep (≥3 lengths including short prompts,
+  3 runs each, closing control) confirming 6 wins across the range, ideally
+  bundled with the next models-v1 republish for another reason. Until then the
+  device runs the ORT default and this recommendation stays doc-only.
 - `past_present_share_buffer: true` (required for KV reuse)
 
 **DML fp16 (routing)** — [`bench/configs/genai_config-dml-test.json`](../bench/configs/genai_config-dml-test.json):


### PR DESCRIPTION
Follow-up to the polishing pass. On whether to ship `intra_op_num_threads: 6` on the CPU asset (the shipped one sets none), the answer — applying the project's own measurement bar — is **not yet, and record why**.

## Reasoning

§5f's +8.5% is real but the **thinnest measurement of the whole campaign**: rigorous at one prompt length (1380 tokens, 3 runs interleaved), single-run at 792 (+3%), single-run at t8. The rest of Phase 12 held 10 lengths with a closing control. Shipping a production config off two lengths would:
- violate the project's own discipline (`bp-record-the-independent-variable`, and the closing-control rigor the threshold work used), and
- move the shipped baseline that **every Phase 12 measurement was taken against**, while #130's mechanism work is still open.

The win is also small in absolute terms on a 360M model (~0.5 s of prefill at 1380 tokens; negligible on the common short prompt).

## Changes

- **recommended-config.md**: the caveat now states a **ship condition** (≥3 lengths incl. short prompts, 3 runs, closing control, ideally bundled with the next models-v1 republish) instead of just "applying means republishing".
- **ROADMAP Phase 12**: split the checked "corrected in docs" item from a new **open, conditional** "ship on the asset" item, so the deferred optimization is tracked with its bar rather than floating in a doc caveat.

This is the continuity-serving move: the finding isn't lost, and the next session/researcher sees the exact condition under which 6 earns production, not a vague "should we?".

Docs only; `generate-benchmark-summary.py --check` and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)