### PR TITLE
docs: sync architecture and SSOT after Phase 11 / #118

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,11 +13,14 @@ Quick reference for AI agents and new contributors.
 
 ```
 xllama/
-├── include/xllama/          # Shared public headers
+├── include/xllama/          # Shared public headers (WinRT-free, host-testable)
 │   ├── inference_params.h   # InferenceParams / InferenceResult
 │   ├── inference.h          # run_inference, write_bench_csv
 │   ├── training_params.h    # TrainingJob / TrainingCapability (training pillar)
 │   ├── training.h           # validate/load job, capability matrix, stage names
+│   ├── device_train.h       # Lane B run_device_train_job + progress callbacks
+│   ├── personalize.h        # Phase 11: last-block filter, job builder, sample count
+│   ├── preference_capture.h # preference JSONL (UI rate + POST /v1/preferences)
 │   ├── routing_policy.h     # routing decision + prompt budget (threshold must stay under it)
 │   ├── sampling.h           # sampling defaults shared by CLI/bench and GUI/API
 │   ├── session.h            # xllama::Session API (persistent model across turns)
@@ -32,43 +35,49 @@ xllama/
 │   ├── sampler_chain.h      # add_sampler_stages — the one llama.cpp sampler chain (#125)
 │   ├── ort_sampling.h       # apply_ort_sampling — the ORT twin, greedy guard shared (#141)
 │   ├── session.cpp          # xllama::Session (OrtSession UWP + LlamaSession Linux)
-│   ├── bench.cpp            # bench CSV writer
+│   ├── training.cpp         # TrainingJob validate/parse (host + UWP linkable)
+│   ├── device_train.cpp     # Lane B engine: prepare → train → export → evaluate
+│   ├── personalize.cpp      # Phase 11 pure helpers
+│   ├── preference_capture.cpp
+│   ├── bench.cpp            # bench CSV writer (incl. run_index)
 │   ├── platform.cpp         # log_output (writes xllama.log in UWP)
 │   ├── path_utils.cpp       # resolve_model_path: LocalState\models\ + InstalledPath fallback
 │   ├── utf8_utils.cpp
-│   ├── cli.cpp
-│   └── training.cpp         # TrainingJob validate/parse (host + UWP linkable)
+│   └── cli.cpp
 ├── src/main.cpp             # Linux entry point (getopt_long; --train-job)
 ├── training/                # Training pillar ops: jobs, datasets, host PEFT
-├── docs/training-architecture.md  # Training SSOT (RE + capability matrix)
+├── docs/                    # SSOT map in docs/README.md
+│   ├── architecture.md      # System structure SSOT
+│   ├── training-architecture.md  # Training SSOT (RE + capability matrix + §11 UI arc)
+│   └── api-endpoint.md      # LAN protocol (chat + prefs + train status + images)
 ├── uwp/                     # C++/WinRT UWP app
 │   ├── App.cpp / App.h      # Application::OnLaunched
-│   ├── MainPage.cpp / .h    # MainPageController (plain C++, not runtimeclass); incl. autopilot driver
-│   ├── inference-bridge.cpp / .h   # UWP main_loop() + bench mode
-│   ├── chat-history.cpp / .h       # ChatHistory: Save/Load/Delete/Clear
-│   ├── model-downloader.cpp / .h   # ModelDownloader::DownloadAsync — catalogue download (GitHub Release models-v1, models/manifest.json)
+│   ├── MainPage.cpp / .h    # MainPageController; personalize UI; autopilot
+│   ├── inference-bridge.cpp / .h   # main_loop, run_train_job_localized, headless flags
+│   ├── api-server.cpp / .h  # opt-in LAN endpoint
+│   ├── chat-history.cpp / .h
+│   ├── model-downloader.cpp / .h   # catalogue download + LoadModelManifest
 │   ├── packages.config      # NuGet pins (ORT GenAI 0.14.1, ORT 1.24.4, DirectML 1.15.4)
 │   └── xllama.sln / .vcxproj
 ├── scripts/
 │   ├── deploy.sh                      # Device Portal: deploy, logs, bench trigger
 │   ├── build-uwp.ps1                  # Windows UWP packaging script
-│   ├── merge_onnx_external_data.py    # merge model.onnx.data → self-contained model.onnx
-│   ├── bench-xbox-ort.sh              # benchmark runner (ORT GenAI; model already on device)
-│   ├── validate-console.sh           # autopilot orchestrator: §2 routing / settings ops / GGUF / §7c TAESD verdicts
-│   ├── package-catalogue-ort-model.sh # stage flat models-v1 assets from merged ORT GenAI dir
-│   ├── install-latest-build.sh        # fetch + deploy latest CI artifact (--bench is opt-in)
-│   ├── generate-benchmark-summary.py  # raw results → generated docs/dashboard
-│   ├── test-dml-config.sh             # upload DML provider_options without MSIX rebuild
-│   ├── vendor-genai-dml-patch.ps1     # overlay #2280 patched onnxruntime-genai.dll
-│   ├── export-taesd-asset.sh          # export TAESD VAE for models-v1 release
-│   ├── check-uwp-host.sh              # Linux host preflight (qemu, libvirt)
-│   └── setup-windows-uwp-dev.ps1      # Windows VM: install VS2022 + UWP workload
-├── tests/                   # Unit tests (doctest, target: xllama-tests)
-├── bench/                   # Benchmark configs, prompts, raw results + summary policy
-├── docs/                    # Technical notes (see docs/README.md)
-├── cmake/                   # Toolchain files
+│   ├── bench-xbox-ort.sh              # benchmark runner (run_index, multi-run)
+│   ├── validate-console.sh            # autopilot: routing / settings / GGUF / TAESD
+│   ├── validate-console-training.sh   # rate / serve / device-train
+│   ├── validate-api.sh                # LAN: spike|chat|prefs|train|all
+│   ├── generate-benchmark-summary.py  # raw results → docs table + dashboard
+│   ├── install-latest-build.sh        # fetch + deploy latest CI artifact
+│   └── …
+├── tests/                   # Unit tests (doctest; incl. test_personalize)
+├── bench/                   # configs, raw results, summary policy
+├── cmake/
 └── .github/workflows/       # build-linux.yml + build-uwp.yml
 ```
+
+**Doc ownership (do not invent a second SSOT):** see `docs/README.md`. Structure →
+`architecture.md`; training → `training-architecture.md`; numbers →
+`bench/results` + generated `benchmarks.md`; UI steps → `using-the-app.md`.
 
 ## Build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Documentation sync for Phase 11 / #118 and SSOT practices.** `docs/README.md`
+  states ownership principles; `architecture.md`, `training-architecture.md` §11,
+  `using-the-app.md`, `api-endpoint.md`, `training/README.md`, root `README.md`,
+  `AGENTS.md`, `ROADMAP.md`, and `CONTRIBUTING.md` reflect in-app personalize and
+  LAN parity instead of “Phase 11 next”.
+
 ### Added
 
 - **Phase 11 in-app personalization (#116).** Settings → "Train on my feedback"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ Mode)**; most constraints come from the UWP/AppContainer sandbox, so read
 
 ## Workflow
 
-1. Branch off `main` (`feat/…`, `fix/…`, `chore/…`) and open a PR — CI builds
-   run on PRs (feature branches don't build on direct push).
+1. Branch off `main` (`feat/…`, `fix/…`, `docs/…`, `chore/…`) and open a PR —
+   CI builds run on PRs (feature branches don't build on direct push).
 2. Keep PRs focused; put orthogonal infra changes in their own PR.
 3. Fill in the PR template's "How verified" section.
 
@@ -21,6 +21,8 @@ ctest --test-dir build/linux-test --output-on-failure
 # Formatting gate (CI enforces it with --Werror):
 clang-format -i <changed .cpp/.h files>
 shellcheck scripts/*.sh   # if you touched shell
+# If you touched bench CSVs or summary policy:
+python3 scripts/generate-benchmark-summary.py --check
 ```
 
 ## Conventions
@@ -29,6 +31,29 @@ shellcheck scripts/*.sh   # if you touched shell
   comments, and commits.
 - **Formatting** is enforced (`.clang-format`, pinned `clang-format` in CI).
 - **Commits**: conventional prefixes (`feat`, `fix`, `docs`, `ci`, `chore`, …).
+
+## Documentation
+
+Project docs follow a **single source of truth** map — see
+[`docs/README.md`](docs/README.md) (principles + ownership table).
+
+| If you change… | Update… |
+| -------------- | ------- |
+| Module boundaries / data flow | `docs/architecture.md` |
+| Training contracts / lanes / Phase 11 | `docs/training-architecture.md` + `training/README.md` |
+| User-facing UI steps | `docs/using-the-app.md` |
+| LAN routes | `docs/api-endpoint.md` |
+| Benchmarks / CSV schema | `bench/README.md` + regen summary if needed |
+| Release behaviour | `CHANGELOG.md` (and `ROADMAP.md` if a phase closes) |
+| Repo layout for agents | `AGENTS.md` |
+
+Do **not** hand-edit generated tables in `docs/benchmarks.md` (run
+`generate-benchmark-summary.py`). Prefer linking to the SSOT over copying
+numbers into a second file.
+
+Public C++ headers under `include/xllama/` should state what they own in a short
+file comment (English). Prefer pure helpers testable on Linux over UWP-only
+logic when the behaviour is not WinRT-specific.
 
 ## Platform notes
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ The project started as a port of [`llama.cpp`](https://github.com/ggml-org/llama
 The default chat model on the shipping **unified** build is **LFM2.5-350M Q4_K_M** (~219 MB, ~94 tok/s), downloaded on first launch from the GitHub Release model catalogue — the MSIX itself is ~19 MB and ships no model. ORT-only builds still default to SmolLM2-360M INT4.
 
 The LAN endpoint is experimental, unauthenticated, foreground-only and disabled
-by default. Personalization is operator-driven: preference samples remain in
-the AppContainer until explicitly pulled to a host for retraining — or consumed
-on-device by a Lane B `partial_ft` job (available, host + console gates PASS).
+by default. Preference samples stay in the AppContainer until the operator pulls
+them for host PEFT **or** the user runs **Settings → Train on my feedback**
+(Phase 11): an in-process Lane B `partial_ft` that publishes a `personalized`
+GGUF to the model picker (code complete; needs a base f16 GGUF on device).
 
 Goals:
 
@@ -169,6 +170,8 @@ xllama/
 │   ├── training_params.h   # TrainingJob / TrainingCapability contracts
 │   ├── training.h          # job validation, capability matrix, stage names
 │   ├── device_train.h      # Lane B in-process partial-FT engine (ggml-opt)
+│   ├── personalize.h       # Phase 11 job builder, filters, sample count, manifest JSON
+│   ├── preference_capture.h # preference JSONL (UI rate + API)
 │   ├── ort_raii.h          # RAII wrappers for OGA* types (UWP)
 │   ├── llama_raii.h        # RAII wrappers for llama_* types (Linux)
 │   ├── cli.h               # parse_cli_args (Linux)
@@ -182,6 +185,8 @@ xllama/
 │       ├── session.cpp     # xllama::Session (OrtSession + LlamaSession)
 │       ├── training.cpp    # job parsing/validation + capability table
 │       ├── device_train.cpp # Lane B engine: prepare → train → export → evaluate
+│       ├── personalize.cpp # Phase 11 pure helpers (host-testable)
+│       ├── preference_capture.cpp
 │       ├── bench.cpp
 │       ├── platform.cpp
 │       ├── path_utils.cpp
@@ -189,11 +194,11 @@ xllama/
 │       └── utf8_utils.cpp
 ├── uwp/                    # C++/WinRT UWP app
 │   ├── App.cpp / App.h     # Application lifecycle, OnLaunched
-│   ├── MainPage.cpp / .h   # MainPageController — programmatic UI (XAML-free)
-│   ├── inference-bridge.cpp / .h  # UWP entry glue + bench mode main_loop()
+│   ├── MainPage.cpp / .h   # MainPageController — programmatic UI (XAML-free); personalize + autopilot
+│   ├── inference-bridge.cpp / .h  # UWP entry glue, bench, run_train_job_localized
 │   ├── diffuse.cpp         # SD-Turbo diffusion pipeline (plain ORT DirectML)
 │   ├── chat-history.cpp / .h      # ChatHistory: Save/Load/Delete/Clear
-│   ├── api-server.cpp / .h        # opt-in OpenAI-compatible LAN front-end
+│   ├── api-server.cpp / .h        # opt-in OpenAI-compatible LAN front-end (chat + prefs + train status + images)
 │   ├── model-downloader.cpp / .h  # ModelDownloader::DownloadAsync + LoadModelManifest (catalogue download)
 │   ├── models/manifest.json # model catalogue (LocalState override supported)
 │   ├── packages.config     # NuGet runtime pins (see docs/recommended-config.md)
@@ -311,11 +316,20 @@ See [docs/uwp-constraints.md](./docs/uwp-constraints.md) for the measured GPU bu
 A dual-lane training pillar lets the app adapt models **on the device**, no cloud:
 
 - **Host PEFT LoRA** (Lane A) — full LoRA fine-tune off-device, merged to GGUF.
-- **On-device partial fine-tune** (Lane B) — an in-process ggml-opt last-block `partial_ft` that runs entirely on the Xbox. **Available**: host + console marker gates PASS (Series S: peak working set 1195 MB, well under the 3 GB budget; marker reproduced end-to-end).
-- **Serve merged GGUF** (Lane C) — load the fine-tuned model through the normal inference path, plus runtime LoRA.
-- **Preference capture** — the in-app Like/Dislike/Correct actions feed a retraining dataset (`training/samples.jsonl`).
+- **On-device partial fine-tune** (Lane B) — in-process ggml-opt last-block
+  `partial_ft` on the Xbox. **Available**: host + console marker gates PASS
+  (Series S: peak working set 1195 MB; marker reproduced end-to-end).
+- **Serve merged GGUF** (Lane C) — load the fine-tuned model through the normal
+  inference path, plus runtime LoRA.
+- **Preference capture** — Like/Dislike/Correct → `training/samples.jsonl`.
+- **In-app personalize (Phase 11)** — Settings → **Train on my feedback** runs
+  Lane B without leaving the UI, surfaces progress, and registers catalogue id
+  `personalized` for the model picker. Needs a base GGUF
+  (`training/base-f16.gguf` or a provisioned SmolLM2 GGUF).
 
-SSOT: [docs/training-architecture.md](./docs/training-architecture.md). Ops and job format: [training/README.md](./training/README.md). Surfacing this loop in the UI is [Phase 11](#roadmap).
+SSOT: [docs/training-architecture.md](./docs/training-architecture.md)
+(§11 for the UI arc). Ops: [training/README.md](./training/README.md).
+App guide: [docs/using-the-app.md](./docs/using-the-app.md).
 
 ---
 
@@ -351,9 +365,9 @@ See [ROADMAP.md](./ROADMAP.md). Headlines:
 10. **Phase 10 — Device partial FT** ✅ ggml-opt Lane B; host + console marker
     gates PASS (Xbox Series S: peak_ws 1195 MB, marker reproduced) —
     `DeviceGgmlPartialFt` available.
-11. **Phase 11 — Headless ↔ UI gap** 🔜 Next: surface the on-device training
-    loop in the UI (trigger, progress, serve the personalized model), plus
-    autopilot/LAN-API parity. See [ROADMAP.md](./ROADMAP.md).
+11. **Phase 11 — Headless ↔ UI gap** ✅ In-app Train on my feedback, publish
+    `personalized` model, autopilot `start_train`/`train_status`, LAN API
+    prefs/training status/images (#116/#118). See [ROADMAP.md](./ROADMAP.md).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,10 +16,11 @@ performance belongs in `docs/benchmarks.md`.
   fixed by graph decomposition — `docs/dml-rmsnorm-fix-runbook.md`); CPU still
   serves decode and short prompts, DirectML serves long-prompt prefill and
   diffusion.
-- Phases 1–9 (delivery, console validation, demo, training pillar,
-  personalization ops) are complete; Phase 10 (Lane B on-device training) has
-  passed both marker gates — `DeviceGgmlPartialFt` is `available` — with only
-  the pin-blocked filter-widening left. Phase 11 (headless ↔ UI gap) is next.
+- Phases 1–11 are complete for product code: Phase 10 Lane B is `available`
+  (host + console marker gates PASS; pin-blocked filter-widening remains);
+  Phase 11 closed the headless↔UI gap (in-app personalize + LAN API parity,
+  #116/#118). Remaining open work is console re-measurement, optional threads-6
+  ship, #130 mechanism profile, and upstream vendor pin drops.
 
 ## Phase 7 — Peer-class model research
 
@@ -88,7 +89,7 @@ pin constraints: [`docs/training-architecture.md`](docs/training-architecture.md
       write, or on us carrying a patch. Not actionable as it stands; listed so
       the gap is visible, not as work anyone can pick up.
 
-## Phase 11 — Close the headless ↔ UI gap (planned; Phase 10 gates now PASS, unblocked)
+## Phase 11 — Close the headless ↔ UI gap ✅ complete (code; console re-validate optional)
 
 Gap analysis 2026-07-20: the training loop is half-invisible (UI captures
 preferences, but launch/progress/serving of the fine-tuned model are

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,22 +2,41 @@
 
 Technical notes and design decisions for xllama.
 
+## Documentation principles
+
+1. **One fact, one home (SSOT).** Every current fact has a single authoritative
+   document. Other pages may explain a decision or quote a headline, but must
+   **link** instead of maintaining a second table.
+2. **Code wins over stale prose.** If a behaviour and a doc disagree, fix the
+   doc in the same PR (or immediately after). CI gates numbers where automated
+   (`generate-benchmark-summary.py --check`); narrative SSOT is human-owned.
+3. **User vs operator vs engineer.** End-user steps live in `using-the-app.md` /
+   `install-release.md`. Operator console harnesses live in runbooks. Structure
+   and contracts live in `architecture.md` + domain SSOTs.
+4. **Generated artefacts are not hand-edited.** Benchmark tables/charts come
+   from raw evidence + policy; do not reflow them by hand.
+5. **English only** for docs, code comments, and commit messages (project
+   convention).
+
 ## Documentation ownership
 
-Each current fact has one authoritative home. Other documents may explain a
-decision or quote one headline, but must link back instead of maintaining a
-second table.
-
-- **System structure** (inference + training pillars, modules, provisioning, membw) → [architecture.md](./architecture.md)
-- **Training pillar SSOT** (RE inventory, capability matrix, hybrid loop) → [training-architecture.md](./training-architecture.md)
-- **Raw performance evidence** → [`../bench/results/`](../bench/results/)
-- **Comparison policy** → [`../bench/benchmark-summary.json`](../bench/benchmark-summary.json)
-- **Generated performance summary** → [benchmarks.md](./benchmarks.md) +
-  [benchmarks-charts.html](./benchmarks-charts.html)
-- **Model catalogue + backend selection** → [model-selection.md](./model-selection.md) (narrative) + [`../uwp/models/manifest.json`](../uwp/models/manifest.json) (data)
-- **UWP/AppContainer constraints** (§1–§13) → [uwp-constraints.md](./uwp-constraints.md)
-- **Runtime NuGet pins** → [recommended-config.md](./recommended-config.md) (narrative) + [`../uwp/packages.config`](../uwp/packages.config) (data); patched-DLL lifecycle → [vendor-lifecycle-plan.md](./vendor-lifecycle-plan.md)
-- **Version / current state** → [../CHANGELOG.md](../CHANGELOG.md) + [../ROADMAP.md](../ROADMAP.md)
+| Concern | Authoritative home |
+| ------- | ------------------ |
+| System structure (modules, backends, KV, routing, provisioning, LAN, training surface) | [architecture.md](./architecture.md) |
+| Training pillar (RE, capability matrix, lanes A/B/C, hybrid loop, Phase 11 in-app arc) | [training-architecture.md](./training-architecture.md) |
+| Training ops (job JSON, host PEFT, device train CLI, pull samples) | [`../training/README.md`](../training/README.md) |
+| Raw performance evidence | [`../bench/results/`](../bench/results/) |
+| Comparison policy | [`../bench/benchmark-summary.json`](../bench/benchmark-summary.json) |
+| Generated performance summary | [benchmarks.md](./benchmarks.md) + [benchmarks-charts.html](./benchmarks-charts.html) |
+| Bench methodology / CSV schema | [`../bench/README.md`](../bench/README.md) |
+| Model catalogue + backend selection | [model-selection.md](./model-selection.md) (narrative) + [`../uwp/models/manifest.json`](../uwp/models/manifest.json) (data) |
+| UWP/AppContainer constraints (§1–§13) | [uwp-constraints.md](./uwp-constraints.md) |
+| Runtime NuGet pins | [recommended-config.md](./recommended-config.md) (narrative) + [`../uwp/packages.config`](../uwp/packages.config) (data) |
+| Patched-DLL lifecycle | [vendor-lifecycle-plan.md](./vendor-lifecycle-plan.md) |
+| LAN HTTP protocol | [api-endpoint.md](./api-endpoint.md) |
+| App gamepad UI (chat, settings, personalize, images) | [using-the-app.md](./using-the-app.md) |
+| Version / current product state | [`../CHANGELOG.md`](../CHANGELOG.md) + [`../ROADMAP.md`](../ROADMAP.md) |
+| Agent / contributor quick map | [`../AGENTS.md`](../AGENTS.md) |
 
 The benchmark flow is intentionally one-way:
 
@@ -29,27 +48,30 @@ Run `python3 scripts/generate-benchmark-summary.py` after changing evidence or
 selectors. CI runs it with `--check` and rejects drift. Research notes and dated
 reports preserve interpretation and history; they are not current metric stores.
 
-| Document                                                         | Description                                                                                                                                  |
-| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| [architecture.md](./architecture.md)                             | Dual pillars (inference + training), modules, backends, KV-reuse, routing, provisioning, membw, diffusion                                    |
-| [training-architecture.md](./training-architecture.md)           | **Training SSOT**: reverse-engineering inventory, capability matrix, lanes A/B/C, Lane B device engine, hybrid preference loop               |
-| [../training/README.md](../training/README.md)                   | Training ops: job JSON, host PEFT runner, device partial FT, stages                                                                          |
-| [install-release.md](./install-release.md)                       | Install a tagged GitHub Release build on your Xbox (cert + VCLibs + MSIX)                                                                    |
-| [using-the-app.md](./using-the-app.md)                           | App guide: chat, settings (model picker, routing, KV reuse), image generation                                                                |
-| [uwp-constraints.md](./uwp-constraints.md)                       | UWP sandbox limitations §1–§13 (GPU budget, AppContainer, training/adapters RE)                                                              |
-| [technical-report.md](./technical-report.md)                     | Historical v1.0 narrative snapshot; published as [Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76)                    |
-| [console-validation-runbook.md](./console-validation-runbook.md) | Current automated on-console gates, benchmark evidence rules and troubleshooting                                                             |
-| [fp16-extdata-runbook.md](./fp16-extdata-runbook.md)             | Current PatchedOrt external-data outcome, rebuild procedure and drop conditions                                                              |
-| [dml-metacommands-runbook.md](./dml-metacommands-runbook.md)     | #91 experiment: `ep.dml.disable_metacommands` vendored knob, on-console parity procedure and outcomes                                        |
-| [dml-rmsnorm-fix-runbook.md](./dml-rmsnorm-fix-runbook.md)       | #91 root cause and fix: broken DML `(Skip)SimplifiedLayerNormalization` kernel, RMSNorm graph surgery, escalation evidence                   |
-| [windows-dev-vm.md](./windows-dev-vm.md)                         | Windows VM setup for local UWP/MSIX builds                                                                                                   |
-| [device-portal.md](./device-portal.md)                           | How to enable Dev Mode and deploy via Device Portal                                                                                          |
-| [phase1-runbook.md](./phase1-runbook.md)                         | Legacy compatibility entrypoint routing readers to current installation, Device Portal and benchmark owners                                  |
-| [model-selection.md](./model-selection.md)                       | Choosing/adding models: hard limits, evaluation sequence, tested models, manifest override how-to + ORT-asset publishing (logit-parity gate) |
-| [api-endpoint.md](./api-endpoint.md)                             | LAN HTTP endpoint (OpenAI-compatible, opt-in, default OFF): enable, protocol, concurrency, validation                                        |
-| [benchmarks.md](./benchmarks.md)                                 | Generated current comparison plus interpretation; raw measurements remain under `bench/results/`                                             |
-| [recommended-config.md](./recommended-config.md)                 | Correct modern settings: models, genai_config, settings.json, build variants, obsolete myths                                                 |
-| [vendor-lifecycle-plan.md](./vendor-lifecycle-plan.md)           | Active patched-runtime pins, upstream dependencies, refresh procedure and removal gates                                                      |
-| [phase7-hypotheses.md](./phase7-hypotheses.md)                   | Phase 7 research log: hypotheses, gates and verdicts; current metrics come from the generated benchmark summary                              |
+## Document index
 
-See also [../CHANGELOG.md](../CHANGELOG.md) for the full pivot history (llama.cpp → ORT GenAI → CPU EP → per-workload routing) and [../diffusion/README.md](../diffusion/README.md) for the SD-Turbo model toolchain.
+| Document | Description |
+| -------- | ----------- |
+| [architecture.md](./architecture.md) | Dual pillars, modules, backends, KV-reuse, routing, provisioning, LAN, training surface, membw, diffusion |
+| [training-architecture.md](./training-architecture.md) | **Training SSOT**: RE inventory, capability matrix, lanes A/B/C, Lane B engine, hybrid loop, Phase 11 UI arc |
+| [../training/README.md](../training/README.md) | Training ops: job JSON, host PEFT, device partial FT, personalize preflight |
+| [using-the-app.md](./using-the-app.md) | App guide: chat, settings (incl. Train on my feedback), image generation, LAN API toggle |
+| [api-endpoint.md](./api-endpoint.md) | LAN HTTP endpoint: enable, protocol (chat + prefs + training status + images), concurrency, validation |
+| [install-release.md](./install-release.md) | Install a tagged GitHub Release build on Xbox (cert + VCLibs + MSIX) |
+| [uwp-constraints.md](./uwp-constraints.md) | UWP sandbox limitations §1–§13 (GPU budget, AppContainer, training/adapters RE) |
+| [technical-report.md](./technical-report.md) | Historical v1.0 narrative snapshot; [Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76) |
+| [console-validation-runbook.md](./console-validation-runbook.md) | Automated on-console gates, benchmark evidence rules, troubleshooting |
+| [fp16-extdata-runbook.md](./fp16-extdata-runbook.md) | PatchedOrt external-data outcome, rebuild procedure, drop conditions |
+| [dml-metacommands-runbook.md](./dml-metacommands-runbook.md) | #91 experiment: `ep.dml.disable_metacommands` |
+| [dml-rmsnorm-fix-runbook.md](./dml-rmsnorm-fix-runbook.md) | #91 root cause/fix: DML RMSNorm graph surgery |
+| [windows-dev-vm.md](./windows-dev-vm.md) | Windows VM setup for local UWP/MSIX builds |
+| [device-portal.md](./device-portal.md) | Dev Mode and Device Portal deploy |
+| [phase1-runbook.md](./phase1-runbook.md) | Legacy compatibility entrypoint → current owners |
+| [model-selection.md](./model-selection.md) | Choosing/adding models, manifest override, ORT asset publishing |
+| [benchmarks.md](./benchmarks.md) | Generated comparison + interpretation; raw data under `bench/results/` |
+| [recommended-config.md](./recommended-config.md) | Modern settings: models, genai_config, settings.json, build variants |
+| [vendor-lifecycle-plan.md](./vendor-lifecycle-plan.md) | Patched-runtime pins, upstream deps, removal gates |
+| [phase7-hypotheses.md](./phase7-hypotheses.md) | Phase 7 research log; metrics still come from the generated summary |
+
+See also [../CHANGELOG.md](../CHANGELOG.md) for release history and
+[../diffusion/README.md](../diffusion/README.md) for the SD-Turbo host toolchain.

--- a/docs/api-endpoint.md
+++ b/docs/api-endpoint.md
@@ -86,6 +86,53 @@ Pydantic validation), and a `usage` block from `InferenceResult` (`n_p_eval` / `
 `stream: true` is **not** implemented in v1 (always returns the full completion). The
 `GenerateParams::on_token` hook is the seam for adding SSE later.
 
+### Preferences (`POST /v1/preferences`)
+
+Same validation as the UI **rate** op. Appends one JSONL line to
+`LocalState\training\samples.jsonl`.
+
+```bash
+curl -s http://<ip-xbox>:11434/v1/preferences \
+  -H 'Content-Type: application/json' \
+  -d '{"label":"like","messages":[
+        {"role":"user","content":"hi"},
+        {"role":"assistant","content":"hello"}
+      ]}'
+# → {"ok":true,"label":"like","path":"training/samples.jsonl"}
+```
+
+`label` ∈ `like|dislike|correction|implicit`. For `correction`, optional
+`preferred_assistant` string. Invalid label or empty messages → `400`.
+
+### Training status (`GET /v1/training/status`)
+
+Read-only snapshot of on-device train progress (headless or in-app):
+
+```bash
+curl -s http://<ip-xbox>:11434/v1/training/status
+# → {"state":"idle"|"running"|"ok"|"fail","usable_samples":N, ...}
+```
+
+Optional fields: `result_done`, `progress` (object from
+`training/progress.json`), `result` (parsed
+`training/out/personalized/result.json` when present). Does **not** start a
+job — use Settings / autopilot `start_train` for that.
+
+### Images (`POST /v1/images/generations`)
+
+In-process SD-Turbo with the same clamps as the Image dialog (`steps` 1–4).
+Shares the single-slot mutex with chat → `503` when busy.
+
+```bash
+curl -s http://<ip-xbox>:11434/v1/images/generations \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt":"a red sports car on a mountain road","steps":1,"seed":42}'
+# → {"created":…,"data":[{"b64_json":"…","path":"diffuse-out.png"}]}
+```
+
+Requires `sd-turbo-fp16` provisioned (auto-download on first UI Generate still
+applies when the user opens Image; the API does not download the model for you).
+
 ## Concurrency
 
 `Session::generate()` is single-slot / non-concurrent. The server holds one shared
@@ -106,10 +153,11 @@ the active request (if any) leaves the single-slot mutex.
 
 ## Validation
 
-See `scripts/validate-api.sh` (`spike|chat|all`). Run it **from another host on the LAN**,
+See `scripts/validate-api.sh` (`spike|chat|prefs|train|all`). Run it **from another host on the LAN**,
 not from a client on the console itself — cross-device inbound needs no loopback exemption,
 but a same-host localhost client would (`CheckNetIsolation`). Spike gate first (`GET /` → 200
-proves the bind survives the Series S firewall/PLM), then a chat round-trip:
+proves the bind survives the Series S firewall/PLM), then chat / prefs / train as needed.
+Images are not in `all` (need SD-Turbo on device; use the curl example above). Chat round-trip:
 
 ```bash
 curl -s http://<ip-xbox>:11434/v1/chat/completions \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,11 +37,18 @@ Header modules (`include/xllama/`), all WinRT-free so they are host-testable:
 | `session.h` / `inference_params.h` | `Session`/`SessionParams`, `InferenceParams/Result`, `Backend` enum          |
 | `sampling.h`                       | `SamplingConfig`, shared defaults; CLI/bench and GUI/API init from it (#125) |
 | `training.h` / `training_params.h` | `TrainingJob`/`TrainingResult`, stages, device gates, job JSON               |
+| `device_train.h`                   | Lane B engine API: `run_device_train_job`, progress callbacks, filters       |
+| `personalize.h`                    | Phase 11 helpers: last-block filter, job builder, sample count, manifest JSON |
+| `preference_capture.h`             | Preference JSONL format + append (Like/Dislike/Correct + API)                |
 | `chat_prompt.h`                    | `ChatFormat`, `chat_format_for`, `apply_stop_sequences`                      |
 | `routing_policy.h`                 | `decide_routing`, `kv_reuse_supported_for_model`, prompt budget              |
 | `model_provision.h`                | `dir_satisfies_expected_files`, `normalize_model_path`                       |
 | `manifest_merge.h`                 | `merge_manifest_entries` (per-entry catalogue override)                      |
 | `membw.h`                          | `measure_membw` (STREAM-style bandwidth probe)                               |
+
+Bridge sources of note under `src/bridge/`: `session.cpp`, `inference.cpp`,
+`training.cpp`, `device_train.cpp`, `personalize.cpp`, `preference_capture.cpp`,
+`sampler_chain.h` / `ort_sampling.h` (one sampler chain per backend).
 
 ## Inference backends and runtime dispatch
 
@@ -185,15 +192,23 @@ or the headless `diffuse.flag`.
 ## LAN HTTP endpoint (OpenAI-compat)
 
 Optional, **default OFF**: a `StreamSocketListener` in `uwp/api-server.cpp`
-exposes a dedicated, lazily created `xllama::Session` as an OpenAI-compatible
-endpoint on the LAN (`POST /v1/chat/completions`, non-streaming). Settings owns
-the live start/stop/rebind lifecycle; `App::OnLaunched` restores it when the
-persistent `LocalState\api.flag` is present. The flag is not consumed and the
-server coexists with the live chat UI. Port 11434 (override `api-port.txt`);
-single-slot with a `try_lock` → HTTP 503 when busy. Capability
-`privateNetworkClientServer` (already in `AppxManifest.xml`) covers LAN inbound;
-no public inbound. Full contract + validation in
-[api-endpoint.md](api-endpoint.md) (`scripts/validate-api.sh`).
+exposes a dedicated, lazily created `xllama::Session` plus thin UI-parity routes
+on the LAN. Settings owns the live start/stop/rebind lifecycle; `App::OnLaunched`
+restores it when the persistent `LocalState\api.flag` is present. The flag is not
+consumed and the server coexists with the live chat UI. Port 11434 (override
+`api-port.txt`); chat and images share a single-slot mutex (`try_lock` → HTTP 503
+when busy). Preferences and training status are file I/O only (no inference lock).
+
+| Route | Role |
+| ----- | ---- |
+| `POST /v1/chat/completions` | Non-streaming chat (own `Session`) |
+| `POST /v1/preferences` | Append preference sample → `training/samples.jsonl` (#118) |
+| `GET /v1/training/status` | `result.done` / `progress.json` / personalized `result.json` (#118) |
+| `POST /v1/images/generations` | SD-Turbo in-process (steps 1–4), same knobs as Image dialog (#118) |
+
+Capability `privateNetworkClientServer` covers LAN inbound; no public inbound.
+Full contract + validation: [api-endpoint.md](api-endpoint.md)
+(`scripts/validate-api.sh` — `spike|chat|prefs|train|all`).
 
 ## Build variants and versioning
 
@@ -237,22 +252,39 @@ First-class subsystem for **learning adapters and producing loadable weights**.
 | **B Device partial FT** | **Available** in llamacpp/unified builds; host + console marker gates PASS |
 | **C Serve merged GGUF** | **Available**; runtime LoRA via `SessionParams.lora_path` / CLI `--lora`   |
 
-### Personalization status (Phases 8–9)
+### Personalization status (Phases 8–11)
 
-Phase 8 is frozen complete: host PEFT + merge, runtime llama.cpp LoRA and
-console preference capture are available and validated. Phase 9 adds the
-operator-driven loop that pulls `LocalState\training\samples.jsonl`, retrains on
-the host and emits a catalogue override for the resulting GGUF. Full device
-fine-tuning, ORT ODT and ORT GenAI runtime adapters remain unavailable; Phase 10
-adds only bounded last-block partial FT. The shipping UI records one
-like, dislike, or correction per completed response, while export/retrain stays
-operator-driven. See the training SSOT and ops guide below.
+| Phase | What shipped |
+| ----- | ------------ |
+| **8** | Host PEFT + merge, runtime llama.cpp LoRA, preference capture contracts |
+| **9** | Operator pull → host retrain → catalogue override; per-response Like/Dislike/Correct UI |
+| **10** | Lane B on-device `partial_ft` (ggml-opt); host + console marker gates PASS |
+| **11** | **In-app arc** (#116): Settings **Train on my feedback** runs `run_train_job_localized` (not `train.flag`), surfaces epoch/loss, publishes catalogue id `personalized`. LAN API prefs / training status / images (#118). |
+
+```
+UI Like/Correct ──► samples.jsonl ──► Settings "Train on my feedback"
+                                              │
+                    run_train_job_localized   │  (in-process Lane B)
+                                              ▼
+                    training/out/personalized/merged.gguf
+                                              │
+                    PublishPersonalizedModel  │  LocalState models\personalized\
+                                              ▼
+                    manifest override ──► model picker ──► Session (GGUF)
+```
+
+Headless `train.flag` remains the console harness path
+(`validate-console-training.sh device-train`). Full device FT and ORT ODT stay
+rejected. Details: [training-architecture.md](training-architecture.md) §11,
+[using-the-app.md](using-the-app.md).
 
 ## See also
 
 - Performance numbers → [benchmarks.md](benchmarks.md)
 - AppContainer constraints (§1–§13) → [uwp-constraints.md](uwp-constraints.md)
 - Model catalogue / selection → [model-selection.md](model-selection.md) + `uwp/models/manifest.json`
+- App UI (incl. personalize) → [using-the-app.md](using-the-app.md)
+- LAN protocol → [api-endpoint.md](api-endpoint.md)
 - v1.0 narrative snapshot → [technical-report.md](technical-report.md)
 - **Training SSOT** → [training-architecture.md](training-architecture.md)
 - Training ops → [training/README.md](../training/README.md)

--- a/docs/console-validation-runbook.md
+++ b/docs/console-validation-runbook.md
@@ -40,8 +40,9 @@ hardware gates pass:
   from the models-v1 release, which would make the gate slower and dependent on
   console-side network. The toggle's own writer is covered by the `settings`
   gate instead;
-- **API** — when included by the orchestrator, the LAN health/chat contract
-  passes through `scripts/validate-api.sh`.
+- **API** — separate LAN gate (`scripts/validate-api.sh`): `spike|chat|prefs|train|all`
+  (chat + #118 preference/training-status probes). Not wired into
+  `validate-console.sh all` today — run it from another host on the LAN.
 
 Run an individual gate while debugging:
 
@@ -50,7 +51,8 @@ Run an individual gate while debugging:
 ./scripts/validate-console.sh settings
 ./scripts/validate-console.sh gguf
 ./scripts/validate-console.sh taesd
-./scripts/validate-api.sh all
+./scripts/validate-api.sh all          # spike + chat + prefs + train
+./scripts/validate-console-training.sh rate   # preference UI path
 ```
 
 ## Benchmark evidence

--- a/docs/training-architecture.md
+++ b/docs/training-architecture.md
@@ -187,8 +187,9 @@ adds `param_filter`, `n_ctx_train`, `epochs`, `checkpoint_every`). C++:
 `load_training_job_file` / `validate_training_job`.
 
 Runners: Lane A `training/host/run_job.sh` (or `xllama-cli --train-job`);
-Lane B `xllama-cli --train-job` in-process on host, `train.flag` +
-`LocalState\training\job.json` on console (§10).
+Lane B `xllama-cli --train-job` in-process on host; on console either headless
+`train.flag` + `LocalState\training\job.json` (§10) or the in-app personalize
+path via `run_train_job_localized` (§11).
 
 ## 6. Hybrid personalization loop (operator-available)
 
@@ -334,9 +335,65 @@ paths through unchanged instead of prepending `LocalState\models\` (which
 doubled the path and failed the on-device load). Linux `resolve_model_path` is
 the identity function, so the host path is unaffected.
 
-## 11. See also
+## 11. Phase 11 — in-app personalization arc (#116)
+
+**Status: code complete** (host unit tests + UWP CI). Console end-to-end with a
+real `base-f16` + user samples remains recommended when hardware is available.
+
+Phase 10 made Lane B available only through Device Portal (`train.flag` exits
+the XAML process). Phase 11 closes the headless↔UI gap without replacing that
+harness path.
+
+### User-visible flow
+
+1. Rate replies with **Like / Correct** (dislike is stored but skipped by the
+   engine corpus builder).
+2. **Settings → Train on my feedback** (enabled when usable samples ≥ 1 and a
+   base GGUF is resolved).
+3. Status bar shows stage/epoch/loss; Cancel requests cooperative abort between
+   epochs (`DeviceTrainCallbacks::abort_flag`).
+4. On success, `merged.gguf` is copied to
+   `LocalState\models\personalized\model.gguf`, a LocalState `manifest.json`
+   override registers catalogue id **`personalized`**, and Settings selects it.
+
+### Code map
+
+| Piece | Location |
+| ----- | -------- |
+| Job builder / filter / sample count / manifest JSON | `include/xllama/personalize.h`, `src/bridge/personalize.cpp` |
+| Shared runner (localize paths, `progress.json`) | `uwp/inference-bridge.cpp` → `run_train_job_localized` |
+| Headless still uses `train.flag` | `run_train()` → same runner → `result.done` |
+| UI + publish | `MainPageController::StartPersonalizeTrain` / `PublishPersonalizedModel` |
+| Autopilot | `start_train`, `train_status` |
+| Host tests | `tests/test_personalize.cpp` |
+
+### Base model preflight
+
+Resolve order (`ResolvePersonalizeBase`):
+
+1. `LocalState\training\base-f16.gguf` (same path as the device-train harness)
+2. Current catalogue model if `kind=gguf`, provisioned, and
+   `guess_last_block_from_model_id` knows the layer count (SmolLM2 family)
+3. Any other provisioned SmolLM2 GGUF in the catalogue
+
+Last-block `param_filter` matches the pin rules (no `attn_k`/`attn_v`); see
+`last_block_param_filter` and `device_train_unsupported_reason`.
+
+### LAN surface (#118)
+
+| Method | Path | Role |
+| ------ | ---- | ---- |
+| `POST` | `/v1/preferences` | Same validation as UI rate → `samples.jsonl` |
+| `GET` | `/v1/training/status` | `result.done`, `progress.json`, personalized `result.json`, sample count |
+| `POST` | `/v1/images/generations` | SD-Turbo parity with Image dialog (not training, same API pass) |
+
+Protocol SSOT: [api-endpoint.md](api-endpoint.md).
+
+## 12. See also
 
 - [architecture.md](architecture.md) — dual pillar map
+- [using-the-app.md](using-the-app.md) — Settings personalize UI
+- [api-endpoint.md](api-endpoint.md) — LAN prefs / training status
 - [uwp-constraints.md](uwp-constraints.md) §13
 - [training/README.md](../training/README.md)
-- [ROADMAP.md](../ROADMAP.md) Phases 8–10
+- [ROADMAP.md](../ROADMAP.md) Phases 8–11

--- a/docs/using-the-app.md
+++ b/docs/using-the-app.md
@@ -39,9 +39,21 @@ once; the choice is stored with the conversation and appended to
   (`uwp/models/manifest.json`; overridable, see
   [model-selection.md](./model-selection.md)). Selecting an entry with a
   download URL fetches it on the spot; entries without one expect USB or
-  Device Portal provisioning.
+  Device Portal provisioning. After a successful on-device personalize train
+  (below), a **Personalized (from your feedback)** entry (`personalized`)
+  appears — a GGUF merged from your preference samples.
   The read-only **Runtime LoRA** line shows the selected entry's adapter and
   scale, or `none`; adapter configuration remains part of the catalogue manifest.
+- **Personalize** — status line shows how many **usable** preference samples
+  are in `LocalState\training\samples.jsonl` (Like/Correct count; Dislike is
+  stored but not used for training) and which base GGUF will be used. The
+  secondary dialog button **Train on my feedback** runs an in-process last-block
+  partial fine-tune (Lane B), shows epoch/loss on the status bar, then switches
+  the model picker to `personalized` when done. Requires a base GGUF:
+  `LocalState\training\base-f16.gguf` (operator upload, same as the device-train
+  harness) or a provisioned SmolLM2 GGUF in the catalogue. Cancel requests a
+  cooperative abort between epochs. Details:
+  [training-architecture.md §11](./training-architecture.md).
 - **Sampling** — Temperature, Top-p, Top-k, Repetition penalty, Max new tokens.
 - **KV-cache reuse** (default on) — reuses the conversation's KV cache across
   turns; measured **4.87×** on ORT and **4.07–20.02×** on GGUF models for
@@ -68,9 +80,10 @@ once; the choice is stored with the conversation and appended to
     re-derivation — see [docs/uwp-constraints.md §5d](./uwp-constraints.md).
 - **LAN API** — enables or stops the OpenAI-compatible endpoint immediately,
   without restarting the app. The port must be 1025–49151 except 11443. The
-  status line reports the active listener or bind error. The endpoint is
-  unauthenticated: enable it only on a trusted LAN; see
-  [api-endpoint.md](api-endpoint.md).
+  status line reports the active listener or bind error. Besides chat, the
+  endpoint can record preferences, report training status, and generate images
+  (same guardrails as the pad UI). It is unauthenticated: enable it only on a
+  trusted LAN; see [api-endpoint.md](api-endpoint.md).
 
 **Note for GGUF models** (`kind: "gguf"` in the catalogue): **KV-cache reuse
 works** (the llama.cpp path keeps a persistent context and appends only the new

--- a/training/README.md
+++ b/training/README.md
@@ -27,7 +27,10 @@ TrainingJob (JSON) ──► host PEFT LoRA ──► adapter ──► merge GG
 
 C++ contracts: `include/xllama/training_params.h`, `include/xllama/training.h`
 (`validate_training_job`, `load_training_job_file`, stage/device names);
-Lane B engine: `include/xllama/device_train.h` (`run_device_train_job`).
+Lane B engine: `include/xllama/device_train.h` (`run_device_train_job`);
+Phase 11 in-app helpers: `include/xllama/personalize.h` (job builder, filters,
+sample count, personalized manifest JSON — host-tested in
+`tests/test_personalize.cpp`).
 
 ## Quick start
 
@@ -88,11 +91,27 @@ bg ./build/linux-test/bin/xllama-cli --train-job training/jobs/smollm2-360m-mark
 llamacpp/unified UWP builds. The current llama.cpp pin only supports selected
 last-block Q/output/FFN/norm tensors plus output/output_norm; K/V projections,
 earlier blocks, embeddings and rope frequencies fail validation before training.
-Full `llama-finetune` and ORT ODT remain rejected. Validate the console path with:
+Full `llama-finetune` and ORT ODT remain rejected.
+
+### Console paths
+
+| Path | How | When to use |
+| ---- | --- | ----------- |
+| **In-app (Phase 11)** | Settings → **Train on my feedback** after Like/Correct samples | End-user personalize; needs base GGUF (see below) |
+| **Headless harness** | `train.flag` + `training/job.json` | CI / `validate-console-training.sh device-train` |
 
 ```bash
 ./scripts/validate-console-training.sh device-train
 ```
+
+**In-app base preflight:** place `LocalState\training\base-f16.gguf` (same ~720 MB
+f16 GGUF the harness uploads), **or** provision a SmolLM2 GGUF catalogue entry
+whose last-block index is known (`guess_last_block_from_model_id`). Samples live
+at `LocalState\training\samples.jsonl`. On success the app publishes
+`models\personalized\model.gguf` and a LocalState manifest override.
+
+Architecture: [`docs/training-architecture.md` §11](../docs/training-architecture.md).
+UI: [`docs/using-the-app.md`](../docs/using-the-app.md).
 
 **Host and console marker gates both PASS** (2026-07-20): the greedy eval prompt
 reproduces `XLLAMA-LORA-OK.` at loss ~0.47. The recipe that converges is LR


### PR DESCRIPTION
## Summary

Complete documentation pass against modern SSOT practices and post-#150 reality:

- **`docs/README.md`**: ownership principles + expanded map (one fact, one home).
- **`architecture.md`**: personalize/preference headers, LAN route table, Phase 8–11 status + flow diagram.
- **`training-architecture.md` §11**: in-app personalize code map, preflight, #118 surface.
- **`using-the-app.md`**, **`api-endpoint.md`**, **`training/README.md`**, **console runbook**: user/operator paths.
- **`README.md`**, **`ROADMAP.md`**, **`AGENTS.md`**, **`CONTRIBUTING.md`**: Phase 11 complete; contrib doc table.

No code behaviour changes.

## Test plan

- [x] Diff review only (markdown)
- [ ] Spot-check links in GitHub preview after merge