### PR TITLE
docs: dedup README and guides against SSOT ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ xllama/
 │   ├── api-server.cpp / .h  # opt-in LAN endpoint
 │   ├── chat-history.cpp / .h
 │   ├── model-downloader.cpp / .h   # catalogue download + LoadModelManifest
-│   ├── packages.config      # NuGet pins (ORT GenAI 0.14.1, ORT 1.24.4, DirectML 1.15.4)
+│   ├── packages.config      # NuGet pins (versions: packages.config; lifecycle: docs/vendor-lifecycle-plan.md)
 │   └── xllama.sln / .vcxproj
 ├── scripts/
 │   ├── deploy.sh                      # Device Portal: deploy, logs, bench trigger
@@ -126,17 +126,18 @@ the "same identity, different contents" install block. Local builds leave `.0`.
 
 ## Critical notes
 
-- **Never commit `.env`** (contains credentials). Use `.env.example` as template.
-- **Never commit `.pfx` / `.cer` certificates**. They are in `.gitignore`.
-
-- **ORT GenAI path**: UWP inference is entirely under `#ifdef XLLAMA_USE_ORT` in `src/bridge/inference.cpp`. ORT types are wrapped in `include/xllama/ort_raii.h`. Linux path (`#else`) uses llama.cpp unchanged.
-
-- **No model in the MSIX**: the package is ~19 MB and ships no model. On first launch the app downloads the default chat model (`lfm25-350m` on unified builds; `smollm2-360m-cpu-int4` on ORT-only) from the GitHub Release `models-v1` catalogue (`uwp/models/manifest.json`) into `LocalState\models\`. Routing GPU (`smollm2-360m-dml-fp16-v2`, the #91 parity-validated graph) auto-downloads from `models-v1` when GPU routing is enabled. Current console gate: `./scripts/validate-console.sh all`.
-
-- **Shipping CI**: `build-uwp.yml` publishes `xllama-appx` as **unified + PatchedGenAI #2280 + PatchedOrt** (cached `onnxruntime.dll` + `onnxruntime-genai.dll` from `vendor-dlls-v1`; hashes in `vendor/onnxruntime-patched/SHA256SUMS` and `vendor/onnxruntime-genai-patched/SHA256SUMS`). `llamacpp` lane is bench-only. Rebuild from source only for pin refresh: `build-uwp-ort-patched.yml` (ORT, 1–3 h) / `build-uwp-patched.yml` (GenAI). Poll whether pins can drop: `scripts/check-vendor-nuget-status.sh`.
-
-- **ONNX external data merge**: ORT 1.24.4 calls `std::filesystem::weakly_canonical()` for models with a separate `.onnx.data` file, which traverses path segments inaccessible inside the Xbox AppContainer (`Q:\Users\UserMgr0\...`). Fix: merge external data into a single `model.onnx` using `scripts/merge_onnx_external_data.py` before MSIX packaging. CI does this automatically.
-
-- **app-local DLLs**: `DirectML.dll`, `onnxruntime.dll`, `onnxruntime-genai.dll` must have `<DeploymentContent>true</DeploymentContent>` in the vcxproj. Without this the MSIX silently omits them and the app crashes on load.
-
-- **UWP constraints**: no POSIX mmap, no dlopen, no registry, no thread-affinity desktop API. See `docs/uwp-constraints.md` for the full list.
+- **Never commit `.env`** (credentials) or **`.pfx` / `.cer`** (gitignored).
+- **ORT path**: UWP inference under `#ifdef XLLAMA_USE_ORT` in `src/bridge/inference.cpp`;
+  RAII in `ort_raii.h`. Linux `#else` is llama.cpp.
+- **No model in the MSIX** (~19 MB): first launch downloads default chat from
+  `models-v1` (`lfm25-350m` unified / `smollm2-360m-cpu-int4` ORT-only). Console
+  gate: `./scripts/validate-console.sh all`.
+- **Shipping CI**: unified + PatchedGenAI + PatchedOrt from `vendor-dlls-v1`
+  (hashes under `vendor/*/SHA256SUMS`). Pin lifecycle SSOT:
+  `docs/vendor-lifecycle-plan.md`. Poll: `scripts/check-vendor-nuget-status.sh`.
+- **External data / AppContainer**: merge `.onnx.data` with
+  `scripts/merge_onnx_external_data.py` before packaging (CI does this). Details:
+  `docs/fp16-extdata-runbook.md`, `docs/uwp-constraints.md` §8.
+- **app-local DLLs**: `DirectML.dll`, `onnxruntime.dll`, `onnxruntime-genai.dll`
+  need `<DeploymentContent>true</DeploymentContent>` or the MSIX omits them.
+- **UWP constraints list**: `docs/uwp-constraints.md` (no mmap/dlopen/registry/…).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `using-the-app.md`, `api-endpoint.md`, `training/README.md`, root `README.md`,
   `AGENTS.md`, `ROADMAP.md`, and `CONTRIBUTING.md` reflect in-app personalize and
   LAN parity instead of “Phase 11 next”.
+- **Doc dedup pass.** Root `README.md` drops the full file tree (→ `AGENTS.md`),
+  full model/perf table (→ `model-selection` / `benchmarks`), long limitations and
+  phase list (→ `uwp-constraints` / `ROADMAP`). `docs/README.md` no longer
+  duplicates the ownership table as a second descriptive index; architecture
+  and UI guides stop restating measured speedups.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,20 @@
 
 `xllama` is a UWP application for Xbox Series S|X in Dev Mode that runs LLM chat and Stable-Diffusion image generation locally, with no cloud dependency and a gamepad-friendly UI. It also includes an opt-in, OpenAI-compatible [LAN endpoint](./docs/api-endpoint.md) and a dual-lane [training/personalization pillar](./docs/training-architecture.md): host PEFT LoRA plus an in-process partial fine-tune that runs fully on the console (ggml-opt Lane B, host + console gates PASS).
 
-The project started as a port of [`llama.cpp`](https://github.com/ggml-org/llama.cpp) (GGUF files, CPU-only), then migrated to **ONNX Runtime GenAI + DirectML**. The measured verdict is **per-workload** (see [docs/technical-report.md](./docs/technical-report.md)): the Zen 2 **CPU wins autoregressive decode** at this model scale (~66 tok/s, SmolLM2-360M int4), the RDNA 2 **GPU wins batch compute** — cold-process prefill on long prompts (3.2× at ~1.6k tokens on the shipping `-v2` asset, which buys first-turn TTFT but not multi-turn throughput; see [§5d](./docs/uwp-constraints.md)) and image generation (**11.1×** on the diffusion workload: SD-Turbo 512×512 in ~7 s). GPU **text** routing is enabled for the parity-validated `smollm2-360m-dml-fp16-v2` asset only ([#91](https://github.com/gianlucamazza/xllama/issues/91): the DML `(Skip)SimplifiedLayerNormalization` kernel computes wrong results on the Series S GPU — fixed by decomposing those nodes into primitives, a data-only graph fix; see [docs/dml-rmsnorm-fix-runbook.md](./docs/dml-rmsnorm-fix-runbook.md)); diffusion stays on the GPU. The llama.cpp path serves Linux development, CI, and — in the `unified` UWP build — modern GGUF-only models (Qwen3.5, LFM2.5); for the same model, ORT stays the text backend (measured decode parity, better prefill).
+The project started as a port of [`llama.cpp`](https://github.com/ggml-org/llama.cpp)
+(GGUF, CPU-only), then migrated to **ONNX Runtime GenAI + DirectML**. The measured
+verdict is **per-workload**: the Zen 2 **CPU wins autoregressive decode** at this
+scale; the RDNA 2 **GPU wins batch compute** (long-prompt first-turn prefill TTFT
+on the parity-validated DML text asset, and diffusion). GPU **text** routing is
+allowlisted for `smollm2-360m-dml-fp16-v2` only ([#91](https://github.com/gianlucamazza/xllama/issues/91)
+root cause and fix: [dml-rmsnorm-fix-runbook.md](./docs/dml-rmsnorm-fix-runbook.md)).
+The llama.cpp path serves Linux, CI, and modern GGUF catalogue models on
+`unified` builds. Narrative snapshot: [docs/technical-report.md](./docs/technical-report.md);
+routing analysis: [docs/uwp-constraints.md §5d](./docs/uwp-constraints.md).
 
-The default chat model on the shipping **unified** build is **LFM2.5-350M Q4_K_M** (~219 MB, ~94 tok/s), downloaded on first launch from the GitHub Release model catalogue — the MSIX itself is ~19 MB and ships no model. ORT-only builds still default to SmolLM2-360M INT4.
+Default chat on **unified** shipping: **LFM2.5-350M** (catalogue download on first
+launch; MSIX ships no model). ORT-only builds still default to SmolLM2-360M INT4.
+Throughput and RAM figures: [docs/benchmarks.md](./docs/benchmarks.md).
 
 The LAN endpoint is experimental, unauthenticated, foreground-only and disabled
 by default. Preference samples stay in the AppContainer until the operator pulls
@@ -101,18 +112,15 @@ release, [docs/using-the-app.md](./docs/using-the-app.md) for the app guide, and
 - **Accessible Dev Mode**: one-time ~$19 activation via Partner Center unlocks unsigned UWP deployment.
 - **Underexplored**: no prior LLM port to the platform at time of writing.
 
-**Measured performance (Xbox Series S):** LFM2.5-350M is the fastest chat option
-at **94.2 tok/s**; the larger LFM catalogue tiers trade throughput for quality.
-KV-cache reuse improves measured turn-2 prefill by up to **20.0×**. GPU text
-routing is live for the parity-validated `-v2` DML asset, where it accelerates
-the **first-turn time-to-first-token** on a long prompt; from the second turn the
-CPU wins at every reachable length, because DirectML cannot reuse a KV cache and
-the CPU can (full verdict and the provisional routing threshold in
-[docs/uwp-constraints.md §5d](./docs/uwp-constraints.md)). DirectML also
-serves diffusion, with SD-Turbo at about **6.9 s** for 512×512. Raw evidence,
-atomic comparison rows and the generated dashboard are described in the
-**[benchmark SSOT](./docs/benchmarks.md)** and
-[comparative charts](./docs/benchmarks-charts.html).
+**Measured performance (Xbox Series S):** LFM2.5-350M is the fastest catalogue
+chat option; larger LFM tiers trade throughput for quality. KV-cache reuse cuts
+turn-2 prefill sharply on CPU paths. GPU text routing accelerates **first-turn
+TTFT** on long prompts (parity-validated `-v2` DML asset); from turn 2 the CPU
+wins at every reachable length (DirectML has no KV reuse). DirectML also runs
+diffusion (SD-Turbo). **Numbers and rows live only in**
+[docs/benchmarks.md](./docs/benchmarks.md) (generated) and the analysis in
+[docs/uwp-constraints.md §5](./docs/uwp-constraints.md) — do not restate them
+elsewhere.
 
 ---
 
@@ -129,8 +137,8 @@ atomic comparison rows and the generated dashboard are described in the
                    ▼  CI build (GitHub Actions, windows-2022)
 ┌──────────────────────────────────────────┐
 │  Build: MSVC + Windows SDK + NuGet       │
-│  ├─ ORT GenAI 0.14.1 + ORT 1.24.4       │
-│  ├─ DirectML 1.15.4 (app-local DLLs)    │
+│  ├─ ORT GenAI + ORT + DirectML (pins)   │
+│  │  see uwp/packages.config             │
 │  └─ Output: xllama_*.msix (~19 MB,      │
 │     no model bundled)                    │
 └──────────────────┬───────────────────────┘
@@ -162,67 +170,23 @@ front-end, training/personalization, the membw micro-bench, and the diffusion pi
 
 ```
 xllama/
-├── llama.cpp/              # upstream submodule (Linux path only)
-├── include/xllama/         # shared public headers
-│   ├── inference_params.h  # InferenceParams / InferenceResult
-│   ├── inference.h         # run_inference, write_bench_csv
-│   ├── session.h           # xllama::Session API (persistent model across turns)
-│   ├── training_params.h   # TrainingJob / TrainingCapability contracts
-│   ├── training.h          # job validation, capability matrix, stage names
-│   ├── device_train.h      # Lane B in-process partial-FT engine (ggml-opt)
-│   ├── personalize.h       # Phase 11 job builder, filters, sample count, manifest JSON
-│   ├── preference_capture.h # preference JSONL (UI rate + API)
-│   ├── ort_raii.h          # RAII wrappers for OGA* types (UWP)
-│   ├── llama_raii.h        # RAII wrappers for llama_* types (Linux)
-│   ├── cli.h               # parse_cli_args (Linux)
-│   ├── platform.h          # log_output, detect_threads(_llama), peak_working_set_mb
-│   ├── path_utils.h        # resolve_model_path, first_gguf_in_dir, backend sniffing
-│   └── utf8_utils.h        # utf8 <-> wstring (Windows)
-├── src/
-│   ├── main.cpp            # Linux entry point
-│   └── bridge/             # shared implementation (Linux + UWP)
-│       ├── inference.cpp   # #ifdef XLLAMA_USE_ORT → ORT GenAI; #else → llama_decode
-│       ├── session.cpp     # xllama::Session (OrtSession + LlamaSession)
-│       ├── training.cpp    # job parsing/validation + capability table
-│       ├── device_train.cpp # Lane B engine: prepare → train → export → evaluate
-│       ├── personalize.cpp # Phase 11 pure helpers (host-testable)
-│       ├── preference_capture.cpp
-│       ├── bench.cpp
-│       ├── platform.cpp
-│       ├── path_utils.cpp
-│       ├── cli.cpp
-│       └── utf8_utils.cpp
-├── uwp/                    # C++/WinRT UWP app
-│   ├── App.cpp / App.h     # Application lifecycle, OnLaunched
-│   ├── MainPage.cpp / .h   # MainPageController — programmatic UI (XAML-free); personalize + autopilot
-│   ├── inference-bridge.cpp / .h  # UWP entry glue, bench, run_train_job_localized
-│   ├── diffuse.cpp         # SD-Turbo diffusion pipeline (plain ORT DirectML)
-│   ├── chat-history.cpp / .h      # ChatHistory: Save/Load/Delete/Clear
-│   ├── api-server.cpp / .h        # opt-in OpenAI-compatible LAN front-end (chat + prefs + train status + images)
-│   ├── model-downloader.cpp / .h  # ModelDownloader::DownloadAsync + LoadModelManifest (catalogue download)
-│   ├── models/manifest.json # model catalogue (LocalState override supported)
-│   ├── packages.config     # NuGet runtime pins (see docs/recommended-config.md)
-│   ├── ggml-uwp.vcxproj    # static ggml+llama lib (shipping GGUF backend in `unified`; sole backend in `llamacpp` variant)
-│   └── xllama.sln / .vcxproj
-├── scripts/
-│   ├── deploy.sh                      # Device Portal: deploy, logs, bench trigger
-│   ├── build-uwp.ps1                  # Windows UWP packaging
-│   ├── merge_onnx_external_data.py    # merge model.onnx.data → self-contained model.onnx
-│   ├── bench-xbox-ort.sh              # automated benchmark orchestrator
-│   ├── generate-benchmark-summary.py  # raw results → docs table + dashboard
-│   ├── install-latest-build.sh        # fetch + deploy latest CI artifact
-│   ├── test-dml-config.sh             # upload DML provider_options without MSIX rebuild
-│   ├── check-uwp-host.sh              # Linux host preflight
-│   └── setup-windows-uwp-dev.ps1      # Windows VM setup
-├── tests/                  # unit tests (doctest, incl. diffusion golden vectors)
-├── bench/                  # benchmark configs, raw results + comparison policy
-├── diffusion/              # SD-Turbo export/convert/validate toolchain (host)
-├── training/               # train jobs (host PEFT + device partial FT), datasets, ops
-├── patches/                # AppContainer/runtime patches used by UWP builds
-├── docs/                   # technical notes
-├── cmake/                  # toolchain files
-└── .github/workflows/      # CI: build-linux + build-uwp (default + llamacpp)
+├── include/xllama/   # public C++ contracts (host-testable, no WinRT)
+├── src/bridge/       # shared implementation (Linux + UWP)
+├── src/main.cpp      # Linux CLI entry
+├── uwp/              # C++/WinRT app (UI, LAN API, headless flags)
+├── training/         # jobs, host PEFT, datasets
+├── bench/            # raw results + summary policy
+├── diffusion/        # SD-Turbo host toolchain
+├── scripts/          # deploy, bench, validate, package
+├── tests/            # doctest (xllama-tests)
+├── docs/             # SSOT map: docs/README.md
+├── patches/          # AppContainer / runtime patches
+├── llama.cpp/        # submodule (GGUF path)
+└── .github/workflows/
 ```
+
+File-level map for agents/contributors: **[AGENTS.md](./AGENTS.md)**.
+Doc ownership (one fact, one home): **[docs/README.md](./docs/README.md)**.
 
 ---
 
@@ -284,90 +248,61 @@ the current developer gates.
 
 ## Models
 
-`xllama` on Xbox uses ONNX Runtime GenAI for text (model directories with `genai_config.json`, `model.onnx`, `tokenizer.json`) and plain ORT DirectML for diffusion (`text_encoder`/`unet`/`vae_decoder` components).
+Text backends: **ORT GenAI** (ONNX catalogue dirs) and **llama.cpp GGUF** on
+`unified` builds; diffusion is plain ORT DirectML. Catalogue data lives in
+`uwp/models/manifest.json` ([models-v1 Release](https://github.com/gianlucamazza/xllama/releases/tag/models-v1));
+first launch downloads the default chat model. Roles and how to add a model:
+[docs/model-selection.md](./docs/model-selection.md). Operator defaults:
+[docs/recommended-config.md](./docs/recommended-config.md). **Performance
+numbers:** [docs/benchmarks.md](./docs/benchmarks.md) only.
 
-Models come from the catalogue `uwp/models/manifest.json` (assets hosted on the [`models-v1` GitHub Release](https://github.com/gianlucamazza/xllama/releases/tag/models-v1)): the app downloads any catalogue entry on demand, with the default chat model fetched on first launch. A `LocalState\manifest.json` uploaded via Device Portal is merged per-entry into the catalogue without a reinstall — see [docs/model-selection.md](./docs/model-selection.md) for adding your own model.
+| Role | Catalogue id (headline) |
+| ---- | ----------------------- |
+| Default chat (unified) | `lfm25-350m` |
+| Balanced / quality chat | `lfm25-1.2b-instruct`, `lfm2-2.6b` |
+| ORT CPU / DML routing base | `smollm2-360m-cpu-int4`, `smollm2-360m-dml-fp16-v2` |
+| Image gen | `sd-turbo-fp16` |
+| Personalized (after on-device train) | `personalized` (LocalState override) |
 
-Catalogue overview (roles + sizes; **decode/prefill/RAM numbers live in
-[docs/benchmarks.md](./docs/benchmarks.md)**, the perf SSOT):
-
-| Model                      | Format        | Size    | Xbox UWP | Role                                                                                                 |
-| -------------------------- | ------------- | ------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| LFM2.5-350M Q4_K_M         | GGUF          | 219 MB  | ✅       | **Default chat** on unified shipping; fastest+lightest                                               |
-| LFM2.5-1.2B Q4_K_M         | GGUF          | 697 MB  | ✅       | Balanced chat: 37.9 tok/s, 811 MB peak, H9 6/8                                                       |
-| LFM2-2.6B Q4_K_M           | GGUF          | 1.46 GB | ✅       | Quality chat: 18.4 tok/s, 1623 MB peak, H9 7/8                                                       |
-| SmolLM2-360M-Instruct INT4 | ONNX GenAI    | 417 MB  | ✅       | ORT default / routing base (CPU)                                                                     |
-| SmolLM2-360M fp16 DML v2   | ONNX GenAI    | ~725 MB | ✅       | Routing target (first-turn TTFT, long prompts; §5d) — RMSNorm-decomposed graph, #91 parity-validated |
-| SmolLM2-1.7B-Instruct INT4 | ONNX GenAI    | 1.4 GB  | ✅       | Larger CPU chat (~20.6 tok/s; in-app `models-v1` download)                                           |
-| Qwen3.5-0.8B Q4_K_M        | GGUF          | 508 MB  | ✅       | `unified` builds (llama.cpp)                                                                         |
-| Gemma-3-270M Q4_K_M        | GGUF          | 253 MB  | ✅       | `unified` builds; fast, tiny                                                                         |
-| Gemma-4-E2B Q3_K_S         | GGUF          | 2.45 GB | ✅       | `unified` builds; heavy/advanced                                                                     |
-| Llama-3.2-3B Q3_K_S        | GGUF          | 1.54 GB | ✅       | `unified` builds; Phase 7 dense-3B comparator (CPU-only, advanced)                                   |
-| SD-Turbo fp16 (image)      | ONNX DirectML | 2.4 GB  | ✅       | Image gen ([diffusion/README.md](./diffusion/README.md))                                             |
-| Phi-3.5-mini CPU INT4      | ONNX GenAI    | ~2.7 GB | ❌       | Not attempted (>2 GB single-file ONNX, §8)                                                           |
-| Phi-3.5-mini Q3_K_S        | GGUF          | 1.68 GB | ⚠️       | H4 A/B measured 11.3 tok/s / 2453 MB; loses to `llama32-3b` — not catalogue                          |
-
-See [docs/uwp-constraints.md](./docs/uwp-constraints.md) for the measured GPU budget (3801 MB), the disk budget, and AppContainer workarounds.
+Hardware and AppContainer limits: [docs/uwp-constraints.md](./docs/uwp-constraints.md).
 
 ---
 
 ## Training and personalization
 
-A dual-lane training pillar lets the app adapt models **on the device**, no cloud:
+- **Lane A** — host PEFT LoRA → merged GGUF  
+- **Lane B** — on-device last-block `partial_ft` (available; host + console gates PASS)  
+- **Lane C** — serve merged GGUF / runtime LoRA  
+- **Preferences** — Like/Dislike/Correct → `training/samples.jsonl`  
+- **Phase 11 UI** — Settings → **Train on my feedback** → catalogue id `personalized`
 
-- **Host PEFT LoRA** (Lane A) — full LoRA fine-tune off-device, merged to GGUF.
-- **On-device partial fine-tune** (Lane B) — in-process ggml-opt last-block
-  `partial_ft` on the Xbox. **Available**: host + console marker gates PASS
-  (Series S: peak working set 1195 MB; marker reproduced end-to-end).
-- **Serve merged GGUF** (Lane C) — load the fine-tuned model through the normal
-  inference path, plus runtime LoRA.
-- **Preference capture** — Like/Dislike/Correct → `training/samples.jsonl`.
-- **In-app personalize (Phase 11)** — Settings → **Train on my feedback** runs
-  Lane B without leaving the UI, surfaces progress, and registers catalogue id
-  `personalized` for the model picker. Needs a base GGUF
-  (`training/base-f16.gguf` or a provisioned SmolLM2 GGUF).
-
-SSOT: [docs/training-architecture.md](./docs/training-architecture.md)
+Contracts and RE matrix: [docs/training-architecture.md](./docs/training-architecture.md)
 (§11 for the UI arc). Ops: [training/README.md](./training/README.md).
-App guide: [docs/using-the-app.md](./docs/using-the-app.md).
+Pad steps: [docs/using-the-app.md](./docs/using-the-app.md).
 
 ---
 
 ## Limitations
 
-- **File-size ceiling, not GPU memory**: the measured per-process GPU budget is **3801 MB** (package designated Game), and the Dev Mode disk allocation is raised to **90 GB** via Dev Home — what caps model choice now is the **2 GB ONNX protobuf / per-file limit** (self-contained `model.onnx` must stay under it; see [docs/uwp-constraints.md](./docs/uwp-constraints.md) §8–§9).
-- **DirectML vs XAML (`887A0036`)**: vanilla NuGet ORT GenAI DML conflicts with the XAML compositor's D3D12 device. Fix [#2280](https://github.com/microsoft/onnxruntime-genai/pull/2280) is **merged on Microsoft `main`** but **not** in NuGet **0.14.1** — shipping MSIX overlays a pinned patched `onnxruntime-genai.dll` from [`vendor-dlls-v1`](https://github.com/gianlucamazza/xllama/releases/tag/vendor-dlls-v1). Image generation uses plain ORT DML and runs **in-process**. Headless `bench.flag` remains for automation.
-- **Sandboxed filesystem**: models are downloaded to `LocalState` or transferred via Device Portal / USB. No arbitrary path access.
-- **AppContainer path traversal / large external data**: ORT 1.24.4 `weakly_canonical()` + large `ReadFile` chunks break models with external `.onnx.data` in the AppContainer. Shipping MSIX includes a **patched `onnxruntime.dll`** (same `vendor-dlls-v1` pin: path guard + 16 MB ReadFile chunks). Prefer merging external data under the 2 GB protobuf ceiling (`scripts/merge_onnx_external_data.py`); Fix B covers un-mergeable >2 GB files. See [docs/fp16-extdata-runbook.md](./docs/fp16-extdata-runbook.md) and [docs/uwp-constraints.md](./docs/uwp-constraints.md) §8.
-- **No POSIX mmap / no `dlopen`**: NuGet-packaged ORT GenAI DLLs must be app-local (`DeploymentContent=true`); no system-wide DLL loading.
-- **Dev Mode only**: no path to retail-mode consoles.
+Headlines only — full constraints SSOT is
+[docs/uwp-constraints.md](./docs/uwp-constraints.md):
 
-For full details see [docs/uwp-constraints.md](./docs/uwp-constraints.md).
+- **2 GB ONNX per-file / protobuf ceiling** (not the GPU budget alone) caps large
+  self-contained graphs; see §8–§9.
+- **Patched runtime DLLs** while NuGet lacks GenAI #2280 and ORT AppContainer
+  fixes — lifecycle in [docs/vendor-lifecycle-plan.md](./docs/vendor-lifecycle-plan.md).
+- **AppContainer** filesystem (LocalState / USB / Device Portal); no arbitrary
+  paths, no POSIX mmap / `dlopen`.
+- **Dev Mode only** — no retail-console path.
 
 ---
 
 ## Roadmap
 
-See [ROADMAP.md](./ROADMAP.md). Headlines:
-
-1. **Phase 1 — CPU baseline** ✅ Working UWP, ORT GenAI, CI green.
-2. **Phase 2 — GPU acceleration** ✅ GPU proven; verdict per-workload (CPU decode, GPU prefill/images).
-3. **Phase 3 / 3.5 — Benchmarks + hardware ceiling** ✅ Measured matrices, routing, KV reuse, llama.cpp A/B (parity), diffusion on console.
-4. **Phase 4 — In-app model download + publication** ✅ Catalogue download, release and technical report.
-5. **Phase 5 — Post-1.0 improvements** ✅ Unified+PatchedGenAI shipping; console gates ALL PASS.
-6. **Phase 6 — Publication + polish** ✅ Patched runtimes, LFM default,
-   v1.2.0 release and [published demo](https://github.com/gianlucamazza/xllama/releases/download/v1.2.0.0/xllama-demo-v1.2.0.mp4).
-7. **Phase 7 — Model research** 🔮 peer-class model campaigns continue.
-8. **Phase 8 — Training pillar** ✅ Host PEFT, runtime LoRA, preference capture
-   and console validation are frozen complete.
-9. **Phase 9 — Personalization ops** ✅ Operator pull/retrain/publish loop
-   and per-response preference UI delivered. See [ROADMAP.md](./ROADMAP.md).
-10. **Phase 10 — Device partial FT** ✅ ggml-opt Lane B; host + console marker
-    gates PASS (Xbox Series S: peak_ws 1195 MB, marker reproduced) —
-    `DeviceGgmlPartialFt` available.
-11. **Phase 11 — Headless ↔ UI gap** ✅ In-app Train on my feedback, publish
-    `personalized` model, autopilot `start_train`/`train_status`, LAN API
-    prefs/training status/images (#116/#118). See [ROADMAP.md](./ROADMAP.md).
+Current work and open items: **[ROADMAP.md](./ROADMAP.md)**. Release history:
+[CHANGELOG.md](./CHANGELOG.md). Phases 1–11 product code is complete; remaining
+items are console re-measurement, optional config ships, #130 mechanism work,
+and upstream pin drops.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,30 +48,42 @@ Run `python3 scripts/generate-benchmark-summary.py` after changing evidence or
 selectors. CI runs it with `--check` and rejects drift. Research notes and dated
 reports preserve interpretation and history; they are not current metric stores.
 
-## Document index
+## Document index (paths only)
 
-| Document | Description |
-| -------- | ----------- |
-| [architecture.md](./architecture.md) | Dual pillars, modules, backends, KV-reuse, routing, provisioning, LAN, training surface, membw, diffusion |
-| [training-architecture.md](./training-architecture.md) | **Training SSOT**: RE inventory, capability matrix, lanes A/B/C, Lane B engine, hybrid loop, Phase 11 UI arc |
-| [../training/README.md](../training/README.md) | Training ops: job JSON, host PEFT, device partial FT, personalize preflight |
-| [using-the-app.md](./using-the-app.md) | App guide: chat, settings (incl. Train on my feedback), image generation, LAN API toggle |
-| [api-endpoint.md](./api-endpoint.md) | LAN HTTP endpoint: enable, protocol (chat + prefs + training status + images), concurrency, validation |
-| [install-release.md](./install-release.md) | Install a tagged GitHub Release build on Xbox (cert + VCLibs + MSIX) |
-| [uwp-constraints.md](./uwp-constraints.md) | UWP sandbox limitations §1–§13 (GPU budget, AppContainer, training/adapters RE) |
-| [technical-report.md](./technical-report.md) | Historical v1.0 narrative snapshot; [Discussion #76](https://github.com/gianlucamazza/xllama/discussions/76) |
-| [console-validation-runbook.md](./console-validation-runbook.md) | Automated on-console gates, benchmark evidence rules, troubleshooting |
-| [fp16-extdata-runbook.md](./fp16-extdata-runbook.md) | PatchedOrt external-data outcome, rebuild procedure, drop conditions |
-| [dml-metacommands-runbook.md](./dml-metacommands-runbook.md) | #91 experiment: `ep.dml.disable_metacommands` |
-| [dml-rmsnorm-fix-runbook.md](./dml-rmsnorm-fix-runbook.md) | #91 root cause/fix: DML RMSNorm graph surgery |
-| [windows-dev-vm.md](./windows-dev-vm.md) | Windows VM setup for local UWP/MSIX builds |
-| [device-portal.md](./device-portal.md) | Dev Mode and Device Portal deploy |
-| [phase1-runbook.md](./phase1-runbook.md) | Legacy compatibility entrypoint → current owners |
-| [model-selection.md](./model-selection.md) | Choosing/adding models, manifest override, ORT asset publishing |
-| [benchmarks.md](./benchmarks.md) | Generated comparison + interpretation; raw data under `bench/results/` |
-| [recommended-config.md](./recommended-config.md) | Modern settings: models, genai_config, settings.json, build variants |
-| [vendor-lifecycle-plan.md](./vendor-lifecycle-plan.md) | Patched-runtime pins, upstream deps, removal gates |
-| [phase7-hypotheses.md](./phase7-hypotheses.md) | Phase 7 research log; metrics still come from the generated summary |
+The ownership table above is the SSOT for *where facts live*. Below is only a
+path checklist for discovery — descriptions are not repeated.
 
-See also [../CHANGELOG.md](../CHANGELOG.md) for release history and
-[../diffusion/README.md](../diffusion/README.md) for the SD-Turbo host toolchain.
+**Structure / product:** [architecture.md](./architecture.md) ·
+[training-architecture.md](./training-architecture.md) ·
+[using-the-app.md](./using-the-app.md) · [api-endpoint.md](./api-endpoint.md) ·
+[model-selection.md](./model-selection.md) ·
+[recommended-config.md](./recommended-config.md)
+
+**Constraints / vendor:** [uwp-constraints.md](./uwp-constraints.md) ·
+[vendor-lifecycle-plan.md](./vendor-lifecycle-plan.md) ·
+[fp16-extdata-runbook.md](./fp16-extdata-runbook.md) ·
+[dml-rmsnorm-fix-runbook.md](./dml-rmsnorm-fix-runbook.md) ·
+[dml-metacommands-runbook.md](./dml-metacommands-runbook.md)
+
+**Ops / install:** [install-release.md](./install-release.md) ·
+[device-portal.md](./device-portal.md) · [windows-dev-vm.md](./windows-dev-vm.md) ·
+[console-validation-runbook.md](./console-validation-runbook.md) ·
+[../training/README.md](../training/README.md) ·
+[../bench/README.md](../bench/README.md)
+
+**Evidence / history:** [benchmarks.md](./benchmarks.md) ·
+[phase7-hypotheses.md](./phase7-hypotheses.md) ·
+[technical-report.md](./technical-report.md) (frozen v1.0) ·
+[phase1-runbook.md](./phase1-runbook.md) (compat redirect) ·
+[../CHANGELOG.md](../CHANGELOG.md) · [../ROADMAP.md](../ROADMAP.md) ·
+[../diffusion/README.md](../diffusion/README.md)
+
+### Acceptable headline vs SSOT
+
+| Kind of content | Allowed outside SSOT | Forbidden |
+| --------------- | -------------------- | --------- |
+| Role / status one-liners | Yes (e.g. README “default chat is LFM2.5-350M”) | Second full catalogue or perf table |
+| Exact tok/s, MB, speedups | Only in benchmarks.md / uwp-constraints / raw CSV | Restating figures in README / UI guide |
+| NuGet version pins | packages.config + recommended-config / vendor-lifecycle | Parallel version tables |
+| Repo file tree | AGENTS.md (agents) | Full second tree in README |
+| Phase checklist | ROADMAP.md | Duplicated phase list in README |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,11 +98,11 @@ and llama.cpp decode loops.
 Multi-turn latency is cut by appending only the new turn's delta instead of
 re-prefilling the whole conversation:
 
-- **ORT GenAI** — persistent generator (turn-2 prefill **4.87×**).
+- **ORT GenAI** — persistent generator (turn-2 prefill speedup; figures in
+  [benchmarks.md](benchmarks.md)).
 - **llama.cpp** — persistent `llama_context` in `LlamaSession`; `reuse_kv` /
   `reset_kv` clear or continue the KV cache (`llama_memory_clear`, position
-  continuation). Turn-2 prefill measures **4.07×** on Gemma-3-270M and up to
-  **20.02×** on the larger LFM models (`benchmarks.md`).
+  continuation). Measured ratios by model: [benchmarks.md](benchmarks.md).
 
 Reuse is gated by `kv_reuse_supported_for_model()` (`routing_policy.h`), which
 excludes the DirectML EP (continuous decoding is CPU-only, verified — the reuse
@@ -184,10 +184,10 @@ GEMV" figure (read 12.35 GB/s @1t; `benchmarks.md`).
 A from-scratch C++ pipeline (`uwp/diffuse.cpp`, `diffusion/`): CLIP BPE tokenizer +
 Euler scheduler (header-only, golden-vector unit-tested) driving **three sequential**
 ORT DirectML sessions (text encoder → UNet → VAE decoder), created→run→destroyed per
-stage to fit the 3801 MB GPU budget. Plain ORT DirectML coexists with the XAML
-compositor in-process (unlike ORT GenAI's DML init — see `uwp-constraints.md §7`).
-Optional TAESD tiny VAE shortens the decode stage. Triggered from the Image dialog
-or the headless `diffuse.flag`.
+stage to fit the console GPU budget (`uwp-constraints.md` §5/§7). Plain ORT
+DirectML coexists with the XAML compositor in-process (unlike ORT GenAI's DML
+init — §7). Optional TAESD tiny VAE shortens the decode stage. Triggered from
+the Image dialog or the headless `diffuse.flag`.
 
 ## LAN HTTP endpoint (OpenAI-compat)
 
@@ -254,29 +254,16 @@ First-class subsystem for **learning adapters and producing loadable weights**.
 
 ### Personalization status (Phases 8–11)
 
-| Phase | What shipped |
-| ----- | ------------ |
-| **8** | Host PEFT + merge, runtime llama.cpp LoRA, preference capture contracts |
-| **9** | Operator pull → host retrain → catalogue override; per-response Like/Dislike/Correct UI |
-| **10** | Lane B on-device `partial_ft` (ggml-opt); host + console marker gates PASS |
-| **11** | **In-app arc** (#116): Settings **Train on my feedback** runs `run_train_job_localized` (not `train.flag`), surfaces epoch/loss, publishes catalogue id `personalized`. LAN API prefs / training status / images (#118). |
+| Phase | What shipped (headline only) |
+| ----- | ---------------------------- |
+| **8–9** | Host PEFT, runtime LoRA, preference UI, operator pull loop |
+| **10** | Lane B on-device `partial_ft` available (marker gates PASS) |
+| **11** | In-app train + publish `personalized`; LAN prefs/status/images |
 
-```
-UI Like/Correct ──► samples.jsonl ──► Settings "Train on my feedback"
-                                              │
-                    run_train_job_localized   │  (in-process Lane B)
-                                              ▼
-                    training/out/personalized/merged.gguf
-                                              │
-                    PublishPersonalizedModel  │  LocalState models\personalized\
-                                              ▼
-                    manifest override ──► model picker ──► Session (GGUF)
-```
-
-Headless `train.flag` remains the console harness path
-(`validate-console-training.sh device-train`). Full device FT and ORT ODT stay
-rejected. Details: [training-architecture.md](training-architecture.md) §11,
-[using-the-app.md](using-the-app.md).
+**Do not expand the Phase 11 flow here** — code map, preflight, and diagram live
+in [training-architecture.md §11](training-architecture.md). Pad steps:
+[using-the-app.md](using-the-app.md). Headless harness remains `train.flag` /
+`validate-console-training.sh device-train`.
 
 ## See also
 

--- a/docs/using-the-app.md
+++ b/docs/using-the-app.md
@@ -56,9 +56,8 @@ once; the choice is stored with the conversation and appended to
   [training-architecture.md §11](./training-architecture.md).
 - **Sampling** — Temperature, Top-p, Top-k, Repetition penalty, Max new tokens.
 - **KV-cache reuse** (default on) — reuses the conversation's KV cache across
-  turns; measured **4.87×** on ORT and **4.07–20.02×** on GGUF models for
-  turn-2 prefill on console. Leave it on
-  unless debugging.
+  turns (large turn-2 prefill win on CPU paths; measured figures in
+  [benchmarks.md](./benchmarks.md)). Leave it on unless debugging.
 - **EP routing (per conversation)** — where inference runs. Routing requires a
   parity-validated DML text asset as `gpu_model` (`dml_text_model_ok`,
   #91 postmortem: the broken DML RMSNorm kernel is worked around by the
@@ -86,11 +85,9 @@ once; the choice is stored with the conversation and appended to
   trusted LAN; see [api-endpoint.md](api-endpoint.md).
 
 **Note for GGUF models** (`kind: "gguf"` in the catalogue): **KV-cache reuse
-works** (the llama.cpp path keeps a persistent context and appends only the new
-turn's delta — measured turn-2 prefill ranges from 4.07× to 20.02× by model; see
-[benchmarks.md](benchmarks.md)).
-Only **EP routing** is disabled (greyed out): the llama.cpp UWP build is
-CPU-only, so there is no GPU model to route to.
+works** (persistent `llama_context`; measured ratios in
+[benchmarks.md](benchmarks.md)). Only **EP routing** is greyed out — the
+llama.cpp UWP build is CPU-only.
 
 Settings persist to `LocalState\settings.json` and take effect on the next
 inference call.


### PR DESCRIPTION
## Audit

| Duplication | Resolution |
| ----------- | ---------- |
| Full file tree in README **and** AGENTS | README top-level only → AGENTS for file map |
| Model table with tok/s in README | Roles + catalogue ids; numbers → benchmarks.md |
| Phase 1–11 list in README | → ROADMAP.md only |
| Long Limitations with NuGet/ORT prose | Headlines → uwp-constraints + vendor-lifecycle |
| 4.87× / 20× in using-the-app | Link benchmarks.md |
| docs/README ownership **and** descriptive index | Path checklist + “acceptable headline” table |
| Phase 11 flow in architecture **and** training SSOT | Architecture headlines; full flow in §11 |

## Test plan

- [x] Link check on README + docs/README
- [x] No residual 94.2 / 4.87 / 3801 / 1195 in README entry sections