### PR TITLE
docs: align model sizes and decode headlines to SSOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   phase list (→ `uwp-constraints` / `ROADMAP`). `docs/README.md` no longer
   duplicates the ownership table as a second descriptive index; architecture
   and UI guides stop restating measured speedups.
+- **Doc coherence pass.** Catalogue download sizes aligned to
+  `uwp/models/manifest.json` `approx_bytes` (LFM/Qwen were understating by
+  ~5–10%); ORT decode headlines aligned to generated `benchmarks.md` (68.0 /
+  20.6, not ~66 / ~21). `docs/README.md` records the check matrix.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,13 @@ source ~/.config/xllama/xbox-env           # sets XBOX_IP, XBOX_USER, XBOX_PASS
 ./scripts/deploy.sh path/to/xllama_*.msix
 ```
 
-On first launch the app **downloads** the default chat model (**LFM2.5-350M** on unified builds, ~219 MB) from the [`models-v1` GitHub Release](https://github.com/gianlucamazza/xllama/releases/tag/models-v1) with a progress bar, then starts the chat UI. No model is bundled in the MSIX. Other catalogue models (SmolLM2 CPU/GPU, Qwen3.5, Gemma, SD-Turbo) download on demand from `models-v1` or Hugging Face.
+On first launch the app **downloads** the default chat model (**LFM2.5-350M** on
+unified builds, ~229 MB catalogue download) from the
+[`models-v1` GitHub Release](https://github.com/gianlucamazza/xllama/releases/tag/models-v1)
+with a progress bar, then starts the chat UI. No model is bundled in the MSIX.
+Other catalogue models (SmolLM2 CPU/GPU, Qwen3.5, Gemma, SD-Turbo) download on
+demand from `models-v1` or Hugging Face. Download sizes:
+`uwp/models/manifest.json` (`approx_bytes`).
 
 > `install-latest-build.sh --bench` uploads `bench.flag` for a headless benchmark.
 > The default install launches the normal UI.

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,7 +83,24 @@ path checklist for discovery — descriptions are not repeated.
 | Kind of content | Allowed outside SSOT | Forbidden |
 | --------------- | -------------------- | --------- |
 | Role / status one-liners | Yes (e.g. README “default chat is LFM2.5-350M”) | Second full catalogue or perf table |
-| Exact tok/s, MB, speedups | Only in benchmarks.md / uwp-constraints / raw CSV | Restating figures in README / UI guide |
-| NuGet version pins | packages.config + recommended-config / vendor-lifecycle | Parallel version tables |
+| Exact tok/s, peak RAM, speedups | Only [benchmarks.md](./benchmarks.md) (generated) + raw `bench/results/` | Restating figures in README / UI guide without linking |
+| Download / catalogue size | Sum of `approx_bytes` in `uwp/models/manifest.json` | Invented MB that drift from the manifest |
+| Hardware ceilings (GPU budget, etc.) | [uwp-constraints.md](./uwp-constraints.md) | Parallel ceilings elsewhere |
+| NuGet version pins | `uwp/packages.config` + recommended-config / vendor-lifecycle | Parallel version tables |
 | Repo file tree | AGENTS.md (agents) | Full second tree in README |
 | Phase checklist | ROADMAP.md | Duplicated phase list in README |
+
+### Coherence check (2026-07-24)
+
+Spot-checked against code + evidence:
+
+| Fact | SSOT | Status |
+| ---- | ---- | ------ |
+| Default chat `lfm25-350m` (unified) | `MainPage.cpp` `DefaultChatModelId` | OK |
+| `token_threshold` 1550 | `routing_policy.h` | OK |
+| GPU allowlist `-v2` only | `dml_text_model_ok` | OK |
+| NuGet 0.14.1 / 1.24.4 / DML 1.15.4 | `packages.config` | OK |
+| Decode table (94.2 / 37.9 / 18.4 / 68.0 / 44.4 / …) | `generate-benchmark-summary.py --check` | OK |
+| H9 6/8 · 7/8 · 4/8 · 5/8 | `phase7-h9.jsonl` | OK |
+| Lane B peak_ws 1195 MB, wall 446 s | `phase10-console-devtrain-result.json` | OK |
+| Catalogue download sizes | `manifest.json` `approx_bytes` | Docs corrected to match (was 218/697/1.46 stale) |

--- a/docs/install-release.md
+++ b/docs/install-release.md
@@ -58,7 +58,8 @@ Notes:
 Launch xllama from Dev Home (or `./scripts/deploy.sh start-app`). The app
 downloads the default chat model with a progress bar, then opens the chat.
 On **unified** shipping builds (v1.1.8+) that default is
-**LFM2.5-350M** (~219 MB); older releases used SmolLM2-360M INT4 (~417 MB). See
+**LFM2.5-350M** (~229 MB catalogue download); older releases used SmolLM2-360M
+INT4 (~421 MB). See
 [using-the-app.md](./using-the-app.md) from here.
 
 For image generation, the SD-Turbo model (2.4 GB) is downloaded from the

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -76,7 +76,7 @@ and llama.cpp (GGUF, CPU).
 
 | Model                          | On-disk (merged) | CPU EP                               | DirectML EP                                      | Notes                                                                                                                                 |
 | ------------------------------ | ---------------- | ------------------------------------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| SmolLM2-360M-Instruct INT4 CPU | 417 MB           | ✅ ORT baseline (66.3 tok/s, 0.14.1) | ❌ `80070057` (CPU-int4 graph in DML fused node) | ORT-only default; downloaded from the `models-v1` Release catalogue                                                                   |
+| SmolLM2-360M-Instruct INT4 CPU | ~421 MB          | ✅ ORT baseline (**68.0** tok/s, `benchmarks.md`) | ❌ `80070057` (CPU-int4 graph in DML fused node) | ORT-only default; size from `manifest.json` `approx_bytes`                                                                   |
 | SmolLM2-360M-Instruct INT4 DML | 285 MB           | —                                    | ⚠️ **8.8 tok/s** but wrong logits (#91)          | Built with ORT GenAI model builder (`-p int4 -e dml`); CPU ~8× faster — and DML text output is numerically wrong on this device (#91) |
 | SmolLM2-1.7B-Instruct INT4 CPU | 1.4 GB           | ✅ in-app (`models-v1` catalogue)    | —                                                | Console: 20.6 tok/s decode, peak 2423 MB (`phase35-1b-cpu.csv`); also USB/LocalState                                                  |
 | Phi-3.5-mini Q3_K_S (GGUF)     | 1.68 GB          | ✅ H4 A/B (11.3 tok/s, 2453 MB)      | —                                                | Loses speed+RAM vs Llama-3.2-3B Q3; **not** catalogue (`phase7-scale.csv`)                                                            |
@@ -244,17 +244,17 @@ the catalogue status only.
 
 | Model            | Path      | Disk size        | Status                                                             |
 | ---------------- | --------- | ---------------- | ------------------------------------------------------------------ |
-| Qwen3.5-0.8B     | llama.cpp | 507 MB           | ✅ `qwen35-0.8b` — optional modern GGUF                            |
-| LFM2.5-350M      | llama.cpp | 218 MB           | ✅ `lfm25-350m` — hybrid edge arch; default chat on unified builds |
-| LFM2.5-1.2B      | llama.cpp | 697 MB           | ✅ `lfm25-1.2b-instruct` — balanced; 37.9 tok/s, H9 6/8            |
-| LFM2-2.6B        | llama.cpp | 1.46 GB          | ✅ `lfm2-2.6b` — quality; 18.4 tok/s, H9 7/8                       |
+| Qwen3.5-0.8B     | llama.cpp | ~533 MB          | ✅ `qwen35-0.8b` — optional modern GGUF                            |
+| LFM2.5-350M      | llama.cpp | ~229 MB          | ✅ `lfm25-350m` — hybrid edge arch; default chat on unified builds |
+| LFM2.5-1.2B      | llama.cpp | ~731 MB          | ✅ `lfm25-1.2b-instruct` — balanced; 37.9 tok/s, H9 6/8            |
+| LFM2-2.6B        | llama.cpp | ~1.56 GB         | ✅ `lfm2-2.6b` — quality; 18.4 tok/s, H9 7/8                       |
 | Qwen3-0.6B       | ORT GenAI | 969 MB merged    | ✅ builds; heavy (151k-vocab embedding dominates)                  |
 | Gemma-3-270M     | llama.cpp | 253 MB           | ✅ `gemma3-270m` — fast, tiny, fits easily                         |
 | Gemma-4-E2B      | llama.cpp | 2.45 GB (Q3_K_S) | ✅ **console-validated** `gemma4-e2b` (see verdict below)          |
 | Gemma-4 E4B/12B+ | llama.cpp | ≥4.5 GB          | ⛔ too big / too slow for the console                              |
 
 **Gemma chat template**: the ORT GenAI _builder_ is frozen at Gemma3, but the
-vendored `llama.cpp` (`9a532ae4b`) already carries `LLM_ARCH_GEMMA3` **and**
+vendored `llama.cpp` (current pin `6d5a910c5`, see `patches/README.md`) already carries `LLM_ARCH_GEMMA3` **and**
 `LLM_ARCH_GEMMA4` — both load and generate (verified via `xllama-cli`,
 `general.architecture = gemma3`/`gemma4`). What was missing was the prompt
 format: the app hard-coded ChatML. `chat_format_for()` (`src/bridge/chat_prompt.cpp`)

--- a/docs/recommended-config.md
+++ b/docs/recommended-config.md
@@ -40,9 +40,9 @@ tables are in [benchmarks.md](benchmarks.md) (the perf SSOT).
 | **Default (unified)** | `lfm25-350m`               | llama.cpp (`unified`) | **94.2 tok/s** (recommended)                                                                                           |
 | **Balanced chat**     | `lfm25-1.2b-instruct`      | llama.cpp (`unified`) | **37.9 tok/s**, 811 MB peak; H9 6/8                                                                                    |
 | **Quality chat**      | `lfm2-2.6b`                | llama.cpp (`unified`) | **18.4 tok/s**, 1623 MB peak; H9 7/8                                                                                   |
-| **ORT default**       | `smollm2-360m-cpu-int4`    | ORT CPU int4          | ~66 tok/s                                                                                                              |
+| **ORT default**       | `smollm2-360m-cpu-int4`    | ORT CPU int4          | **68.0** tok/s                                                                                                         |
 | **Routing GPU**       | `smollm2-360m-dml-fp16-v2` | ORT DML fp16          | 44.4 tok/s decode; 236.7 tok/s prefill — RMSNorm-decomposed graph, #91 parity-validated (`dml-rmsnorm-fix-runbook.md`) |
-| **Larger chat**       | `smollm2-1.7b-cpu-int4`    | ORT CPU int4          | ~21 tok/s (in-app `models-v1` download)                                                                                |
+| **Larger chat**       | `smollm2-1.7b-cpu-int4`    | ORT CPU int4          | **20.6** tok/s (in-app `models-v1` download)                                                                           |
 | **Modern GGUF**       | `qwen35-0.8b`              | llama.cpp (`unified`) | 35.1 tok/s (98.1 prefill, t6)                                                                                          |
 | **Fast modern GGUF**  | `lfm25-350m`               | llama.cpp (`unified`) | 94.2 tok/s (241.4 prefill, t6)                                                                                         |
 

--- a/docs/using-the-app.md
+++ b/docs/using-the-app.md
@@ -8,8 +8,8 @@ App guide for the gamepad UI. For installation see
 ## First launch — model download
 
 The MSIX ships no model (~19 MB). On first launch the app downloads the default
-chat model (**LFM2.5-350M** Q4_K_M, ~219 MB, on unified shipping builds; ORT-only
-builds still use SmolLM2-360M-Instruct INT4, ~417 MB) from the
+chat model (**LFM2.5-350M** Q4_K_M, ~229 MB download, on unified shipping builds;
+ORT-only builds still use SmolLM2-360M-Instruct INT4, ~421 MB) from the
 [`models-v1` GitHub Release](https://github.com/gianlucamazza/xllama/releases/tag/models-v1)
 with a progress bar, writes it to `LocalState\models\`, and opens the chat.
 The console needs internet access for this step; afterwards everything runs
@@ -65,7 +65,8 @@ once; the choice is stored with the conversation and appended to
   every mode resolves to the CPU model, it is not auto-downloaded (#95), and a
   missing `gpu_model` never blocks a turn (#100). Diffusion (plain ORT) stays
   on GPU. Semantics (subject to `gpu_available` = provisioned `gpu_model`):
-  - **CPU only (default)** — best decode throughput at 360M scale (~66 tok/s).
+  - **CPU only (default)** — best decode throughput at 360M scale (ORT int4;
+    see [benchmarks.md](./benchmarks.md)).
   - **GPU only (DML)** — prefers DirectML when `gpu_model` is provisioned (e.g.
     `smollm2-360m-dml-fp16-v2` in LocalState); if `gpu_available` is false, falls
     back to the CPU model.


### PR DESCRIPTION
## Audit

Cross-checked catalogue, code, CSV, and generated summary.

### Correct as-is
- Default chat `lfm25-350m` / ORT fallback `smollm2-360m-cpu-int4`
- `token_threshold` 1550, DML allowlist `-v2`
- NuGet pins 0.14.1 / 1.24.4 / DML 1.15.4
- Generated decode table (94.2, 37.9, 18.4, 44.4, 35.1, …)
- H9 scores, Lane B 1195 MB / 446 s, KV 4.87×

### Fixed
- Catalogue **download sizes** understating LFM/Qwen vs `manifest.json`
- ORT **~66 / ~21** → **68.0 / 20.6** (benchmarks SSOT)
- Stale llama.cpp SHA in model-selection; install-release sizes

### Left historical
- `technical-report.md` (frozen v1.0, 66.3 era)
- `phase7-hypotheses.md` campaign package sizes at research time