### PR TITLE
perf(build): make the declared ISA baseline real (Linux GGML flags + UWP CPU_REPACK)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,10 +31,18 @@ message(STATUS "xllama: building for target=linux")
 # ------------------------------------------------------------------
 # llama.cpp sub-project
 # ------------------------------------------------------------------
-set(LLAMA_NATIVE          OFF CACHE BOOL "" FORCE)
-set(LLAMA_AVX2            ON  CACHE BOOL "" FORCE)
-set(LLAMA_F16C            ON  CACHE BOOL "" FORCE)
-set(LLAMA_FMA             ON  CACHE BOOL "" FORCE)
+# ISA baseline. The old LLAMA_NATIVE/LLAMA_AVX2/... spellings are inert here:
+# llama.cpp maps deprecated vars only when truthy, and the AVX2/F16C/FMA ones
+# have no GGML_* mapping at all — set the GGML_* vars directly.
+option(XLLAMA_NATIVE_OPT "Tune ggml for the build host CPU (-march=native) instead of portable AVX2" OFF)
+if(XLLAMA_NATIVE_OPT)
+    set(GGML_NATIVE       ON  CACHE BOOL "" FORCE)
+else()
+    set(GGML_NATIVE       OFF CACHE BOOL "" FORCE)
+    set(GGML_AVX2         ON  CACHE BOOL "" FORCE)
+    set(GGML_F16C         ON  CACHE BOOL "" FORCE)
+    set(GGML_FMA          ON  CACHE BOOL "" FORCE)
+endif()
 set(LLAMA_BUILD_TESTS     OFF CACHE BOOL "" FORCE)
 set(LLAMA_BUILD_EXAMPLES  ON  CACHE BOOL "" FORCE)
 set(LLAMA_BUILD_SERVER    OFF CACHE BOOL "" FORCE)
@@ -98,7 +106,7 @@ add_executable(xllama-cli src/main.cpp)
 target_link_libraries(xllama-cli PRIVATE xllama)
 
 target_compile_options(xllama-cli PRIVATE
-    -march=znver2 -mavx2 -O3 -fno-omit-frame-pointer
+    -fno-omit-frame-pointer
 )
 
 set_target_properties(xllama-cli PROPERTIES

--- a/uwp/ggml-uwp.vcxproj
+++ b/uwp/ggml-uwp.vcxproj
@@ -6,9 +6,11 @@
        Compiled from the llama.cpp submodule sources (patched via
        scripts/apply-uwp-patches.sh — three desktop-only APIs guarded, see
        patches/README.md). No dynamic backend loading (the CPU backend is
-       registered statically via GGML_USE_CPU), no CUDA/Metal/DML — this is the
-       llama.cpp CPU A/B lane (ROADMAP Phase 3.5), built only when the app
-       project is invoked with /p:XllamaBackend=llamacpp.
+       registered statically via GGML_USE_CPU, with the repacked-weight GEMM
+       path enabled via GGML_USE_CPU_REPACK — covers Q4_0/Q4_K/Q8_0/IQ4_NL),
+       no CUDA/Metal/DML — this is the llama.cpp CPU A/B lane (ROADMAP Phase
+       3.5), built only when the app project is invoked with
+       /p:XllamaBackend=llamacpp.
        ===================================================================== -->
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -66,6 +68,7 @@
         WIN32_LEAN_AND_MEAN;
         _CRT_SECURE_NO_WARNINGS;
         GGML_USE_CPU;
+        GGML_USE_CPU_REPACK;
         GGML_STATIC;
         GGML_VERSION=&quot;uwp-static&quot;;
         GGML_COMMIT=&quot;9a532ae4b&quot;;


### PR DESCRIPTION
## What

Two verified build-flag defects, one per target:

**Linux (`CMakeLists.txt`)** — `LLAMA_NATIVE OFF` + `LLAMA_AVX2/F16C/FMA ON` were inert: llama.cpp's `llama_option_depr` maps deprecated vars only when truthy, and the three ISA ones have no `GGML_*` mapping at all. Real cache before this PR: `GGML_NATIVE=ON, GGML_AVX2/FMA/F16C=OFF` — i.e. `-march=native`, so the CI `xllama-cli-linux` artifact was pinned to the runner's CPU. Now the `GGML_*` vars are set directly; `XLLAMA_NATIVE_OPT` (default OFF) opts back into host tuning for local builds. `-march=znver2 -mavx2 -O3` is dropped from `xllama-cli` — it only covered `src/main.cpp` (not the `xllama` lib, not ggml) and contradicted the portable artifact.

**UWP (`uwp/ggml-uwp.vcxproj`)** — `repack.cpp` / `arch/x86/repack.cpp` were compiled but `GGML_USE_CPU_REPACK` was never defined, so the repacked-weight GEMM path (`ggml-cpu.cpp:64,632` guards; covers Q4_0/**Q4_K**/Q8_0/IQ4_NL — the shipped GGUF default is Q4_K_M) was dead code on console. Linux already had it (`GGML_CPU_REPACK=ON`). Now defined project-wide (single unconditional `ItemDefinitionGroup`, covers Debug and Release).

## How verified

- Fresh `cmake --preset linux-test` configure: cache now reads `GGML_NATIVE=OFF, GGML_AVX2=ON, GGML_F16C=ON, GGML_FMA=ON` (was `NATIVE=ON`, rest `OFF`).
- Full `linux-test` build + `ctest` running locally; CI runs the same suite on this PR.
- UWP compile is exercised by `build-uwp.yml` on this PR (llamacpp lane); a console before/after GGUF bench (`bench-xbox-ort.sh`, 3 runs with `run_index`) is planned as the Fase D validation window before any perf claim lands in docs.

No doc updates needed: no `.md` references `znver2`, `LLAMA_AVX2`, `LLAMA_NATIVE` or `CPU_REPACK` (grepped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to choose between host-optimized and portable CPU builds.
  * Enabled optimized CPU weight processing for UWP CPU-only builds.

* **Bug Fixes**
  * Improved build portability by removing architecture-specific compiler flags from the command-line build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->