### PR TITLE
perf: remove per-token hot-loop overhead (stdout echo, string alloc, UNet reconversion)

### DIFF
--- a/include/xllama/inference_params.h
+++ b/include/xllama/inference_params.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <functional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace xllama {
@@ -100,9 +101,14 @@ struct InferenceParams {
     std::string train_job_path;
 
     // UI callbacks (optional). Called from the inference thread — must marshal
-    // to the UI thread before touching XAML controls.
+    // to the UI thread before touching XAML controls. on_token receives a view
+    // into a per-iteration buffer: copy it before the callback returns.
     std::function<void(const std::string&)> on_status; // e.g. "loading model"
-    std::function<void(const std::string&)> on_token;  // per-token text piece
+    std::function<void(std::string_view)> on_token;    // per-token text piece
+
+    // Stream generated pieces to stdout (interactive CLI). Off by default so
+    // the UWP unified build's bench path pays no per-token write+flush.
+    bool echo_stdout = false;
 
     // Set to true from the UI thread to request early termination.
     std::atomic<bool>* abort_flag = nullptr;

--- a/include/xllama/session.h
+++ b/include/xllama/session.h
@@ -11,6 +11,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace xllama {
@@ -77,7 +78,9 @@ struct GenerateParams {
     bool reuse_kv = false;
     bool reset_kv = false;
 
-    std::function<void(const std::string&)> on_token;
+    // on_token receives a view into a per-iteration buffer: copy it before
+    // the callback returns.
+    std::function<void(std::string_view)> on_token;
     std::function<void(const std::string&)> on_status;
     std::atomic<bool>* abort_flag = nullptr;
 };

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -349,7 +349,7 @@ InferenceResult run_inference_ort(const InferenceParams& params) {
                 if (piece && *piece) {
                     res.output_text += piece;
                     if (params.on_token)
-                        params.on_token(std::string(piece));
+                        params.on_token(std::string_view(piece));
                 }
             }
             ++n_generated;
@@ -595,9 +595,11 @@ InferenceResult run_inference_llama(const InferenceParams& params) {
             buf[len] = '\0';
             res.output_text += buf;
             if (params.on_token)
-                params.on_token(std::string(buf, static_cast<size_t>(len)));
-            std::fputs(buf, stdout);
-            std::fflush(stdout);
+                params.on_token(std::string_view(buf, static_cast<size_t>(len)));
+            if (params.echo_stdout) {
+                std::fputs(buf, stdout);
+                std::fflush(stdout);
+            }
         }
 
         // Stop strings (e.g. Gemma's <end_of_turn>, not an EOG token in every
@@ -619,7 +621,8 @@ InferenceResult run_inference_llama(const InferenceParams& params) {
         ++n_generated;
     }
 
-    std::fputc('\n', stdout);
+    if (params.echo_stdout)
+        std::fputc('\n', stdout);
 
     const double gen_ms =
         std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_gen0)

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -156,7 +156,7 @@ class OrtSession final : public Session {
                 if (piece && *piece) {
                     res.output_text += piece;
                     if (gp.on_token)
-                        gp.on_token(std::string(piece));
+                        gp.on_token(std::string_view(piece));
                 }
             }
             ++n_generated;
@@ -508,7 +508,7 @@ class LlamaSession final : public Session {
                 buf[len] = '\0';
                 res.output_text += buf;
                 if (gp.on_token)
-                    gp.on_token(std::string(buf, static_cast<size_t>(len)));
+                    gp.on_token(std::string_view(buf, static_cast<size_t>(len)));
             }
 
             // Stop sequences (shared suffix-match helper).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@
 
 int main(int argc, char** argv) {
     xllama::InferenceParams params;
+    params.echo_stdout = true; // interactive CLI streams pieces as they decode
     if (!xllama::parse_cli_args(argc, argv, params))
         return 1;
 

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -2600,7 +2600,7 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
                                     [self, ws, k]() { self->SetStatus(ws, k); });
             };
             // Token accumulation — no per-token RunAsync dispatch (batched by flush timer)
-            auto on_token = [self](const std::string& tok) {
+            auto on_token = [self](std::string_view tok) {
                 // Stamp prefill-end on the first token — the only place that
                 // knows when the model stopped reading and started writing.
                 // This runs on the inference thread; FlushTokenBuffer reads the

--- a/uwp/diffuse.cpp
+++ b/uwp/diffuse.cpp
@@ -97,18 +97,26 @@ Ort::MemoryInfo cpu_mem() {
     return Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
 }
 
-// Read a run output (index 0) into a float vector, converting from fp16 or fp32.
-std::vector<float> read_output_f32(Ort::Value& v) {
+// Read a run output into the caller's float buffer (reused across UNet steps),
+// converting from fp16 or fp32.
+void read_output_f32_into(Ort::Value& v, std::vector<float>& out) {
     auto info = v.GetTensorTypeAndShapeInfo();
     const size_t n = info.GetElementCount();
-    std::vector<float> out(n);
+    out.resize(n);
     if (info.GetElementType() == ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16) {
         const auto* p = reinterpret_cast<const uint16_t*>(v.GetTensorData<Ort::Float16_t>());
-        out = from_half(p, n);
+        for (size_t i = 0; i < n; ++i)
+            out[i] = diffusion::half_to_float(p[i]);
     } else {
         const float* p = v.GetTensorData<float>();
         std::copy(p, p + n, out.begin());
     }
+}
+
+// Read a run output (index 0) into a float vector, converting from fp16 or fp32.
+std::vector<float> read_output_f32(Ort::Value& v) {
+    std::vector<float> out;
+    read_output_f32_into(v, out);
     return out;
 }
 
@@ -316,6 +324,15 @@ void run_diffuse() {
                        std::to_string(hidden_dim) + ", ts rank " + std::to_string(ts_rank) +
                        ", te+unet load " + std::to_string((int)ms_since(t_load0)) + " ms\n");
 
+            // encoder_hidden_states is constant across steps: convert to fp16
+            // once; each step only wraps these buffers in a zero-copy tensor.
+            std::vector<uint16_t> hs_f16;
+            if (unet_fp16)
+                hs_f16 = to_half(hidden);
+            std::vector<float> scaled;        // reused across steps
+            std::vector<uint16_t> scaled_f16; // reused when unet_fp16
+            std::vector<float> noise;         // reused across steps
+
             for (size_t s = 0; s < sched.timesteps().size(); ++s) {
                 const std::string step_label =
                     std::to_string(s + 1) + "/" + std::to_string(sched.timesteps().size());
@@ -326,12 +343,27 @@ void run_diffuse() {
                 }
                 write_progress("unet " + step_label);
                 // scale_model_input on a copy (UNet sees the scaled latent).
-                std::vector<float> scaled = latent;
+                scaled = latent;
                 sched.scale_model_input(scaled);
-                FloatInput u_sample = make_float_input(mem, std::move(scaled), s_shape.data(),
-                                                       s_shape.size(), unet_fp16);
-                FloatInput u_hs =
-                    make_float_input(mem, hidden, h_shape.data(), h_shape.size(), unet_fp16);
+                Ort::Value u_sample{nullptr};
+                if (unet_fp16) {
+                    scaled_f16.resize(scaled.size());
+                    for (size_t i = 0; i < scaled.size(); ++i)
+                        scaled_f16[i] = diffusion::float_to_half(scaled[i]);
+                    u_sample = Ort::Value::CreateTensor(
+                        mem, scaled_f16.data(), scaled_f16.size() * sizeof(uint16_t),
+                        s_shape.data(), s_shape.size(), ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16);
+                } else {
+                    u_sample = Ort::Value::CreateTensor<float>(mem, scaled.data(), scaled.size(),
+                                                               s_shape.data(), s_shape.size());
+                }
+                Ort::Value u_hs =
+                    unet_fp16 ? Ort::Value::CreateTensor(mem, hs_f16.data(),
+                                                         hs_f16.size() * sizeof(uint16_t),
+                                                         h_shape.data(), h_shape.size(),
+                                                         ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16)
+                              : Ort::Value::CreateTensor<float>(mem, hidden.data(), hidden.size(),
+                                                                h_shape.data(), h_shape.size());
                 const double ts_val = sched.timesteps()[s];
                 int64_t ts_i64 = (int64_t)ts_val;
                 float ts_f32 = (float)ts_val;
@@ -348,15 +380,14 @@ void run_diffuse() {
                         Ort::Value::CreateTensor<int64_t>(mem, &ts_i64, 1, t_shape.data(), ts_rank);
                 }
 
-                Ort::Value u_ins[] = {std::move(u_sample.value), std::move(u_ts),
-                                      std::move(u_hs.value)};
+                Ort::Value u_ins[] = {std::move(u_sample), std::move(u_ts), std::move(u_hs)};
                 const char* u_in_names[] = {"sample", "timestep", "encoder_hidden_states"};
                 const char* u_out_names[] = {"out_sample"};
                 auto t_u0 = std::chrono::steady_clock::now();
                 auto u_out =
                     unet.Run(Ort::RunOptions{nullptr}, u_in_names, u_ins, 3, u_out_names, 1);
                 unet_ms += ms_since(t_u0);
-                std::vector<float> noise = read_output_f32(u_out[0]); // epsilon [1,4,64,64]
+                read_output_f32_into(u_out[0], noise); // epsilon [1,4,64,64]
 
                 sched.step(noise, latent); // latent <- previous sample
             }


### PR DESCRIPTION
## What

Three hot-loop cleanups from the performance audit:

1. **Per-token `fputs`+`fflush(stdout)`** in the llama.cpp decode loop (`src/bridge/inference.cpp`) ran unconditionally — also in the UWP unified build and inside bench timing. New `InferenceParams::echo_stdout` (default **off**); only the interactive CLI sets it (`src/main.cpp`), preserving CLI streaming UX byte-for-byte.
2. **`on_token` is now `std::function<void(std::string_view)>`** (`inference_params.h`, `session.h`): both backends' loops passed a freshly heap-allocated `std::string` per token. Call sites updated (`inference.cpp`, `session.cpp`, `MainPage.cpp`); the UI token buffer still copies under its mutex, so lifetime is unchanged. Any missed consumer fails to compile (no implicit `string_view`→`string` conversion in `std::function` invocation).
3. **UNet step loop (`uwp/diffuse.cpp`)**: the constant `encoder_hidden_states` (77×hidden_dim) was converted to fp16 again on every step — now converted once before the loop; `scaled`/`scaled_f16`/`noise` buffers are hoisted and reused (new `read_output_f32_into`); per-step tensors are zero-copy `CreateTensor` wrappers over those buffers. Cancel/progress file I/O stays per-step (~µs against ~1 s of UNet Run; the progress line is operator UX).

## How verified

- Full `linux-test` build + `ctest`: 100% pass (suite includes `test_sampling`, `test_session`, `test_diffusion` goldens for tokenizer/scheduler/fp16 conversion).
- `clang-format` clean.
- UWP compile exercised by `build-uwp.yml` on this PR; runtime diffusion validation on console per `docs/console-validation-runbook.md` §7 available on request (the correctness-critical diffusion logic is host-tested against goldens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)