### PR TITLE
perf(#130): warm up DirectML at session load; log per-turn prefill

### DIFF
--- a/include/xllama/routing_policy.h
+++ b/include/xllama/routing_policy.h
@@ -142,11 +142,18 @@ inline bool kv_reuse_allowed_for_kind(const std::wstring& kind) {
     return true;
 }
 
+// DirectML-routed models are identified by catalogue naming convention
+// ("-dml-" in the model id, e.g. smollm2-360m-dml-fp16-v2). Single home for
+// the substring check: KV-reuse gating and the DML load warm-up both key on it.
+inline bool model_is_dml(const std::string& active_model) {
+    return active_model.find("dml") != std::string::npos;
+}
+
 // ORT GenAI continuous decoding (KV reuse) is CPU-only today; DirectML rejects
 // AppendTokenSequences on a persistent generator ("Continuous decoding is not
 // supported on the selected device type (DirectML)").
 inline bool kv_reuse_supported_for_model(const std::string& active_model) {
-    return active_model.find("dml") == std::string::npos;
+    return !model_is_dml(active_model);
 }
 
 } // namespace xllama

--- a/include/xllama/session.h
+++ b/include/xllama/session.h
@@ -35,6 +35,12 @@ struct SessionParams {
     // not training). Scale defaults to 1.0. ORT GenAI sessions ignore this field.
     std::string lora_path;
     float lora_scale = 1.0f;
+
+    // #130: run a throwaway generate at load for DirectML models, paying the
+    // one-time per-process cost (§5e: cold→warm prefill 1.64-1.72×) inside the
+    // "loading model" phase instead of on the user's first turn. Ignored for
+    // CPU models (§5e control: 1.00×) and by the llama.cpp backend.
+    bool dml_warmup = true;
 };
 
 struct GenerateParams {

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -381,7 +381,15 @@ std::unique_ptr<Session> create_ort(const SessionParams& sp, std::string* err) {
                 OgaSequences* raw_wseqs = nullptr;
                 oga_check(OgaCreateSequences(&raw_wseqs), "OgaCreateSequences warmup");
                 OgaSequencesPtr wseqs(raw_wseqs);
-                oga_check(OgaTokenizerEncode(tok.get(), "warmup", wseqs.get()),
+                // A ~2-token warm-up left turn-1 at ~76% of the warm prefill
+                // rate (validated on-console, PR #158 build 678): a tiny
+                // prompt never exercises the long-sequence prefill GEMMs. A
+                // few hundred tokens lands in the same regime as real turns.
+                std::string wtext;
+                wtext.reserve(2048);
+                for (int i = 0; i < 256; ++i)
+                    wtext += "warmup ";
+                oga_check(OgaTokenizerEncode(tok.get(), wtext.c_str(), wseqs.get()),
                           "OgaTokenizerEncode warmup");
                 OgaGenerator* raw_wgen = nullptr;
                 oga_check(OgaCreateGenerator(model.get(), wparams.get(), &raw_wgen),
@@ -389,7 +397,12 @@ std::unique_ptr<Session> create_ort(const SessionParams& sp, std::string* err) {
                 OgaGeneratorPtr wgen(raw_wgen);
                 oga_check(OgaGenerator_AppendTokenSequences(wgen.get(), wseqs.get()),
                           "AppendTokenSequences warmup");
-                oga_check(OgaGenerator_GenerateNextToken(wgen.get()), "GenerateNextToken warmup");
+                // 3 steps: the first IS the prefill compute; only later ones
+                // run the seq=1 decode kernels (turn-1 decode stayed 17% slow
+                // with a single step — decode was never warmed).
+                for (int i = 0; i < 3; ++i)
+                    oga_check(OgaGenerator_GenerateNextToken(wgen.get()),
+                              "GenerateNextToken warmup");
                 const double w_ms = std::chrono::duration<double, std::milli>(
                                         std::chrono::steady_clock::now() - t_w0)
                                         .count();

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -9,6 +9,7 @@
 #include "xllama/inference_params.h"
 #include "xllama/path_utils.h"
 #include "xllama/platform.h"
+#include "xllama/routing_policy.h"
 
 #include <algorithm>
 #include <chrono>
@@ -288,9 +289,16 @@ class OrtSession final : public Session {
     void log_gen(const InferenceResult& res, bool chat) {
         double dt =
             (res.n_eval > 0 && res.t_eval_ms > 0) ? res.n_eval / (res.t_eval_ms / 1000.0) : 0.0;
+        // Prefill rate too: without it the per-turn TTFT (and the #130
+        // cold-vs-warm gap) cannot be reconstructed from the log.
+        double pt = (res.n_p_eval > 0 && res.t_p_eval_ms > 0)
+                        ? res.n_p_eval / (res.t_p_eval_ms / 1000.0)
+                        : 0.0;
         char log_buf[256];
-        snprintf(log_buf, sizeof(log_buf), "[xllama] session generate%s: decode=%.1f tok/s n=%d\n",
-                 chat ? " (chat)" : "", dt, res.n_eval);
+        snprintf(log_buf, sizeof(log_buf),
+                 "[xllama] session generate%s: prefill=%.1f tok/s (%d tok, %.0f ms) "
+                 "decode=%.1f tok/s n=%d\n",
+                 chat ? " (chat)" : "", pt, res.n_p_eval, res.t_p_eval_ms, dt, res.n_eval);
         log_output(log_buf);
     }
 
@@ -351,6 +359,49 @@ std::unique_ptr<Session> create_ort(const SessionParams& sp, std::string* err) {
             log_output(gpu_buf);
         }
         int n_ctx = sp.n_ctx > 0 ? sp.n_ctx : 2048;
+
+        // #130: DirectML pays a large one-time per-process cost on the first
+        // generate (§5e: cold→warm prefill 1.64-1.72×; CPU control 1.00× —
+        // suspected lazy kernel compilation). Pay it here, inside the load
+        // phase the UI already presents as such, instead of on the user's
+        // first turn. The throwaway generator uses max_length = n_ctx exactly
+        // like every real turn: the §5c valley is keyed by max_length, so
+        // warming a smaller shape could warm the wrong regime. Failure is
+        // non-fatal — the session is still usable, just cold.
+        if (sp.dml_warmup && model_is_dml(sp.model_path)) {
+            try {
+                const auto t_w0 = std::chrono::steady_clock::now();
+                OgaGeneratorParams* raw_wp = nullptr;
+                oga_check(OgaCreateGeneratorParams(model.get(), &raw_wp),
+                          "OgaCreateGeneratorParams warmup");
+                OgaGeneratorParamsPtr wparams(raw_wp);
+                oga_check(OgaGeneratorParamsSetSearchNumber(wparams.get(), "max_length",
+                                                            static_cast<double>(n_ctx)),
+                          "SetSearchNumber warmup");
+                OgaSequences* raw_wseqs = nullptr;
+                oga_check(OgaCreateSequences(&raw_wseqs), "OgaCreateSequences warmup");
+                OgaSequencesPtr wseqs(raw_wseqs);
+                oga_check(OgaTokenizerEncode(tok.get(), "warmup", wseqs.get()),
+                          "OgaTokenizerEncode warmup");
+                OgaGenerator* raw_wgen = nullptr;
+                oga_check(OgaCreateGenerator(model.get(), wparams.get(), &raw_wgen),
+                          "OgaCreateGenerator warmup");
+                OgaGeneratorPtr wgen(raw_wgen);
+                oga_check(OgaGenerator_AppendTokenSequences(wgen.get(), wseqs.get()),
+                          "AppendTokenSequences warmup");
+                oga_check(OgaGenerator_GenerateNextToken(wgen.get()), "GenerateNextToken warmup");
+                const double w_ms = std::chrono::duration<double, std::milli>(
+                                        std::chrono::steady_clock::now() - t_w0)
+                                        .count();
+                char w_buf[96];
+                snprintf(w_buf, sizeof(w_buf), "[xllama] Session: DML warm-up %.0f ms\n", w_ms);
+                log_output(w_buf);
+            } catch (const std::exception& we) {
+                log_output(("[xllama] Session: DML warm-up failed (non-fatal): " +
+                            std::string(we.what()) + "\n")
+                               .c_str());
+            }
+        }
         return std::make_unique<OrtSession>(std::move(model), std::move(tok), n_ctx);
 
     } catch (const std::exception& e) {

--- a/tests/test_routing_policy.cpp
+++ b/tests/test_routing_policy.cpp
@@ -165,3 +165,12 @@ TEST_CASE("kv reuse: dml ep disabled") {
     CHECK_FALSE(kv_reuse_supported_for_model("smollm2-360m-dml-fp16"));
     CHECK_FALSE(kv_reuse_supported_for_model("smollm2-360m-dml-fp16-v2"));
 }
+
+TEST_CASE("model_is_dml: gates the load warm-up (#130)") {
+    CHECK(model_is_dml("smollm2-360m-dml-fp16-v2"));
+    CHECK_FALSE(model_is_dml("smollm2-360m-cpu-int4"));
+    CHECK_FALSE(model_is_dml("lfm25-350m"));
+    // Single home for the substring check: must agree with KV-reuse gating.
+    CHECK(model_is_dml("smollm2-360m-dml-fp16") !=
+          kv_reuse_supported_for_model("smollm2-360m-dml-fp16"));
+}


### PR DESCRIPTION
## What

**DML load warm-up.** DirectML pays a one-time per-process cost on the first generate (§5e: cold→warm prefill 1.64–1.72×, CPU control 1.00×). New evidence gathered today on the Session/LAN-API path (build 1.4.0.675, same process, same 960-token request): turn-1 **5.90 s** vs turn-2 **1.77 s**, decode **18.2 → 23.1 tok/s** — the lazy-compilation cost hits decode kernels too. `detail::create_ort` now runs a throwaway 1-token generate for DML-routed models inside the "loading model" phase (`SessionParams::dml_warmup`, default on; non-fatal on failure). The warm-up generator uses `max_length = n_ctx` like every real turn — the §5c valley is keyed by `max_length`, so warming a smaller shape could warm the wrong regime.

**`model_is_dml()`** (`routing_policy.h`): single home for the `-dml-` naming check, now shared by `kv_reuse_supported_for_model()` and the warm-up gate; pinned by a domain test in `test_routing_policy.cpp`.

**Session `log_gen` logs prefill** (rate, tokens, ms) next to decode — previously only decode was logged, so per-turn TTFT and the #130 cold/warm gap could not be reconstructed from `xllama.log`.

## How verified

- `linux-test` build + `ctest` 100% pass (new `model_is_dml` domain test included; the warm-up body is `XLLAMA_USE_ORT`-only and compiles in `build-uwp.yml` on this PR).
- Console validation planned on this PR's MSIX: LAN-API turn-1 on `smollm2-360m-dml-fp16-v2` must log `DML warm-up N ms` at load and show turn-1 prefill ≈ warm regime (baseline captured on 675 above). Results will be posted here.

Closes the actionable half of #130; the mechanism note (compilation is per-process and affects decode too) goes to `uwp-constraints.md` §5e in the follow-up docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to run a brief warm-up generation when loading DirectML models, enabled by default.
  * DirectML warm-up can be disabled through session settings.
  * Performance logs now report both prefill and decoding token speeds.

* **Bug Fixes**
  * Improved model routing detection to apply DirectML-specific behavior consistently.
  * Warm-up failures are handled safely without preventing the session from loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->