### PR TITLE
docs: stale bench ref + pristine-config preflight (drift fixes)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,8 @@
 #
 # Usage:
 #   set -a; source .env; set +a
-#   ./scripts/deploy.sh path/to/xllama_0.1.0.0_x64.appx
-#   ./scripts/bench-xbox.sh ~/models/qwen3-1.7b-Q4_K_M.gguf
+#   ./scripts/deploy.sh path/to/xllama_X.Y.Z.R_x64.msix
+#   ./scripts/bench-xbox-ort.sh lfm25-350m --prompt bench/prompts/standard-512.txt
 
 XBOX_IP=192.168.1.42
 XBOX_USER=devuser

--- a/docs/console-validation-runbook.md
+++ b/docs/console-validation-runbook.md
@@ -62,6 +62,18 @@ Use `scripts/bench-xbox-ort.sh` and the fixed prompts described in
 atomic CSV record; never combine the best prefill, decode and RAM values from
 different runs.
 
+**Preflight — verify the on-device config is pristine.** `--threads` swaps
+`models\<name>\genai_config.json` on the device and restores it on exit, but a
+crashed or pre-restore-era sweep can leave the swap in place (observed twice: a
+t8 residue, and a t4 residue found 2026-07-25 — the shipped CPU asset sets no
+`intra_op_num_threads` at all). Before any measurement session:
+
+```bash
+./scripts/deploy.sh fetch-file "$(./scripts/deploy.sh pfn)" genai_config.json \
+    /tmp/cfg.json 'models\smollm2-360m-cpu-int4'
+grep intra_op_num_threads /tmp/cfg.json && echo "DRIFT: restore the pristine config first"
+```
+
 After adding or changing committed evidence:
 
 ```bash


### PR DESCRIPTION
## What

Two drift fixes found during today's perf session:

- **`.env.example`** referenced `scripts/bench-xbox.sh` (removed in the ORT pivot) with a host-path `.gguf` usage pattern; updated to the current `bench-xbox-ort.sh` + model-dir-name form.
- **`docs/console-validation-runbook.md`**: new preflight step — verify the on-device `genai_config.json` is pristine before measuring. Found a `t4` residue on the console today (the shipped CPU asset sets no `intra_op_num_threads`); a leftover swap silently skews every subsequent bench and app run. Includes the two-line check command.

## How verified

`check-coherence.py` OK 35/WARN 0/ERR 0; the removed-script scan across first-party docs now returns clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)