### PR TITLE
perf(uwp): manifest cache, no throwaway session load in routing, O(n) trimmer, shared max_length ladder

### DIFF
--- a/include/xllama/inference_params.h
+++ b/include/xllama/inference_params.h
@@ -5,6 +5,7 @@
 
 #include "xllama/sampling.h"
 
+#include <algorithm>
 #include <atomic>
 #include <functional>
 #include <string>
@@ -113,6 +114,23 @@ struct InferenceParams {
     // Set to true from the UI thread to request early termination.
     std::atomic<bool>* abort_flag = nullptr;
 };
+
+// #130: single home for the max_length ladder — the ROADMAP hardening item on
+// the saturation being "expressed in two files that agree by comment".
+//   override_v < 0  → saturate to n_ctx. What Session ALWAYS does (session.cpp
+//                     passes -1): on DirectML max_length is the variable that
+//                     controls prefill throughput and the interior band
+//                     ~1400..n_ctx is a measured valley (uwp-constraints §5c).
+//   override_v == 0 → derive min(n_ctx, n_prompt + n_predict). Bench default;
+//                     keeps every historical row's meaning.
+//   override_v > 0  → explicit, clamped to (n_prompt, n_ctx].
+inline int resolve_max_length(int n_ctx, int n_prompt, int n_predict, int override_v) {
+    if (override_v < 0)
+        return n_ctx;
+    if (override_v > 0)
+        return std::clamp(override_v, n_prompt + 1, n_ctx);
+    return std::min(n_ctx, n_prompt + n_predict);
+}
 
 struct InferenceResult {
     bool success = false;

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -178,17 +178,10 @@ InferenceResult run_inference_ort(const InferenceParams& params) {
         // Size max_length from the ACTUAL prompt, clamped to the context: the old
         // fixed "n_predict + 512" headroom underflowed on long prompts (a 959-tok
         // routed turn exceeded max_length 768 before generating a single token).
-        const int derived =
-            std::min(params.n_ctx, static_cast<int>(n_prompt_tok) + params.n_predict);
-        // #130: see InferenceParams::max_length_override. Default 0 keeps the
-        // derived value, so no existing bench row changes meaning.
-        const int max_len =
-            params.max_length_override < 0
-                ? params.n_ctx
-                : (params.max_length_override > 0
-                       ? std::clamp(params.max_length_override, static_cast<int>(n_prompt_tok) + 1,
-                                    params.n_ctx)
-                       : derived);
+        // #130: full ladder lives in resolve_max_length (inference_params.h),
+        // shared with Session so the two surfaces cannot drift apart.
+        const int max_len = resolve_max_length(params.n_ctx, static_cast<int>(n_prompt_tok),
+                                               params.n_predict, params.max_length_override);
         res.max_length = max_len;
         {
             char pbuf[128];

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -105,10 +105,15 @@ class OrtSession final : public Session {
                m_b_top_k == gp.top_k && m_b_rep == gp.repetition_penalty;
     }
 
-    OgaGeneratorParamsPtr make_params(const GenerateParams& gp, int max_length) {
+    OgaGeneratorParamsPtr make_params(const GenerateParams& gp) {
         OgaGeneratorParams* raw_params = nullptr;
         oga_check(OgaCreateGeneratorParams(m_model.get(), &raw_params), "OgaCreateGeneratorParams");
         OgaGeneratorParamsPtr gparams(raw_params);
+        // Session ALWAYS saturates max_length to n_ctx via the shared #130
+        // ladder (resolve_max_length, inference_params.h) — the interior band
+        // is a measured DirectML valley (§5c; table at the stateless caller).
+        // The n_predict bound is enforced by run_decode's cap instead.
+        const int max_length = resolve_max_length(m_n_ctx, 0, 0, /*override_v=*/-1);
         oga_check(OgaGeneratorParamsSetSearchNumber(gparams.get(), "max_length",
                                                     static_cast<double>(max_length)),
                   "SetSearchNumber max_length");
@@ -217,7 +222,7 @@ class OrtSession final : public Session {
         //
         // The shipping default (n_predict 256) landed at 1545 — inside the valley.
         // Mechanism still unknown; suspected shape-bucketed DML kernel selection.
-        OgaGeneratorParamsPtr gparams = make_params(gp, m_n_ctx);
+        OgaGeneratorParamsPtr gparams = make_params(gp);
         OgaGenerator* raw_gen = nullptr;
         oga_check(OgaCreateGenerator(m_model.get(), gparams.get(), &raw_gen), "OgaCreateGenerator");
         OgaGeneratorPtr gen(raw_gen);
@@ -246,7 +251,7 @@ class OrtSession final : public Session {
         const bool reuse = !gp.reset_kv && sampling_matches(gp);
         if (!reuse) {
             reset_chat_state();
-            m_chat_params = make_params(gp, m_n_ctx);
+            m_chat_params = make_params(gp);
             OgaGenerator* raw_gen = nullptr;
             oga_check(OgaCreateGenerator(m_model.get(), m_chat_params.get(), &raw_gen),
                       "OgaCreateGenerator(chat)");

--- a/tests/test_session.cpp
+++ b/tests/test_session.cpp
@@ -8,6 +8,22 @@
 #include <filesystem>
 #include <fstream>
 
+TEST_CASE("resolve_max_length: the #130 ladder has one home") {
+    using xllama::resolve_max_length;
+    // override < 0: saturate to n_ctx — what Session always requests.
+    CHECK(resolve_max_length(2048, 1289, 256, -1) == 2048);
+    CHECK(resolve_max_length(3072, 10, 96, -1) == 3072);
+    // override == 0: derive min(n_ctx, prompt + n_predict) — bench default,
+    // keeps every historical row's meaning.
+    CHECK(resolve_max_length(2048, 1289, 256, 0) == 1545); // the shipping default
+                                                           // that landed in the valley
+    CHECK(resolve_max_length(2048, 1800, 512, 0) == 2048); // clamped to context
+    // override > 0: explicit, clamped to (n_prompt, n_ctx].
+    CHECK(resolve_max_length(2048, 1289, 256, 1801) == 1801);
+    CHECK(resolve_max_length(2048, 1289, 256, 100) == 1290);  // floor: prompt+1
+    CHECK(resolve_max_length(2048, 1289, 256, 9999) == 2048); // ceiling: n_ctx
+}
+
 TEST_CASE("Session::create rejects non-existent model path") {
     xllama::SessionParams sp;
     sp.model_path = "/nonexistent/path/model.gguf";

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -2404,7 +2404,10 @@ bool MainPageController::EnsureSession(const std::string& model, std::string* er
     // (no extension), so Backend::Auto's suffix sniffing cannot classify it.
     // Optional catalogue `lora` (relative to model dir) enables runtime LoRA.
     {
-        const auto& manifest = CachedManifest();
+        // Direct load, not CachedManifest: this runs on the worker thread and
+        // the cache is UI-thread-only (no lock). Cold path anyway — a disk
+        // parse is noise next to the model load that follows.
+        auto manifest = ::xllama::LoadModelManifest();
         const auto* entry = ::xllama::FindManifestEntry(manifest, ::xllama::utf8_to_wstring(model));
         if (entry && entry->kind == L"gguf") {
             sp.backend = xllama::Backend::LlamaCpp;

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -667,23 +667,27 @@ std::string MainPageController::BuildPrompt(const std::string& user_text, int* o
             turn_starts.push_back(i);
     }
 
-    // Build prompt starting from oldest turn; drop turns if over token budget
-    auto calc_size = [&](size_t from_turn) -> int {
-        int chars = (int)m_system_prompt.size();
-        for (size_t ti = from_turn; ti < turn_starts.size(); ++ti) {
-            size_t i = turn_starts[ti];
-            chars += (int)m_current.messages[i].content.size(); // user
-            if (i + 1 < m_current.messages.size() &&
-                m_current.messages[i + 1].role == xllama::ui::MessageRole::Assistant)
-                chars += (int)m_current.messages[i + 1].content.size(); // assistant
-        }
-        chars += (int)user_text.size(); // new user message
-        return ::xllama::estimate_tokens_from_chars(static_cast<size_t>(chars));
-    };
+    // Build prompt starting from oldest turn; drop turns if over token budget.
+    // Per-turn char sizes are computed once and the running total is reduced as
+    // turns drop (the previous shape re-walked every surviving turn for each
+    // candidate — O(turns²) per prompt build).
+    std::vector<int> turn_chars(turn_starts.size(), 0);
+    long long chars =
+        static_cast<long long>(m_system_prompt.size()) + static_cast<long long>(user_text.size());
+    for (size_t ti = 0; ti < turn_starts.size(); ++ti) {
+        size_t i = turn_starts[ti];
+        int c = (int)m_current.messages[i].content.size(); // user
+        if (i + 1 < m_current.messages.size() &&
+            m_current.messages[i + 1].role == xllama::ui::MessageRole::Assistant)
+            c += (int)m_current.messages[i + 1].content.size(); // assistant
+        turn_chars[ti] = c;
+        chars += c;
+    }
 
     size_t first_turn = 0;
-    while (first_turn < turn_starts.size() && calc_size(first_turn) > kMaxEstimatedTokens)
-        ++first_turn;
+    while (first_turn < turn_starts.size() &&
+           ::xllama::estimate_tokens_from_chars(static_cast<size_t>(chars)) > kMaxEstimatedTokens)
+        chars -= turn_chars[first_turn++];
     if (first_turn > 0)
         log_output("[xllama] context trimmed: dropped " + std::to_string(first_turn) +
                    " old turn(s)\n");
@@ -708,6 +712,14 @@ std::string MainPageController::BuildPrompt(const std::string& user_text, int* o
 
 xllama::ChatFormat MainPageController::chat_format() const {
     return ::xllama::chat_format_for(::xllama::wstring_to_utf8(m_model_filename));
+}
+
+const std::vector<::xllama::ManifestEntry>& MainPageController::CachedManifest() const {
+    if (!m_manifest_cached) {
+        m_manifest_cache = ::xllama::LoadModelManifest();
+        m_manifest_cached = true;
+    }
+    return m_manifest_cache;
 }
 
 std::string MainPageController::BuildDeltaPrompt(const std::string& user_text) const {
@@ -1562,6 +1574,7 @@ bool MainPageController::PublishPersonalizedModel(const std::string& merged_gguf
     // a full JSON rewriter; the per-entry merge means a same-name replace is
     // enough, and a one-entry override still keeps all bundled models.
     write_local_bytes(L"manifest.json", override_json);
+    InvalidateManifestCache(); // catalogue changed — StartInference reads the cache
     return true;
 }
 
@@ -2391,7 +2404,7 @@ bool MainPageController::EnsureSession(const std::string& model, std::string* er
     // (no extension), so Backend::Auto's suffix sniffing cannot classify it.
     // Optional catalogue `lora` (relative to model dir) enables runtime LoRA.
     {
-        auto manifest = ::xllama::LoadModelManifest();
+        const auto& manifest = CachedManifest();
         const auto* entry = ::xllama::FindManifestEntry(manifest, ::xllama::utf8_to_wstring(model));
         if (entry && entry->kind == L"gguf") {
             sp.backend = xllama::Backend::LlamaCpp;
@@ -2479,7 +2492,9 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
     // this flag.
     bool base_is_gguf = false;
     {
-        auto manifest = ::xllama::LoadModelManifest();
+        // Cached: this runs on the UI thread on every turn, and the manifest
+        // JSON only changes on a personalized-model publish (which invalidates).
+        const auto& manifest = CachedManifest();
         const auto* e = ::xllama::FindManifestEntry(manifest, m_model_filename);
         base_is_gguf = e && e->kind == L"gguf";
     }
@@ -2497,7 +2512,14 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
 
         int n_tok = 0;
         if (m_routing == 2 && !base_is_gguf) {
-            if (EnsureSession(rs.cpu_model, nullptr))
+            // Exact count only when the CPU session is already resident (a
+            // pointer-compare no-op). The previous shape loaded the CPU model
+            // just to tokenize and then could tear it down for the DML model —
+            // +1.2 s on a GPU-routed first turn (uwp-constraints §5, 2786 ms
+            // vs 1570 ms). With no session loaded the chars/5.0 estimator
+            // decides — the same estimator whose ceiling already bounds this
+            // prompt in BuildPrompt, so routing and trimming stay coherent.
+            if (m_session && m_session_model == rs.cpu_model)
                 n_tok = m_session->count_tokens(full_prompt);
             else
                 n_tok = ::xllama::estimate_tokens_from_chars(full_prompt.size());

--- a/uwp/MainPage.h
+++ b/uwp/MainPage.h
@@ -169,6 +169,17 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     std::string m_gpu_model{"smollm2-360m-dml-fp16-v2"};
     std::wstring m_active_model;
 
+    // Model-catalogue cache: LoadModelManifest re-reads and parses JSON from
+    // disk, and StartInference needed it on the UI thread for every turn.
+    // Invalidated on catalogue mutation (personalized-model publish); slow
+    // paths that mutate keep calling LoadModelManifest directly.
+    const std::vector<::xllama::ManifestEntry>& CachedManifest() const;
+    void InvalidateManifestCache() {
+        m_manifest_cached = false;
+    }
+    mutable std::vector<::xllama::ManifestEntry> m_manifest_cache;
+    mutable bool m_manifest_cached{false};
+
     // Image generation: TAESD tiny VAE replaces the full VAE decoder in-place
     // under models\sd-turbo-fp16\vae_decoder\ (same UNet/text_encoder).
     bool m_diffuse_taesd{false};


### PR DESCRIPTION
## What

Phase C structural items, part 1 (the host-testable / low-risk half):

1. **`resolve_max_length()`** in `inference_params.h` — single home for the #130 max_length ladder (saturate / derive / explicit-clamped). `run_inference` and `OrtSession::make_params` both call it; `make_params` loses its `max_length` parameter since Session always saturates. Closes the ROADMAP hardening item ("expressed in two files that agree by comment"). Pinned by a new doctest in `test_session.cpp` including the historical 1545-in-the-valley shipping default.
2. **Manifest cache** (`MainPageController::CachedManifest`): `StartInference` parsed `manifest.json` from disk on the UI thread every turn just for `base_is_gguf`; now cached, invalidated on personalized-model publish (`PublishPersonalizedModel` — the only in-app catalogue mutation; slow paths keep calling `LoadModelManifest` directly).
3. **Auto-routing token count without a throwaway load**: the old shape called `EnsureSession(cpu_model)` purely to `count_tokens()`, and a GPU-routed first turn then destroyed that session (+1.2 s measured, `uwp-constraints` §5: 2786 ms vs 1570 ms). Exact count now only when the CPU session is already resident (pointer no-op); otherwise the `chars/5.0` estimator decides — the same estimator whose `kMaxPromptTokens` ceiling already bounds the prompt in `BuildPrompt`, so routing and trimming stay coherent. Worst case is a different-but-valid routing choice on a cold start, never a correctness issue (#133 domain tests keep the threshold reachable).
4. **O(n) trimmer**: `BuildPrompt` re-walked every surviving turn per drop candidate (O(turns²)); per-turn char sizes are computed once and subtracted as turns drop. Behaviour-identical (same estimator on the same totals).

## How verified

- `linux-test` build + `ctest` 100% pass (new `resolve_max_length` cases; `test_routing_policy` unchanged and green).
- `clang-format` clean; `check-coherence.py` OK.
- UWP compile via `build-uwp.yml` on this PR. Functional console gates (`validate-console.sh routing|settings|gguf`) recommended after merge alongside the part-2 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)