### PR TITLE
perf(uwp): single Session owner (GUI+API), session pre-load, incremental turn finalize

### DIFF
--- a/include/xllama/session_hub.h
+++ b/include/xllama/session_hub.h
@@ -22,6 +22,7 @@
 
 #include "xllama/session.h"
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -34,6 +35,13 @@ struct SessionHub {
     std::unique_ptr<Session> session; // guarded by mtx
     std::string model;                // model id loaded into `session`; guarded by mtx
     uint64_t generation = 0;          // bumps on every resident-session change; guarded by mtx
+
+    // True while a background pre-load holds (or is about to take) mtx.
+    // Lets the LAN API distinguish "warming up, wait briefly" from "another
+    // request is generating, report busy" — without it the first request
+    // right after app-Ready bounced with a 503 while the preload held the
+    // lock (observed on-console during Phase C validation).
+    std::atomic<bool> preloading{false};
 
     // Under mtx: return the resident session for |model_id|, creating it (and
     // destroying any other model's session FIRST — never 2x model in RAM) if

--- a/include/xllama/session_hub.h
+++ b/include/xllama/session_hub.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2024 Venere Labs
+// SPDX-License-Identifier: MIT
+// Single process-wide owner of the loaded model Session.
+//
+// Before this existed the GUI (MainPageController::m_session) and the LAN API
+// (api-server.cpp g_session) each owned an independent Session: both could
+// hold a model at the same time, silently breaking the "never 2x model in
+// RAM" invariant EnsureSession enforced only within the GUI. The hub is the
+// one owner; both surfaces lock it for the duration of a turn.
+//
+// Locking contract:
+//   - Take `mtx` before touching `session` / `model`, and HOLD it across
+//     ensure_locked() + generate() so a concurrent surface cannot swap the
+//     resident model mid-turn. The GUI blocks on the lock (its turns are
+//     serialized anyway); the API uses try_lock and reports busy.
+//   - `generation` increments every time the resident session changes. A
+//     surface that keeps per-conversation state tied to the live session
+//     (the GUI's KV-reuse flag) must record it and drop that state when it
+//     no longer matches — the other surface may have swapped models between
+//     turns.
+#pragma once
+
+#include "xllama/session.h"
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace xllama {
+
+struct SessionHub {
+    std::mutex mtx;
+    std::unique_ptr<Session> session; // guarded by mtx
+    std::string model;                // model id loaded into `session`; guarded by mtx
+    uint64_t generation = 0;          // bumps on every resident-session change; guarded by mtx
+
+    // Under mtx: return the resident session for |model_id|, creating it (and
+    // destroying any other model's session FIRST — never 2x model in RAM) if
+    // needed. On creation failure the hub is left empty and nullptr returns.
+    Session* ensure_locked(const std::string& model_id, const SessionParams& sp,
+                           std::string* err = nullptr) {
+        if (session && model == model_id)
+            return session.get();
+        session.reset(); // release the old model before loading the new one
+        model.clear();
+        ++generation;
+        auto s = Session::create(sp, err);
+        if (!s)
+            return nullptr;
+        session = std::move(s);
+        model = model_id;
+        ++generation;
+        return session.get();
+    }
+
+    // Under mtx: drop the resident session (e.g. to free RAM on demand).
+    void reset_locked() {
+        if (session) {
+            session.reset();
+            model.clear();
+            ++generation;
+        }
+    }
+};
+
+// The process-wide hub (defined in session.cpp).
+SessionHub& session_hub();
+
+} // namespace xllama

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -10,6 +10,7 @@
 #include "xllama/path_utils.h"
 #include "xllama/platform.h"
 #include "xllama/routing_policy.h"
+#include "xllama/session_hub.h"
 
 #include <algorithm>
 #include <chrono>
@@ -696,6 +697,11 @@ std::unique_ptr<Session> Session::create(const SessionParams& sp, std::string* e
 #else // XLLAMA_USE_LLAMA
     return detail::create_llama(sp, err);
 #endif
+}
+
+SessionHub& session_hub() {
+    static SessionHub hub;
+    return hub;
 }
 
 } // namespace xllama

--- a/tests/test_session.cpp
+++ b/tests/test_session.cpp
@@ -3,10 +3,28 @@
 
 #include "xllama/path_utils.h"
 #include "xllama/session.h"
+#include "xllama/session_hub.h"
 
 #include <doctest/doctest.h>
 #include <filesystem>
 #include <fstream>
+
+TEST_CASE("SessionHub: failed create leaves the hub empty and bumps generation") {
+    auto& hub = xllama::session_hub();
+    std::lock_guard<std::mutex> lk(hub.mtx);
+    const uint64_t g0 = hub.generation;
+    xllama::SessionParams sp;
+    sp.model_path = "/nonexistent/hub-model.gguf";
+    std::string err;
+    CHECK(hub.ensure_locked("hub-model", sp, &err) == nullptr);
+    CHECK(hub.session == nullptr);
+    CHECK(hub.model.empty());
+    // The attempted swap must invalidate any holder's generation even though
+    // creation failed — its old session pointer is gone either way.
+    CHECK(hub.generation == g0 + 1);
+    hub.reset_locked(); // no-op when already empty
+    CHECK(hub.generation == g0 + 1);
+}
 
 TEST_CASE("resolve_max_length: the #130 ladder has one home") {
     using xllama::resolve_max_length;

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -2438,11 +2438,16 @@ void MainPageController::PreloadSessionAsync() {
     auto self = shared_from_this();
     std::thread([self, model]() {
         auto& hub = ::xllama::session_hub();
-        std::lock_guard<std::mutex> hub_lk(hub.mtx);
-        std::string err;
-        if (!self->EnsureSession(model, &err))
-            ::xllama::log_output(
-                ("[xllama] session preload failed (non-fatal): " + err + "\n").c_str());
+        hub.preloading.store(true); // API waits briefly instead of 503-ing
+        try {
+            std::lock_guard<std::mutex> hub_lk(hub.mtx);
+            std::string err;
+            if (!self->EnsureSession(model, &err))
+                ::xllama::log_output(
+                    ("[xllama] session preload failed (non-fatal): " + err + "\n").c_str());
+        } catch (...) {
+        }
+        hub.preloading.store(false);
     }).detach();
 }
 

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -789,6 +789,34 @@ void MainPageController::RenderConversation() {
     m_outputScroll.ChangeView(nullptr, m_outputScroll.ScrollableHeight(), nullptr);
 }
 
+void MainPageController::FinalizeStreamedTurn(const std::string& output_text) {
+    using namespace winrt::Windows::UI::Xaml::Documents;
+    // The streamed paragraph holds the raw pieces; swap in the postprocessed
+    // text (the caller already ran postprocess_output) and attach the
+    // feedback controls. The rest of the conversation tree is untouched —
+    // the previous shape rebuilt every Paragraph/Run of the conversation
+    // after each turn, discarding what streaming had just appended.
+    if (!m_currentParagraph) {
+        RenderConversation();
+        return;
+    }
+    m_currentParagraph.Inlines().Clear();
+    Run label;
+    label.Text(L"Assistant: ");
+    label.FontWeight(winrt::Windows::UI::Text::FontWeights::Bold());
+    m_currentParagraph.Inlines().Append(label);
+    Run content;
+    content.Text(::xllama::utf8_to_wstring(output_text));
+    m_currentParagraph.Inlines().Append(content);
+    // The assistant message was just pushed onto m_current.messages.
+    AppendFeedbackControls(m_currentParagraph, m_current.messages.size() - 1);
+    m_outputBody.Blocks().Append(Paragraph()); // spacing
+    m_currentParagraph = Paragraph();
+    m_outputBody.Blocks().Append(m_currentParagraph);
+    m_outputScroll.UpdateLayout();
+    m_outputScroll.ChangeView(nullptr, m_outputScroll.ScrollableHeight(), nullptr);
+}
+
 void MainPageController::LoadConversation(const std::string& id) {
     SaveCurrentConversation();
     m_kv_valid = false;     // switching conversations → the reused KV no longer applies
@@ -1456,8 +1484,11 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
         if (new_model != self->m_model_filename) {
             self->m_model_filename = new_model;
             self->m_modelText.Text(new_model);
-            self->m_session.reset();
-            self->m_session_model.clear();
+            {
+                auto& hub = ::xllama::session_hub();
+                std::lock_guard<std::mutex> hub_lk(hub.mtx);
+                hub.reset_locked();
+            }
             self->m_kv_valid = false;
             self->m_model_ready.store(false);
             self->m_runButton.IsEnabled(false);
@@ -1617,8 +1648,11 @@ void MainPageController::StartPersonalizeTrain() {
                       ::xllama::format_train_progress_json("prepare", 0, job.epochs, 0, 0, 0));
 
     // Free chat RSS before train (Phase 10 peak gate ~1.2 GB).
-    m_session.reset();
-    m_session_model.clear();
+    {
+        auto& hub = ::xllama::session_hub();
+        std::lock_guard<std::mutex> hub_lk(hub.mtx);
+        hub.reset_locked();
+    }
     m_kv_valid = false;
 
     m_train_abort.store(false);
@@ -1672,8 +1706,11 @@ void MainPageController::StartPersonalizeTrain() {
                     self->m_model_filename =
                         ::xllama::utf8_to_wstring(::xllama::kPersonalizedModelId);
                     self->m_modelText.Text(self->m_model_filename);
-                    self->m_session.reset();
-                    self->m_session_model.clear();
+                    {
+                        auto& hub = ::xllama::session_hub();
+                        std::lock_guard<std::mutex> hub_lk(hub.mtx);
+                        hub.reset_locked();
+                    }
                     self->m_kv_valid = false;
                     self->m_active_model.clear();
                     self->SaveSettings();
@@ -2088,6 +2125,7 @@ fire_and_forget MainPageController::EnsureModelNamedAsync(std::wstring model_nam
             self->m_runButton.IsEnabled(true);
             self->m_model_ready.store(true);
             self->EnsureGpuModelIfNeeded();
+            self->PreloadSessionAsync();
         }
         co_return;
     }
@@ -2108,6 +2146,7 @@ fire_and_forget MainPageController::EnsureModelNamedAsync(std::wstring model_nam
                 self->m_runButton.IsEnabled(true);
                 self->m_model_ready.store(true);
                 self->EnsureGpuModelIfNeeded();
+                self->PreloadSessionAsync();
             }
             co_return;
         }
@@ -2237,6 +2276,7 @@ fire_and_forget MainPageController::EnsureModelNamedAsync(std::wstring model_nam
                 self->m_runButton.IsEnabled(true);
                 self->m_model_ready.store(true);
                 self->EnsureGpuModelIfNeeded();
+                self->PreloadSessionAsync();
             }
             co_return;
         }
@@ -2367,6 +2407,7 @@ fire_and_forget MainPageController::EnsureModelNamedAsync(std::wstring model_nam
                 self->LoadModelName();
                 self->m_model_ready.store(true);
                 self->EnsureGpuModelIfNeeded();
+                self->PreloadSessionAsync();
             }
         });
 }
@@ -2383,13 +2424,35 @@ void MainPageController::LoadModelName() {
 }
 
 // ---------------------------------------------------------------------------
-// EnsureSession: lazy-build persistent Session (hot path is a pointer check)
+// EnsureSession: lazy-build the resident Session (hot path is a name check).
+// The session lives in xllama::session_hub() — one owner shared with the LAN
+// API, so the two surfaces can no longer hold a model each ("never 2× model
+// in RAM" now holds process-wide). The CALLER must hold hub.mtx and keep it
+// held for as long as it uses m_turn_session.
 // ---------------------------------------------------------------------------
 
+void MainPageController::PreloadSessionAsync() {
+    const std::string model = ::xllama::wstring_to_utf8(m_model_filename);
+    if (model.empty())
+        return;
+    auto self = shared_from_this();
+    std::thread([self, model]() {
+        auto& hub = ::xllama::session_hub();
+        std::lock_guard<std::mutex> hub_lk(hub.mtx);
+        std::string err;
+        if (!self->EnsureSession(model, &err))
+            ::xllama::log_output(
+                ("[xllama] session preload failed (non-fatal): " + err + "\n").c_str());
+    }).detach();
+}
+
 bool MainPageController::EnsureSession(const std::string& model, std::string* err_out) {
-    if (m_session && m_session_model == model)
+    auto& hub = ::xllama::session_hub();
+    if (hub.session && hub.model == model) {
+        m_turn_session = hub.session.get();
         return true;
-    m_session.reset();  // free before creating new (avoid 2× model in RAM)
+    }
+    m_turn_session = nullptr;
     m_kv_valid = false; // new session object → no reusable KV carries over
     xllama::SessionParams sp;
     sp.model_path = model;
@@ -2425,14 +2488,13 @@ bool MainPageController::EnsureSession(const std::string& model, std::string* er
         }
     }
     std::string err;
-    auto s = xllama::Session::create(sp, &err);
+    ::xllama::Session* s = ::xllama::session_hub().ensure_locked(model, sp, &err);
     if (!s) {
         if (err_out)
             *err_out = err;
         return false;
     }
-    m_session = std::move(s);
-    m_session_model = model;
+    m_turn_session = s;
     return true;
 }
 
@@ -2516,14 +2578,18 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
         int n_tok = 0;
         if (m_routing == 2 && !base_is_gguf) {
             // Exact count only when the CPU session is already resident (a
-            // pointer-compare no-op). The previous shape loaded the CPU model
-            // just to tokenize and then could tear it down for the DML model —
-            // +1.2 s on a GPU-routed first turn (uwp-constraints §5, 2786 ms
-            // vs 1570 ms). With no session loaded the chars/5.0 estimator
+            // name-compare no-op). The previous shape loaded the CPU model
+            // just to tokenize — ON THE UI THREAD — and then could tear it
+            // down for the DML model (+1.2 s, uwp-constraints §5, 2786 ms vs
+            // 1570 ms). With no session resident the chars/5.0 estimator
             // decides — the same estimator whose ceiling already bounds this
             // prompt in BuildPrompt, so routing and trimming stay coherent.
-            if (m_session && m_session_model == rs.cpu_model)
-                n_tok = m_session->count_tokens(full_prompt);
+            // try_lock: if the hub is busy (LAN API mid-turn) fall back to the
+            // estimator rather than blocking the UI thread.
+            auto& hub = ::xllama::session_hub();
+            std::unique_lock<std::mutex> hub_lk(hub.mtx, std::try_to_lock);
+            if (hub_lk.owns_lock() && hub.session && hub.model == rs.cpu_model)
+                n_tok = hub.session->count_tokens(full_prompt);
             else
                 n_tok = ::xllama::estimate_tokens_from_chars(full_prompt.size());
         }
@@ -2601,8 +2667,21 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
     xllama::ChatFormat fmt = chat_format();
 
     std::thread([self, full_prompt, delta_prompt, do_reuse, kv_reuse, ep_kv_ok, model, fmt,
-                 dispatcher]() {
+                 dispatcher]() mutable {
         try {
+            // One hub lock for the whole turn: the resident session cannot be
+            // swapped from under us (LAN API requests report busy meanwhile,
+            // exactly as they do against each other).
+            auto& hub = ::xllama::session_hub();
+            std::lock_guard<std::mutex> hub_lk(hub.mtx);
+            // The other surface may have swapped the resident model between
+            // our turns — the persistent generator the KV flag refers to is
+            // gone. Fall back to a full prefill (no user-visible failure).
+            if (do_reuse && hub.generation != self->m_hub_generation) {
+                ::xllama::log_output(
+                    "[xllama] KV reuse skipped: resident session changed between turns\n");
+                do_reuse = false;
+            }
             std::string load_err;
             if (!self->EnsureSession(model, &load_err)) {
                 dispatcher.RunAsync(CoreDispatcherPriority::Normal, [self, load_err]() {
@@ -2656,7 +2735,7 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
                 gp.reset_kv = reset;
                 gp.on_status = on_status;
                 gp.on_token = on_token;
-                return self->m_session->generate(gp);
+                return self->m_turn_session->generate(gp);
             };
 
             xllama::InferenceResult res;
@@ -2674,6 +2753,11 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
                 // when KV reuse is enabled, else a pure stateless turn.
                 res = run_turn(full_prompt, /*reuse=*/kv_reuse, /*reset=*/kv_reuse);
             }
+
+            // Stamp the resident-session generation this turn's KV state was
+            // built on (still under hub.mtx); the next turn's reuse check
+            // compares against it.
+            self->m_hub_generation = hub.generation;
 
             std::wstring metrics;
             if (res.success) {
@@ -2732,7 +2816,7 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
                 }
                 self->SaveCurrentConversation(was_aborted);
                 if (!was_aborted && !output_text.empty())
-                    self->RenderConversation();
+                    self->FinalizeStreamedTurn(output_text);
             });
         } catch (const std::exception& ex) {
             ::xllama::log_output(std::string("[xllama] thread terminated: ") + ex.what() + "\n");

--- a/uwp/MainPage.h
+++ b/uwp/MainPage.h
@@ -11,6 +11,7 @@
     #include "pch.h"
     #include "xllama/chat_prompt.h"
     #include "xllama/session.h"
+    #include "xllama/session_hub.h"
 
     #include <atomic>
     #include <chrono>
@@ -78,6 +79,12 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     winrt::fire_and_forget EnsureModelNamedAsync(std::wstring model_name,
                                                  bool set_app_ready = false);
     void EnsureGpuModelIfNeeded();
+    // Load (and, for DML models, warm up — #130 §5e) the resident session
+    // ahead of the first turn, so the first send pays prefill+decode only.
+    // Call on the UI thread right after the model becomes Ready; the load
+    // runs detached, serialized by hub.mtx (a concurrent first turn simply
+    // queues behind it and finds the session resident).
+    void PreloadSessionAsync();
     void StartInference(std::wstring const& prompt);
     void OnRunClick(winrt::Windows::Foundation::IInspectable const&,
                     winrt::Windows::UI::Xaml::RoutedEventArgs const&);
@@ -93,6 +100,10 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     winrt::fire_and_forget ShowHistory();
     void LoadConversation(const std::string& id);
     void RenderConversation();
+    // Post-turn finalize of the streamed paragraph (postprocessed text +
+    // feedback controls) — no full conversation rebuild. RenderConversation
+    // stays for history load and feedback-driven edits.
+    void FinalizeStreamedTurn(const std::string& output_text);
     void AddUserParagraph(std::wstring const& text);
     void AppendFeedbackControls(winrt::Windows::UI::Xaml::Documents::Paragraph const& paragraph,
                                 size_t assistant_index);
@@ -143,9 +154,15 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     winrt::Windows::UI::Xaml::DispatcherTimer m_flush_timer{nullptr};
     winrt::event_token m_flush_tick_token{};
 
-    // Persistent inference session — loaded once, reused across chat turns.
-    std::unique_ptr<xllama::Session> m_session;
-    std::string m_session_model;
+    // The persistent inference session lives in xllama::session_hub() — one
+    // process-wide owner shared with the LAN API ("never 2× model in RAM").
+    // m_turn_session is a non-owning view set by EnsureSession, valid ONLY
+    // while the current worker turn holds hub.mtx. m_hub_generation records
+    // the resident-session generation the KV-reuse state was built on; a
+    // mismatch at the next turn means the API swapped models in between and
+    // the persistent generator is gone (worker-thread only).
+    ::xllama::Session* m_turn_session{nullptr};
+    uint64_t m_hub_generation{0};
 
     // KV-cache reuse (continuous decoding) state.
     //   m_kv_reuse: feature toggle (settings.json "kv_reuse", default true).

--- a/uwp/api-server.cpp
+++ b/uwp/api-server.cpp
@@ -25,6 +25,7 @@
     #include "xllama/platform.h"
     #include "xllama/preference_capture.h"
     #include "xllama/session.h"
+    #include "xllama/session_hub.h"
     #include "xllama/utf8_utils.h"
 
     #include <algorithm>
@@ -47,14 +48,15 @@ using namespace winrt::Windows::Data::Json;
 // ---------------------------------------------------------------------------
 // Shared single-slot inference state
 //
-// The server owns ONE Session, created lazily on the first request and reused.
-// g_mtx serializes both (re)creation and generate(): xllama::Session::generate()
-// is not concurrent (session.h:74). A request that finds the slot busy gets 503.
+// The Session lives in xllama::session_hub() — ONE process-wide owner shared
+// with the GUI (previously each surface owned its own Session and both could
+// hold a model at once, breaking the "never 2× model in RAM" invariant).
+// hub.mtx serializes (re)creation and generate(): xllama::Session::generate()
+// is not concurrent (session.h). A request that finds the hub busy — another
+// API request OR a GUI turn — gets 503, exactly the old busy semantics
+// widened to the whole process.
 // ---------------------------------------------------------------------------
-std::mutex g_mtx;
-std::unique_ptr<::xllama::Session> g_session;
-std::string g_model;        // model id currently loaded into g_session
-uint64_t g_req_counter = 0; // monotonic, for unique response ids (under g_mtx)
+std::atomic<uint64_t> g_req_counter{0}; // monotonic, for unique response ids
 
 std::mutex g_state_mtx;
 ServerStatus g_status;
@@ -262,7 +264,7 @@ void split_messages(JsonArray const& messages, std::string& system,
         final_user = cur_user; // trailing user turn is the one we answer
 }
 
-// Handles one chat request under g_mtx (already locked by the caller).
+// Handles one chat request under session_hub().mtx (already locked by the caller).
 std::string handle_chat_locked(const std::string& body, const char*& status) {
     JsonObject root{nullptr};
     if (!JsonObject::TryParse(winrt::to_hstring(body), root) || root == nullptr) {
@@ -296,16 +298,17 @@ std::string handle_chat_locked(const std::string& body, const char*& status) {
     if (system.empty())
         system = "You are a helpful AI assistant.";
 
-    // Lazily (re)create the Session when the requested model differs.
-    if (!g_session || g_model != model) {
+    // Lazily (re)create the resident Session when the requested model differs
+    // (hub.mtx is held by the caller; the swap invalidates the GUI's KV-reuse
+    // state via hub.generation, which its next turn detects).
+    ::xllama::Session* session = nullptr;
+    {
         std::string err;
         ::xllama::SessionParams sp;
         sp.model_path = model;
         sp.n_ctx = 2048;
-        g_session = ::xllama::Session::create(sp, &err);
-        g_model = model;
-        if (!g_session) {
-            g_model.clear();
+        session = ::xllama::session_hub().ensure_locked(model, sp, &err);
+        if (!session) {
             status = "500 Internal Server Error";
             return error_json("session create failed: " + err);
         }
@@ -341,7 +344,7 @@ std::string handle_chat_locked(const std::string& body, const char*& status) {
         }
     }
 
-    const ::xllama::InferenceResult r = g_session->generate(gp);
+    const ::xllama::InferenceResult r = session->generate(gp);
     if (!r.success) {
         status = "500 Internal Server Error";
         return error_json("generation failed: " + r.error_msg);
@@ -371,7 +374,7 @@ std::string handle_chat_locked(const std::string& body, const char*& status) {
     usage.Insert(L"total_tokens", JsonValue::CreateNumberValue(r.n_p_eval + r.n_eval));
 
     JsonObject resp;
-    // Unique per response (id is keyed by clients / trace dedup). g_mtx is held.
+    // Unique per response (id is keyed by clients / trace dedup). hub.mtx is held.
     const std::string id =
         "chatcmpl-xllama-" + std::to_string(time(nullptr)) + "-" + std::to_string(++g_req_counter);
     resp.Insert(L"id", JsonValue::CreateStringValue(winrt::to_hstring(id)));
@@ -384,14 +387,15 @@ std::string handle_chat_locked(const std::string& body, const char*& status) {
     return winrt::to_string(resp.Stringify());
 }
 
-// The single model the server can currently serve: the loaded one, else the
-// LocalState\model.txt hint. Empty id if neither is set. g_model is mutated
-// under g_mtx by chat requests; read it only if we can take the lock, else fall
-// back to the file hint (which touches no shared state) to avoid a data race.
+// The single model the server can currently serve: the resident one, else the
+// LocalState\model.txt hint. Empty id if neither is set. hub.model is mutated
+// under hub.mtx; read it only if we can take the lock, else fall back to the
+// file hint (which touches no shared state) to avoid a data race.
 std::string current_model_id() {
-    std::unique_lock<std::mutex> lk(g_mtx, std::try_to_lock);
-    if (lk.owns_lock() && !g_model.empty())
-        return g_model;
+    auto& hub = ::xllama::session_hub();
+    std::unique_lock<std::mutex> lk(hub.mtx, std::try_to_lock);
+    if (lk.owns_lock() && !hub.model.empty())
+        return hub.model;
     return read_local_text("model.txt");
 }
 
@@ -399,7 +403,7 @@ std::string current_model_id() {
 // it loadable (model_dir_files_ready — base GGUF or ORT layout). The active /
 // hinted model is appended if it is not already in the list (model.txt may
 // name a raw path outside the catalogue). Sorted for stable output; the scan
-// touches no shared state, so no g_mtx is needed.
+// touches no shared state, so no hub lock is needed.
 std::vector<std::string> servable_model_ids() {
     std::vector<std::string> ids;
     std::error_code ec;
@@ -701,7 +705,7 @@ void handle_connection(StreamSocket const& socket, uint64_t generation) {
         }
 
         if (req.method == "POST" && req.path == "/v1/chat/completions") {
-            std::unique_lock<std::mutex> lk(g_mtx, std::try_to_lock);
+            std::unique_lock<std::mutex> lk(::xllama::session_hub().mtx, std::try_to_lock);
             if (!lk.owns_lock()) {
                 write_response(socket, "503 Service Unavailable", error_json("busy"));
                 return;
@@ -755,7 +759,7 @@ void handle_connection(StreamSocket const& socket, uint64_t generation) {
 
         // #118: image generation — shares the single-slot mutex with chat.
         if (req.method == "POST" && req.path == "/v1/images/generations") {
-            std::unique_lock<std::mutex> lk(g_mtx, std::try_to_lock);
+            std::unique_lock<std::mutex> lk(::xllama::session_hub().mtx, std::try_to_lock);
             if (!lk.owns_lock()) {
                 write_response(socket, "503 Service Unavailable", error_json("busy"));
                 return;
@@ -809,11 +813,9 @@ void stop_server_locked(bool write_log) {
         } catch (...) {
         }
     }
-    {
-        std::lock_guard<std::mutex> lock(g_mtx);
-        g_session.reset();
-        g_model.clear();
-    }
+    // Deliberately NOT resetting the hub here: the Session is process-shared
+    // now, and the GUI may be the one using the resident model. A model loaded
+    // solely via the API simply stays resident; the GUI swaps it on next use.
     if (write_log)
         ::xllama::log_output("[xllama] api: stopped\n");
 }

--- a/uwp/api-server.cpp
+++ b/uwp/api-server.cpp
@@ -58,6 +58,21 @@ using namespace winrt::Windows::Data::Json;
 // ---------------------------------------------------------------------------
 std::atomic<uint64_t> g_req_counter{0}; // monotonic, for unique response ids
 
+// Acquire the hub for a request. Busy (another request or a GUI turn) →
+// unowned lock, caller answers 503. But if the holder is the session
+// PRE-LOAD (app just became Ready), wait briefly instead: the client's very
+// first request used to bounce with 503 while the model was warming up
+// (observed on-console). Bounded: ≤15 s, and only while preloading is set.
+std::unique_lock<std::mutex> acquire_hub_or_busy() {
+    auto& hub = ::xllama::session_hub();
+    std::unique_lock<std::mutex> lk(hub.mtx, std::try_to_lock);
+    for (int i = 0; i < 150 && !lk.owns_lock() && hub.preloading.load(); ++i) {
+        Sleep(100);
+        (void)lk.try_lock();
+    }
+    return lk;
+}
+
 std::mutex g_state_mtx;
 ServerStatus g_status;
 uint64_t g_generation = 0; // invalidates callbacks accepted by an older listener
@@ -705,7 +720,7 @@ void handle_connection(StreamSocket const& socket, uint64_t generation) {
         }
 
         if (req.method == "POST" && req.path == "/v1/chat/completions") {
-            std::unique_lock<std::mutex> lk(::xllama::session_hub().mtx, std::try_to_lock);
+            std::unique_lock<std::mutex> lk = acquire_hub_or_busy();
             if (!lk.owns_lock()) {
                 write_response(socket, "503 Service Unavailable", error_json("busy"));
                 return;
@@ -759,7 +774,7 @@ void handle_connection(StreamSocket const& socket, uint64_t generation) {
 
         // #118: image generation — shares the single-slot mutex with chat.
         if (req.method == "POST" && req.path == "/v1/images/generations") {
-            std::unique_lock<std::mutex> lk(::xllama::session_hub().mtx, std::try_to_lock);
+            std::unique_lock<std::mutex> lk = acquire_hub_or_busy();
             if (!lk.owns_lock()) {
                 write_response(socket, "503 Service Unavailable", error_json("busy"));
                 return;


### PR DESCRIPTION
## What

Phase C structural items, part 2 (stacked on #161 — merge that first, then retarget/merge this).

1. **`xllama::SessionHub`** (`include/xllama/session_hub.h`, defined in `session.cpp`, host-tested): one process-wide Session owner. Previously the GUI (`MainPageController::m_session`) and the LAN API (`api-server.cpp g_session`) each owned an independent Session — both could hold a model simultaneously, silently breaking the "never 2× model in RAM" invariant that `EnsureSession` only enforced within the GUI. Contract: hold `hub.mtx` across ensure+generate. The GUI worker locks it for the whole turn; the API keeps its `try_lock` → 503-busy semantics, now correctly extended to GUI turns (previously GUI and API could generate concurrently on two resident models). `hub.generation` lets the GUI detect an API-driven model swap between its turns and fall back to a full prefill instead of appending to a dead persistent generator (logged, no user-visible failure). API stop no longer frees the session (it may be the GUI's).
2. **Session pre-load** (`PreloadSessionAsync`): fired at the four "model Ready" sites of `EnsureModelNamedAsync`. The session is created — and for DML models #158's warm-up runs — in a detached worker while the user reads "Ready", so the first send pays prefill+decode only. This is the missing half that turns the #158 warm-up into a genuine wall-clock win (documented honestly in §5e: with lazy creation it only moved cost inside the same wait). A concurrent first turn just queues on `hub.mtx` and finds the session resident.
3. **`FinalizeStreamedTurn`**: post-turn the streamed paragraph is finalized in place (postprocessed text swap + feedback controls + fresh paragraph) instead of `RenderConversation()` rebuilding the entire conversation's Paragraph/Run tree and discarding what streaming had just appended. `RenderConversation` remains for history load and feedback-driven edits.

Also in the hub migration: routing's resident-count check uses `try_lock` (falls back to the estimator rather than blocking the UI thread if the API is mid-turn), and the three session-teardown sites (model switch, pre-train RSS free, personalize publish) go through `hub.reset_locked()`.

## How verified

- `linux-test` build + `ctest` 100% (new `SessionHub` doctest: failed create leaves the hub empty and bumps `generation`; `resolve_max_length` suite from #161 still green).
- `clang-format` clean.
- UWP compile via `build-uwp.yml` on this PR.
- Console validation for the pair (#161+this): `validate-console.sh all` + `validate-api.sh all`, plus the API-busy-during-GUI-turn and GUI-KV-invalidation-after-API-swap scenarios; and the D1 follow-up measurement — first-send TTFT on a DML-routed model should now show the warmed prefill (~870 tok/s) with the load+warm-up already paid at "Ready".

🤖 Generated with [Claude Code](https://claude.com/claude-code)