### PR TITLE
perf: Phase 13 host quick wins — n_threads_batch, predicted overflow, one n_ctx home, UI micro-costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Performance
+
+- **GGUF prefill now runs on the configured thread count (#168, PR #177).**
+  Neither llama context creation set `n_threads_batch`, whose pin default is
+  4 regardless of `n_threads` — so prefill (any ubatch > 1 token) ran on 4
+  threads while decode got 6, including every published GGUF prefill figure
+  (the +62% repack numbers among them). Same defect class as the
+  never-defined `GGML_USE_CPU_REPACK`. The on-console prefill delta is
+  **not yet measured** (t7/t8 livelock caveat, `uwp-constraints.md` §5f);
+  #168 stays open for the bench.
+- **UI-thread per-turn costs (#174, PR #177).** `IsModelProvisioned`'s
+  filesystem probe (LocalState + InstalledPath stats + USB-root `_wfopen`)
+  ran on the UI thread on every turn but only the sticky first-turn routing
+  decision consumes it — moved inside that branch. `RenderConversation`
+  resolved the per-model chat format once per message (~10 string builds per
+  call); once per render now. The third item (BuildPrompt off the UI thread)
+  folds into #170: without session-side prompt bookkeeping the worker's
+  snapshot costs what the render costs.
+
+### Changed
+
+- **The shipping context size has one home (#171, PR #177).**
+  `kDefaultNCtx` (`inference_params.h`) replaces the three unlinked
+  `n_ctx = 2048` literals in the chat UI, the LAN API and the Session/CLI
+  defaults — the #133/#141 one-quantity-two-homes class, consolidated
+  before divergence this time. `tests/test_routing_policy.cpp` pins
+  `kMaxPromptTokens < kDefaultNCtx` with ≥200 tokens of generation headroom.
+  KV-cache quantization stays open on #171, gated on measurement.
+
+### Fixed
+
+- **Context overflow is predicted instead of discovered by a failed turn
+  (#173, PR #177).** A continuation turn that cannot fit (KV + delta + at
+  least one generated token over `n_ctx`) used to surface as a failed
+  append/decode; the UI then retried with a full prefill — a wasted attempt
+  while the user waits. Both backends now check the arithmetic up front
+  (the KV length is already at hand on both) and fail fast with a
+  `context full` error before touching the generator, so the existing
+  fallback runs immediately. The llama generation loop is also clamped to
+  the context end — a clean stop instead of "decode failed, stopping".
+
 ## [1.5.0.0] - 2026-07-26
 
 ### Performance

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -223,7 +223,7 @@ long prompt and the CPU wins from the second turn (§5d). Evidence under
       user's first send instead of inside its wait — confirmed on-console
       (first DML request: prefill 873 tok/s, decode at warm parity).
 
-## Phase 13 — CPU prefill & KV-reuse structural campaign (planned)
+## Phase 13 — CPU prefill & KV-reuse structural campaign (in progress)
 
 Sourced from the 2026-07-26 architecture review: a docs sweep of everything
 already adopted or rejected (`uwp-constraints.md`, `phase7-hypotheses.md`)
@@ -232,11 +232,13 @@ considered** — none appears in any prior doc or issue. Ordered by
 impact/risk; each issue carries the evidence (file:line) and the candidate
 fix.
 
-- [ ] **#168 — `n_threads_batch` is never set: GGUF prefill runs at 4 threads,
-      decode at 6.** Same defect class as the never-defined
-      `GGML_USE_CPU_REPACK` (#155); every published GGUF prefill figure —
-      including the +62% repack numbers — was measured at 4 prefill threads.
-      One-line fix; on-console validation required (t7/t8 livelock risk, §5f).
+- [~] **#168 — `n_threads_batch` is never set: GGUF prefill runs at 4 threads,
+  decode at 6.** Same defect class as the never-defined
+  `GGML_USE_CPU_REPACK` (#155); every published GGUF prefill figure —
+  including the +62% repack numbers — was measured at 4 prefill threads.
+  **Fix landed (PR #177)**; the issue stays open for the on-console bench
+  (prefill delta + the t7/t8 livelock check, §5f) — no gain is quoted
+  until it runs.
 - [ ] **#169 — the context trimmer permanently disables KV reuse** once a chat
       exceeds `kMaxPromptTokens`: every later turn pays a full ~1800-token
       re-prefill. Candidate: context shift (`llama_memory_seq_rm`/`seq_add`) + delta prefill. Highest impact, medium-high risk.
@@ -244,18 +246,24 @@ fix.
       switch and every LAN-API request re-prefill from zero today; step (a)
       is in-memory prefix diff (low risk), step (b) persistent KV via
       `llama_state_seq_save_file` (needs an eviction policy).
-- [ ] **#171 — KV quantization (q8_0) + explicit flash_attn; consolidate the
-      three unlinked `n_ctx = 2048` homes** (the #133/#141 duplicated-state
-      class, caught before divergence this time). Frees the headroom that
-      would let `n_ctx` rise, pushing the #169 cliff later.
+- [~] **#171 — KV quantization (q8_0) + explicit flash_attn; consolidate the
+  three unlinked `n_ctx = 2048` homes** (the #133/#141 duplicated-state
+  class, caught before divergence this time). Frees the headroom that
+  would let `n_ctx` rise, pushing the #169 cliff later. **Consolidation
+  half landed (PR #177)**: `kDefaultNCtx` in `inference_params.h` is the
+  one home, domain test pins the trimmer relation. KV quantization
+  remains, gated on a quality measurement (logit-parity harness).
 - [ ] **#172 — re-sweep `n_ubatch` on console post-repack** (knob already
       plumbed, never measured on-device; #155 redrew the GEMM economics).
       Measure together with #168 — blocked on console access.
-- [ ] **#173 — predict context overflow** instead of failing the turn and
-      retrying with a full prefill.
-- [ ] **#174 — UI-thread micro-costs in `StartInference`** (per-turn
-      provisioning I/O, always-rendered `BuildPrompt`, per-message
-      `chat_format()`).
+- [x] **#173 — predict context overflow** instead of failing the turn and
+      retrying with a full prefill. Done (PR #177): both backends fail fast
+      pre-append when KV + delta + one token exceeds `n_ctx`, and the llama
+      generation loop stops cleanly at the context end.
+- [x] **#174 — UI-thread micro-costs in `StartInference`** (per-turn
+      provisioning I/O, per-message `chat_format()`). Done (PR #177) for
+      items 1 and 3; the BuildPrompt-off-UI-thread item folded into #170 on
+      cost parity (the worker snapshot costs what the render costs).
 - [ ] **#175 — decide the repetition-penalty window semantics**: resets per
       turn on llama.cpp, persists on ORT — the runtime-state residual of the
       #125/#136/#141 sampling unification.

--- a/docs/recommended-config.md
+++ b/docs/recommended-config.md
@@ -53,7 +53,11 @@ tables are in [benchmarks.md](benchmarks.md) (the perf SSOT).
 
 GGUF thread default: llama.cpp auto-detect is capped at **6** on console
 (`detect_threads_llama` — t6 measured optimum, t7/t8 livelock); explicit
-`--threads` on `bench-xbox-ort.sh` still wins.
+`--threads` on `bench-xbox-ort.sh` still wins. Caveat (#168): the "t6" in the
+GGUF rows above describes **decode** — until PR #177 the app never set
+`n_threads_batch`, so every published GGUF **prefill** figure ran on the
+llama.cpp default of 4 prefill threads. Re-measure pending
+(`uwp-constraints.md` §5f, 2026-07-26 note).
 
 ### Do not use
 

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -371,6 +371,18 @@ lengths. **Shipped 2026-07-25** with the 1.5.0.0 identity migration (the forced
 re-provision was the "next models-v1 republish" the ship condition bundled
 with); the release's `genai_config.json` now sets `intra_op_num_threads: 6`.
 
+**2026-07-26 — the GGUF path had its own thread gap all along (#168).**
+Everything above concerns the ORT knob (`intra_op_num_threads`). On the
+llama.cpp side the app set only `n_threads` (decode), never
+`n_threads_batch` — and llama.cpp runs prefill on `n_threads_batch`, whose
+default is 4 regardless of `n_threads`. So while these sweeps tuned ORT
+prefill, **GGUF prefill ran on 4 of the 6 usable cores in every measurement
+ever published**, the +62% repack rows included. Fixed in PR #177
+(`n_threads_batch = n_threads`); the on-console prefill delta is
+deliberately unquoted until the bench runs — 6-thread prefill is exactly the
+regime where the t7/t8-style ggml spin-wait pathology would show if the cap
+logic ever drifts, so the measurement doubles as the livelock check.
+
 ### §5 (continued) — disk, availability and the App/Game lever
 
 **Effect on disk**: models too large to fit the Dev Mode partition also fail before reaching `OgaCreateModel`. This is a distinct failure mode — see §9.

--- a/include/xllama/inference_params.h
+++ b/include/xllama/inference_params.h
@@ -14,6 +14,12 @@
 
 namespace xllama {
 
+// The one home for the shipping context size (#171). Every surface that opens a
+// context (chat UI, LAN API, Session default, CLI default) reads this constant;
+// the trimmer budget kMaxPromptTokens (routing_policy.h) is sized against it —
+// tests/test_routing_policy.cpp pins the relation.
+inline constexpr int kDefaultNCtx = 2048;
+
 // ---------------------------------------------------------------------------
 // Inference configuration
 // ---------------------------------------------------------------------------
@@ -21,7 +27,7 @@ struct InferenceParams {
     std::string model_path; // Linux: absolute path; UWP: filename in LocalFolder
     std::string prompt;
     int n_predict = 128;
-    int n_ctx = 2048;
+    int n_ctx = kDefaultNCtx;
 
     // #130 bench knob (ORT path). max_length is what governs DirectML prefill
     // throughput, and it is normally DERIVED as min(n_ctx, n_prompt + n_predict)

--- a/include/xllama/routing_policy.h
+++ b/include/xllama/routing_policy.h
@@ -36,8 +36,9 @@ namespace xllama {
 // estimate does not model them.
 inline constexpr double kEstimatedCharsPerToken = 5.0;
 
-// Token budget for the prompt itself, sized against n_ctx 2048 with ~250 tokens
-// left for generation.
+// Token budget for the prompt itself, sized against kDefaultNCtx
+// (inference_params.h) with ~250 tokens left for generation —
+// tests/test_routing_policy.cpp pins the relation (#171).
 inline constexpr int kMaxPromptTokens = 1800;
 
 inline constexpr int estimate_tokens_from_chars(std::size_t chars) {

--- a/include/xllama/session.h
+++ b/include/xllama/session.h
@@ -23,11 +23,11 @@ namespace xllama {
 enum class Backend { Auto, OrtGenAI, LlamaCpp };
 
 struct SessionParams {
-    std::string model_path; // same semantics as InferenceParams::model_path
-    int n_ctx = 2048;
-    int n_threads = 0; // 0 = auto
-    int n_batch = 0;   // llama.cpp only; 0 = default (2048). Logical prefill batch.
-    int n_ubatch = 0;  // llama.cpp only; 0 = default (512). Physical prefill chunk.
+    std::string model_path;   // same semantics as InferenceParams::model_path
+    int n_ctx = kDefaultNCtx; // one home, inference_params.h (#171)
+    int n_threads = 0;        // 0 = auto
+    int n_batch = 0;          // llama.cpp only; 0 = default (2048). Logical prefill batch.
+    int n_ubatch = 0;         // llama.cpp only; 0 = default (512). Physical prefill chunk.
     Backend backend = Backend::Auto;
     int n_gpu_layers = 0; // llama.cpp only; 0 = CPU (Xbox has no ggml GPU backend)
 

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -467,6 +467,9 @@ InferenceResult run_inference_llama(const InferenceParams& params) {
     llama_context_params cparams = llama_context_default_params();
     cparams.n_ctx = static_cast<uint32_t>(params.n_ctx);
     cparams.n_threads = n_threads;
+    // Prefill runs on n_threads_batch (default 4, independent of n_threads) —
+    // see LlamaSession::generate and #168.
+    cparams.n_threads_batch = n_threads;
     if (params.n_batch > 0)
         cparams.n_batch = static_cast<uint32_t>(params.n_batch);
     if (params.n_ubatch > 0)

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -277,6 +277,19 @@ class OrtSession final : public Session {
                   "OgaTokenizerEncode");
         int n_prompt_tok = static_cast<int>(OgaSequencesGetSequenceCount(seqs.get(), 0));
 
+        // #173: a continuation that cannot fit (KV + delta + >=1 generated token
+        // over n_ctx) is predictable from state we already hold — fail before
+        // touching the generator instead of letting the append discover it. The
+        // throw lands in generate()'s catch, which resets the chat state; the
+        // caller sees n_eval == 0 and falls back to a trimmed full prefill.
+        if (reuse) {
+            const int kv = static_cast<int>(OgaGenerator_GetSequenceCount(m_chat_gen.get(), 0));
+            if (kv + n_prompt_tok + 1 > m_n_ctx)
+                throw std::runtime_error("context full: kv=" + std::to_string(kv) +
+                                         " + delta=" + std::to_string(n_prompt_tok) +
+                                         " exceeds n_ctx=" + std::to_string(m_n_ctx));
+        }
+
         if (gp.on_status)
             gp.on_status("generating");
         auto t0 = std::chrono::steady_clock::now();
@@ -476,6 +489,10 @@ class LlamaSession final : public Session {
             llama_context_params cparams = llama_context_default_params();
             cparams.n_ctx = m_n_ctx;
             cparams.n_threads = m_n_threads;
+            // Prefill (any ubatch > 1 token) runs on n_threads_batch, whose
+            // default is GGML_DEFAULT_N_THREADS (4) regardless of n_threads —
+            // left unset it caps prefill at 4 threads while decode gets 6 (#168).
+            cparams.n_threads_batch = m_n_threads;
             if (m_n_batch > 0)
                 cparams.n_batch = static_cast<uint32_t>(m_n_batch);
             if (m_n_ubatch > 0)
@@ -539,6 +556,23 @@ class LlamaSession final : public Session {
         }
         tokens.resize(static_cast<size_t>(n_tokens));
 
+        // #173: on a continuation turn the KV length is exact and free to read
+        // (seq_pos_max is -1 on an empty cache). Predict the overflow — KV +
+        // delta + at least one generated token — and fail before the decode
+        // attempt; the caller retries with the trimmed full prompt. The same
+        // arithmetic clamps the generation loop below so hitting the context
+        // end is a clean stop, not a mid-generation decode failure.
+        const int kv_len =
+            full_prompt ? 0
+                        : static_cast<int>(llama_memory_seq_pos_max(llama_get_memory(ctx), 0)) + 1;
+        if (!full_prompt && kv_len + n_tokens + 1 > m_n_ctx) {
+            res.error_msg = "context full: kv=" + std::to_string(kv_len) +
+                            " + delta=" + std::to_string(n_tokens) +
+                            " exceeds n_ctx=" + std::to_string(m_n_ctx);
+            log_output(("[xllama] session generate: " + res.error_msg + "\n").c_str());
+            return res;
+        }
+
         // Prefill: positions continue automatically from the KV cache end, so a
         // reuse turn appends after the retained context.
         const auto t_prefill0 = std::chrono::steady_clock::now();
@@ -564,7 +598,12 @@ class LlamaSession final : public Session {
         bool stopped_by_seq = false;
         const auto t_decode0 = std::chrono::steady_clock::now();
 
-        while (n_generated < gp.n_predict) {
+        // Clean stop at the context end (#173): each generated token needs a KV
+        // slot, so the loop must not outrun n_ctx - (kv_len + prompt).
+        const int n_predict_eff =
+            std::min(gp.n_predict, m_n_ctx - kv_len - static_cast<int>(tokens.size()));
+
+        while (n_generated < n_predict_eff) {
             if (gp.abort_flag && gp.abort_flag->load())
                 break;
 
@@ -665,7 +704,7 @@ std::unique_ptr<Session> create_llama(const SessionParams& sp, std::string* err)
     }
 
     int n_threads = sp.n_threads > 0 ? sp.n_threads : detect_threads_llama();
-    int n_ctx = sp.n_ctx > 0 ? sp.n_ctx : 2048;
+    int n_ctx = sp.n_ctx > 0 ? sp.n_ctx : kDefaultNCtx;
     log_output("[xllama] Session: GGUF model loaded via llama.cpp (persistent)\n");
     return std::make_unique<LlamaSession>(LlamaModelPtr(raw_model), std::move(adapter),
                                           sp.lora_scale, n_ctx, n_threads, sp.n_batch, sp.n_ubatch);

--- a/tests/test_routing_policy.cpp
+++ b/tests/test_routing_policy.cpp
@@ -3,6 +3,7 @@
 
 #include <doctest/doctest.h>
 
+#include "xllama/inference_params.h" // kDefaultNCtx (#171)
 #include "xllama/routing_policy.h"
 
 using namespace xllama;
@@ -140,6 +141,16 @@ TEST_CASE("routing: the threshold stays reachable under the context trimmer") {
     // the trimmer cuts a turn routing would have sent to the GPU.
     CHECK(estimate_tokens_from_chars(7100) == 1420);
     CHECK(estimate_tokens_from_chars(7100) < kMaxPromptTokens);
+}
+
+TEST_CASE("routing: the trimmer budget fits the shipping context") {
+    // #171. kMaxPromptTokens is sized against kDefaultNCtx "with ~250 tokens
+    // left for generation" — but until the context size had one home, nothing
+    // related the two numbers (the same silent-divergence shape as #133). A
+    // trimmed-full prompt must fit the context with real room to generate;
+    // if either constant moves, this states the invariant the other must keep.
+    CHECK(kMaxPromptTokens < kDefaultNCtx);
+    CHECK(kDefaultNCtx - kMaxPromptTokens >= 200);
 }
 
 TEST_CASE("routing: gguf disables routing") {

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -761,6 +761,10 @@ void MainPageController::NewChat() {
 void MainPageController::RenderConversation() {
     using namespace winrt::Windows::UI::Xaml::Documents;
     m_outputBody.Blocks().Clear();
+    // One format resolution for the whole render, not one per message (#174) —
+    // chat_format_for builds ~10 strings per call and the format only depends
+    // on m_model_filename, which cannot change mid-loop.
+    const xllama::ChatFormat fmt = chat_format();
     for (size_t message_index = 0; message_index < m_current.messages.size(); ++message_index) {
         const auto& msg = m_current.messages[message_index];
         if (msg.role == xllama::ui::MessageRole::System)
@@ -773,7 +777,7 @@ void MainPageController::RenderConversation() {
         label.FontWeight(winrt::Windows::UI::Text::FontWeights::Bold());
         p.Inlines().Append(label);
         Run content;
-        content.Text(::xllama::utf8_to_wstring(chat_format().postprocess_output(msg.content)));
+        content.Text(::xllama::utf8_to_wstring(fmt.postprocess_output(msg.content)));
         if (msg.partial)
             content.Text(content.Text() + L" [cancelled]");
         p.Inlines().Append(content);
@@ -2461,7 +2465,7 @@ bool MainPageController::EnsureSession(const std::string& model, std::string* er
     m_kv_valid = false; // new session object → no reusable KV carries over
     xllama::SessionParams sp;
     sp.model_path = model;
-    sp.n_ctx = 2048;
+    sp.n_ctx = ::xllama::kDefaultNCtx;
     // 0 = default: llama.cpp gets detect_threads_llama() (capped at 6 on UWP —
     // t6 measured optimum, t7/t8 livelock); ORT threads come from
     // genai_config.json intra_op_num_threads on the model dir.
@@ -2572,9 +2576,11 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
     // Stage 3: decide EP routing once per conversation (sticky — the KV cache is
     // per-EP). m_active_model is cleared on new/loaded chat, so this fires on the
     // first turn and stays fixed after. Default (m_routing==0) keeps the CPU model.
-    const bool gpu_provisioned =
-        ::xllama::IsModelProvisioned(::xllama::utf8_to_wstring(m_gpu_model));
     if (m_active_model.empty()) {
+        // Filesystem probe (LocalState + InstalledPath stats) — only the sticky
+        // first-turn decision consumes it, so keep it off the per-turn path (#174).
+        const bool gpu_provisioned =
+            ::xllama::IsModelProvisioned(::xllama::utf8_to_wstring(m_gpu_model));
         ::xllama::RoutingSettings rs;
         rs.mode = static_cast<::xllama::RoutingMode>(m_routing);
         rs.cpu_model = ::xllama::wstring_to_utf8(m_model_filename);

--- a/uwp/api-server.cpp
+++ b/uwp/api-server.cpp
@@ -321,7 +321,7 @@ std::string handle_chat_locked(const std::string& body, const char*& status) {
         std::string err;
         ::xllama::SessionParams sp;
         sp.model_path = model;
-        sp.n_ctx = 2048;
+        sp.n_ctx = ::xllama::kDefaultNCtx;
         session = ::xllama::session_hub().ensure_locked(model, sp, &err);
         if (!session) {
             status = "500 Internal Server Error";


### PR DESCRIPTION
First slice of the Phase 13 campaign (ROADMAP): the items fixable and verifiable host-side today.

- **#168 — `n_threads_batch` set on both llama context creations.** Prefill ran on the pin default of **4 threads** while decode got 6 (`llama_context_default_params` → `GGML_DEFAULT_N_THREADS`); every published GGUF prefill figure was measured that way. One line per site + constraint comment. **Gain is not quoted until the on-console bench runs** (t7/t8 livelock caveat, §5f) — issue stays open for the measurement.
- **#173 — context overflow predicted, not discovered.** Both backends now fail fast before touching the KV when a continuation cannot fit (KV + delta + ≥1 token > n_ctx) — the error surfaces with `n_eval == 0`, so the existing UI fallback (full trimmed prefill) runs as before, minus the wasted attempt. The llama generation loop is clamped to the context end: a clean stop instead of "decode failed, stopping".
- **#171 (consolidation half) — `kDefaultNCtx` is the one home** for the shipping context size (`inference_params.h`); chat UI, LAN API, Session and CLI defaults read it. New domain test pins `kMaxPromptTokens < kDefaultNCtx` with ≥200 headroom — the #133 relation class, stated before divergence this time. KV quantization stays open on the issue (needs measurement).
- **#174 — UI-thread micro-costs**: `IsModelProvisioned`'s filesystem probe moves inside the sticky first-turn branch (it ran on every turn); `RenderConversation` resolves the chat format once per render, not once per message. The third item (BuildPrompt off the UI thread) is dropped on cost parity — the by-value snapshot the worker would need costs what the render costs; commented on the issue.

Verification: `linux-test` build clean; `ctest` PASS including the new #171 domain test; `check-coherence.py` OK 35/0/0; clang-format (pinned 22.1.5) clean; CLI greedy smoke on a real GGUF gives the same argmax output.

Console follow-ups tracked on the issues: #168 bench (prefill delta + t-livelock check), #173 behavior visible in the session log's `context full` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)