### PR TITLE
sampling(#175): penalty state follows the KV lifecycle on both backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Repetition-penalty state now follows the KV lifecycle on both backends
+  (#175).** llama.cpp rebuilt its sampler chain every turn, so the penalty
+  window (and the dist RNG) reset per turn while the ORT persistent
+  generator carried them across the conversation — the runtime-state
+  residual of the #125/#136/#141 unification. Decision: state lives as long
+  as the conversation (resets with `reset_kv` or a sampling change);
+  `LlamaSession` keeps its chain across reuse turns behind the `same_chain`
+  guard (`sampling.h`), the twin of `OrtSession::sampling_matches`. The
+  window WIDTH stays deliberately divergent — llama's last-64 vs ORT's
+  whole-sequence penalty (no window in the C API); the short window is kept
+  on purpose, whole-sequence penalties being the known cause of long-chat
+  degradation. Greedy paths (all quality gates) are unaffected.
+
 - **The shipping context size has one home (#171, PR #177).**
   `kDefaultNCtx` (`inference_params.h`) replaces the three unlinked
   `n_ctx = 2048` literals in the chat UI, the LAN API and the Session/CLI

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -266,9 +266,13 @@ fix.
       provisioning I/O, per-message `chat_format()`). Done (PR #177) for
       items 1 and 3; the BuildPrompt-off-UI-thread item folded into #170 on
       cost parity (the worker snapshot costs what the render costs).
-- [ ] **#175 — decide the repetition-penalty window semantics**: resets per
-      turn on llama.cpp, persists on ORT — the runtime-state residual of the
-      #125/#136/#141 sampling unification.
+- [x] **#175 — repetition-penalty state semantics decided (2026-07-26):
+      sampler state follows the KV lifecycle** on both backends — lives as
+      long as the conversation, resets with `reset_kv` or a sampling change.
+      llama now keeps its chain across reuse turns (`same_chain` guard,
+      mirroring `OrtSession::sampling_matches`); the window WIDTH stays
+      deliberately divergent (llama last-64 vs ORT whole-sequence, whose C
+      API exposes no window) — rationale in `sampling.h`.
 
 Explicitly **not** reopened: mmap via `CreateFileMappingFromApp` — tried and
 reverted 2026-07-14 with zero measured benefit (`uwp-constraints.md` §1);

--- a/include/xllama/sampling.h
+++ b/include/xllama/sampling.h
@@ -26,6 +26,15 @@ inline constexpr int kTopK = 40;
 inline constexpr float kRepetitionPenalty = 1.1f;
 // Window the repetition penalty looks back over. Not exposed as a flag —
 // llama.cpp's own default is 64 and no surface has ever varied it.
+//
+// #175 (decided 2026-07-26): sampler STATE follows the KV lifecycle on both
+// backends — it lives as long as the conversation and resets with reset_kv or
+// a sampling change (llama: chain kept across reuse turns in LlamaSession;
+// ORT: the persistent generator always worked this way). The window WIDTH
+// still differs by design: llama penalizes the last 64 generated tokens, ORT
+// GenAI penalizes the whole sequence and its C API exposes no window — the
+// short window is kept deliberately (whole-sequence penalties are the known
+// cause of long-chat degradation), not an alignment gap to fix.
 inline constexpr int kPenaltyLastN = 64;
 inline constexpr uint32_t kSeed = 0xFFFFFFFF; // LLAMA_DEFAULT_SEED
 
@@ -53,5 +62,18 @@ struct SamplingConfig {
         return greedy || temperature <= 0.0f;
     }
 };
+
+// Would these two configs assemble the same sampler chain? The #175 chain-reuse
+// guard: a persistent chain may only be reused while every stage parameter is
+// unchanged (both backends rebuild their sampler state on any mismatch — see
+// LlamaSession::generate and OrtSession::sampling_matches).
+inline bool same_chain(const SamplingConfig& a, const SamplingConfig& b) {
+    if (a.is_greedy() != b.is_greedy())
+        return false;
+    if (a.is_greedy())
+        return true; // greedy chains have no other parameters
+    return a.temperature == b.temperature && a.top_p == b.top_p && a.top_k == b.top_k &&
+           a.repetition_penalty == b.repetition_penalty && a.seed == b.seed;
+}
 
 } // namespace xllama

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -476,6 +476,14 @@ class LlamaSession final : public Session {
     // (reuse_kv && !reset_kv) can append only the delta instead of re-prefilling
     // the whole conversation. Created lazily on the first generate().
     LlamaContextPtr m_ctx;
+    // #175 decision: sampler state follows the KV lifecycle, mirroring the ORT
+    // persistent generator — the penalty window (and the dist RNG) live as long
+    // as the conversation, so the tail of the previous reply stays penalized at
+    // the start of the next turn. Rebuilt on reset_kv or a sampling change
+    // (same_chain guard). The 64-token window itself is a deliberate divergence
+    // from ORT's whole-sequence penalty — see sampling.h.
+    LlamaSamplerPtr m_sampler;
+    SamplingConfig m_sampler_cfg;
 
     explicit LlamaSession(LlamaModelPtr model, LlamaAdapterLoraPtr adapter, float lora_scale,
                           int n_ctx, int n_threads, int n_batch, int n_ubatch)
@@ -587,12 +595,19 @@ class LlamaSession final : public Session {
                 .count();
         res.n_p_eval = static_cast<int>(tokens.size());
 
-        const llama_sampler_chain_params sparams = llama_sampler_chain_default_params();
-        LlamaSamplerPtr sampler(llama_sampler_chain_init(sparams));
         // Shared with run_inference — see src/bridge/sampler_chain.h and #125.
         // SamplingConfig::is_greedy() also covers temperature 0, where the full
         // chain must not run (the repetition penalty can flip the argmax).
-        add_sampler_stages(sampler.get(), gp.sampling());
+        // #175: reuse the chain on a continuation turn with unchanged sampling,
+        // so penalty/RNG state crosses turn boundaries exactly as the KV does.
+        const SamplingConfig sc = gp.sampling();
+        if (full_prompt || !m_sampler || !same_chain(m_sampler_cfg, sc)) {
+            const llama_sampler_chain_params sparams = llama_sampler_chain_default_params();
+            m_sampler.reset(llama_sampler_chain_init(sparams));
+            add_sampler_stages(m_sampler.get(), sc);
+            m_sampler_cfg = sc;
+        }
+        llama_sampler* sampler_chain = m_sampler.get();
 
         int n_generated = 0;
         bool stopped_by_seq = false;
@@ -607,7 +622,7 @@ class LlamaSession final : public Session {
             if (gp.abort_flag && gp.abort_flag->load())
                 break;
 
-            llama_token token = llama_sampler_sample(sampler.get(), ctx, -1);
+            llama_token token = llama_sampler_sample(sampler_chain, ctx, -1);
             if (llama_vocab_is_eog(vocab, token))
                 break;
 

--- a/tests/test_sampling.cpp
+++ b/tests/test_sampling.cpp
@@ -84,6 +84,36 @@ TEST_CASE("sampling: temperature 0 is greedy, independently of the greedy flag")
     CHECK(sc.is_greedy());
 }
 
+TEST_CASE("sampling: same_chain gates the #175 persistent-chain reuse") {
+    // Sampler state follows the KV lifecycle; a persistent chain may only be
+    // reused while it would be assembled identically. Any stage parameter
+    // change must force a rebuild — reusing across a mismatch would sample
+    // with parameters the caller no longer holds.
+    SamplingConfig a;
+    SamplingConfig b;
+    CHECK(same_chain(a, b));
+
+    b.top_k = a.top_k + 1;
+    CHECK_FALSE(same_chain(a, b));
+    b = a;
+    b.seed = a.seed + 1;
+    CHECK_FALSE(same_chain(a, b));
+
+    // Greedy chains have a single stage: two greedy configs match regardless
+    // of the (unused) sampling values, and greedy never matches non-greedy —
+    // including via temperature 0, which is greedy without the flag.
+    b = a;
+    a.greedy = b.greedy = true;
+    b.top_p = 0.123f;
+    CHECK(same_chain(a, b));
+    b.greedy = false;
+    CHECK_FALSE(same_chain(a, b));
+    a.greedy = false;
+    a.temperature = 0.0f;
+    b.temperature = 0.8f;
+    CHECK_FALSE(same_chain(a, b));
+}
+
 TEST_CASE("sampling: the CLI can express every value the GUI can") {
     // Regression for the concrete complaint in #125: a generation observed in
     // the GUI must be reproducible from the command line. Parse the flags and


### PR DESCRIPTION
Product decision (evaluated 2026-07-26): **sampler state follows the KV lifecycle** — it lives as long as the conversation and resets with `reset_kv` or a sampling change.

The divergence was the runtime-state residual of the #125/#136/#141 unification: llama rebuilt its chain every turn (penalty window + dist RNG reset per turn) while the ORT persistent generator carried them across the conversation. ORT is not alignable the other way (sampling lives inside the generator; recreating it per turn would destroy KV reuse), and llama is fully controllable — so llama now keeps its chain across reuse turns behind the new `same_chain` guard (`sampling.h`, host-tested), the structural twin of `OrtSession::sampling_matches`.

Deliberately NOT aligned: the window width. llama penalizes the last 64 generated tokens; ORT GenAI penalizes the whole sequence and its C API exposes no window. The short window is kept on purpose — whole-sequence penalties are the known cause of long-chat degradation. Rationale documented at `kPenaltyLastN`.

Verification: 140/140 host tests (new `same_chain` case included); greedy paths — every quality gate — bypass the chain entirely; the opt-in CLI↔Session parity test compares single turns, which rebuild identically.

Closes #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Repetition-penalty state now follows the conversation’s KV-cache lifecycle across supported backends.
  * State persists during conversation continuations and resets when the KV cache or sampling settings are reset.
  * Sampling behavior remains consistent across reused turns, while greedy generation is unaffected.
  * Backend-specific penalty windows remain intentionally different to support long-chat performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->