### PR TITLE
perf(#171): q8_0 KV-cache knob, measured — default stays OFF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **q8_0 KV-cache knob, measured — default stays OFF (#171).** `--kv-q8`
+  (CLI), `SessionParams::kv_q8`, `bench_kvq8.txt` (+ `-kvq8` host tag and
+  driver guard) set `type_k/type_v = q8_0` and force flash attention, which
+  quantized V requires; on a context-creation failure the session falls
+  back to F16 KV so an arch without FA support still loads. Measured with
+  the logit-parity comparator: KV **−47%** on both tested archs
+  (LFM2.5 24 → 12.75 MiB, SmolLM2 80 → 42.5 at n_ctx 2048), FA alone is
+  **bit-identical**, but the quantization drifts the logits — LFM2.5 NMSE
+  8.25e-03 with a top-1 flip on a trivial prompt (SmolLM2 2.13e-03,
+  top-1 stable). Verdict: at n_ctx 2048 the saving is noise next to the
+  weights, so the default stays F16; revisit with the #169 context raise,
+  gated on H9.
+
 - **`--ubatch` bench knob + on-console `n_ubatch` sweep (#172).**
   `bench_ubatch.txt` reaches `InferenceParams::n_ubatch` on the GGUF path and
   the device tags the CSV host column with `-uN` (the schema has no ubatch

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -246,13 +246,17 @@ fix.
       switch and every LAN-API request re-prefill from zero today; step (a)
       is in-memory prefix diff (low risk), step (b) persistent KV via
       `llama_state_seq_save_file` (needs an eviction policy).
-- [~] **#171 — KV quantization (q8_0) + explicit flash_attn; consolidate the
-  three unlinked `n_ctx = 2048` homes** (the #133/#141 duplicated-state
-  class, caught before divergence this time). Frees the headroom that
-  would let `n_ctx` rise, pushing the #169 cliff later. **Consolidation
-  half landed (PR #177)**: `kDefaultNCtx` in `inference_params.h` is the
-  one home, domain test pins the trimmer relation. KV quantization
-  remains, gated on a quality measurement (logit-parity harness).
+- [x] **#171 — KV quantization measured; verdict: knob shipped, default
+      OFF.** Consolidation half landed first (PR #177: `kDefaultNCtx`, domain
+      test). The q8_0+flash-attn knob (`--kv-q8`, `SessionParams::kv_q8`,
+      `bench_kvq8.txt`, F16 fallback if an arch refuses FA) is measured on
+      host with the logit-parity comparator: KV −47% on both archs, but the
+      drift is entirely from the quantization (FA alone is bit-identical) —
+      NMSE 8.25e-03 with a **top-1 flip on the default LFM2.5 model** at a
+      trivial prompt (SmolLM2: 2.13e-03, top-1 stable). At `n_ctx` 2048 the
+      saving is 11–40 MiB against 320–1600 MB of weights, so shipping it ON
+      would trade visible quality for headroom nothing uses yet. Revisit with
+      the #169 `n_ctx` raise, gated on H9.
 - [x] **#172 — re-sweep `n_ubatch` on console post-repack.** Done 2026-07-26
       (`--ubatch` knob + on-device sweep u128–u1024 at P=1000,
       `bench/results/phase13c-ubatch-sweep.csv`): **the default 512 is the

--- a/include/xllama/inference_params.h
+++ b/include/xllama/inference_params.h
@@ -54,6 +54,9 @@ struct InferenceParams {
     // sets prefill throughput on the Zen 2 CPU — the sweep knob for TTFT tuning.
     int n_batch = 0;
     int n_ubatch = 0;
+    // #171: q8_0 KV cache + forced flash attention (GGUF path only; quantized V
+    // requires FA). Same semantics and fallback as SessionParams::kv_q8.
+    bool kv_q8 = false;
     // Sampling. Defaults come from xllama/sampling.h so the CLI/bench surface
     // cannot drift from the GUI/API surface (GenerateParams) the way it did
     // before #125, when this path had no top_p / top_k / repetition_penalty at

--- a/include/xllama/session.h
+++ b/include/xllama/session.h
@@ -37,6 +37,14 @@ struct SessionParams {
     std::string lora_path;
     float lora_scale = 1.0f;
 
+    // #171: quantize the llama.cpp KV cache to q8_0 (halves its footprint) and
+    // force flash attention, which quantized V requires — the pin throws at
+    // context creation otherwise. On any context-creation failure the session
+    // retries with default cache types, so an architecture without flash
+    // attention support degrades to F16 KV instead of failing to load.
+    // Default off until the on-console measurement decides (#171).
+    bool kv_q8 = false;
+
     // #130: run a throwaway generate at load for DirectML models, paying the
     // one-time per-process cost (§5e: cold→warm prefill 1.64-1.72×) inside the
     // "loading model" phase instead of on the user's first turn. Ignored for

--- a/scripts/bench-xbox-kv.sh
+++ b/scripts/bench-xbox-kv.sh
@@ -141,6 +141,7 @@ for run in $(seq 1 "$RUNS"); do
 	remove "bench_npredict.txt"
 	remove "bench_maxlen.txt"
 	remove "bench_ubatch.txt"
+	remove "bench_kvq8.txt"
 	# Append-only across restarts: clear it so the failure grep below sees only
 	# this run (a stale DirectML error would otherwise be attributed to it).
 	remove "xllama.log"

--- a/scripts/bench-xbox-ort.sh
+++ b/scripts/bench-xbox-ort.sh
@@ -32,6 +32,9 @@
 #                    bench_ubatch.txt (#172). 0 = llama default (512). GGUF
 #                    models only; the ORT path ignores it. The device tags the
 #                    CSV host column with -uN so the row carries the variable.
+#   --kv-q8          q8_0 KV cache + flash attention via bench_kvq8.txt (#171).
+#                    GGUF models only. Host column tagged -kvq8 (same rationale
+#                    as -uN); the guard fails if the MSIX ignores the knob.
 #
 # Required env: XBOX_IP, XBOX_USER, XBOX_PASS
 #
@@ -54,6 +57,7 @@ N_CTX=0     # 0 = engine default (2048)
 N_PREDICT=0 # 0 = engine default (512)
 MAX_LEN=0   # 0 = derive min(n_ctx, prompt+n_predict); -1 = saturate to n_ctx; >0 = explicit
 UBATCH=0    # 0 = llama default (512); #172 sweep knob, GGUF only
+KVQ8=0      # 1 = q8_0 KV + flash attention; #171 A/B knob, GGUF only
 N_RUNS=4    # warmup run 1 dropped; runs 2..N recorded individually (W1.1) → 3 by default
 PROMPT_FILE=""
 OUT_CSV=""
@@ -82,6 +86,10 @@ while [[ $# -gt 0 ]]; do
 	--ubatch)
 		UBATCH="${2:?--ubatch requires a value}"
 		shift 2
+		;;
+	--kv-q8)
+		KVQ8=1
+		shift
 		;;
 	--runs)
 		N_RUNS="${2:?--runs requires a value}"
@@ -341,6 +349,7 @@ printf '%d' "$N_PREDICT" >"${TMPDIR_LOCAL}/bench_npredict.txt"
 # value left by a previous run would otherwise stay in force.
 printf '%d' "$MAX_LEN" >"${TMPDIR_LOCAL}/bench_maxlen.txt"
 printf '%d' "$UBATCH" >"${TMPDIR_LOCAL}/bench_ubatch.txt"
+printf '%d' "$KVQ8" >"${TMPDIR_LOCAL}/bench_kvq8.txt"
 
 # bench.flag — consumed by app on each start; must be re-uploaded per run
 printf 'bench' >"${TMPDIR_LOCAL}/bench.flag"
@@ -391,6 +400,7 @@ for ((run = 1; run <= N_RUNS; run++)); do
 	upload_to_localstate "${TMPDIR_LOCAL}/bench_npredict.txt"
 	upload_to_localstate "${TMPDIR_LOCAL}/bench_maxlen.txt"
 	upload_to_localstate "${TMPDIR_LOCAL}/bench_ubatch.txt"
+	upload_to_localstate "${TMPDIR_LOCAL}/bench_kvq8.txt"
 	upload_to_localstate "${TMPDIR_LOCAL}/bench_run_index.txt"
 
 	echo "  Starting app..."
@@ -446,6 +456,15 @@ for ((run = 1; run <= N_RUNS; run++)); do
 			if [[ "$got_host" != *"-u${UBATCH}"* ]]; then
 				echo "Error: the console ignored --ubatch: host column says '${got_host}', asked -u${UBATCH}." >&2
 				echo "  The installed MSIX predates bench_ubatch.txt — redeploy before measuring." >&2
+				exit 1
+			fi
+		fi
+		# And for --kv-q8 (#171): require the -kvq8 host tag.
+		if ((KVQ8 != 0)); then
+			got_host=$(awk -F, '{print $15}' <<<"$data_row")
+			if [[ "$got_host" != *"-kvq8"* ]]; then
+				echo "Error: the console ignored --kv-q8: host column says '${got_host}'." >&2
+				echo "  The installed MSIX predates bench_kvq8.txt — redeploy before measuring." >&2
 				exit 1
 			fi
 		fi

--- a/scripts/profile-dml-run.sh
+++ b/scripts/profile-dml-run.sh
@@ -263,6 +263,7 @@ delete_file "" "bench_ctx.txt"
 delete_file "" "bench_npredict.txt"
 delete_file "" "bench_maxlen.txt"
 delete_file "" "bench_ubatch.txt"
+delete_file "" "bench_kvq8.txt"
 
 # Append-only log: remember current size to slice only the new tail later.
 download_file "" "xllama.log" "${TMPDIR_LOCAL}/xllama_before.log"

--- a/src/bridge/cli.cpp
+++ b/src/bridge/cli.cpp
@@ -35,6 +35,8 @@ static void print_help(const char* prog) {
                  "      --batch <N>      Logical prefill batch; 0 = llama default 2048\n"
                  "      --ubatch <N>     Physical prefill chunk (TTFT sweep knob);\n"
                  "                       0 = llama default 512\n"
+                 "      --kv-q8          q8_0 KV cache + flash attention (#171); falls\n"
+                 "                       back to F16 KV if the arch refuses flash attn\n"
                  "      --membw          Run the CPU memory-bandwidth micro-bench and\n"
                  "                       exit (no model needed); prints read/copy/triad GB/s\n"
                  "      --greedy         Deterministic argmax decode (implies logit parity);\n"
@@ -89,6 +91,7 @@ bool parse_cli_args(int argc, char** argv, InferenceParams& out) {
         {"top-k", required_argument, nullptr, 15},
         {"repetition-penalty", required_argument, nullptr, 16},
         {"system", required_argument, nullptr, 17},
+        {"kv-q8", no_argument, nullptr, 18},
         {"help", no_argument, nullptr, 'h'},
         {nullptr, 0, nullptr, 0}};
 
@@ -162,6 +165,9 @@ bool parse_cli_args(int argc, char** argv, InferenceParams& out) {
             break;
         case 17:
             out.system_prompt = optarg;
+            break;
+        case 18:
+            out.kv_q8 = true;
             break;
         case 'h':
             print_help(argv[0]);

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -477,8 +477,23 @@ InferenceResult run_inference_llama(const InferenceParams& params) {
     if (params.n_batch > 0 || params.n_ubatch > 0)
         log_output("[xllama] prefill batch override: n_batch=" + std::to_string(cparams.n_batch) +
                    " n_ubatch=" + std::to_string(cparams.n_ubatch) + "\n");
+    if (params.kv_q8) {
+        // #171: q8_0 KV needs flash attention (quantized V throws without it);
+        // mirror LlamaSession — force FA, fall back below if the arch refuses.
+        cparams.type_k = GGML_TYPE_Q8_0;
+        cparams.type_v = GGML_TYPE_Q8_0;
+        cparams.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_ENABLED;
+        log_output("[xllama] KV cache: q8_0 + flash attention (#171)\n");
+    }
 
     llama_context* raw_ctx = llama_init_from_model(model.get(), cparams);
+    if (!raw_ctx && params.kv_q8) {
+        log_output("[xllama] q8_0 KV context failed — falling back to default cache types\n");
+        cparams.type_k = llama_context_default_params().type_k;
+        cparams.type_v = llama_context_default_params().type_v;
+        cparams.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_AUTO;
+        raw_ctx = llama_init_from_model(model.get(), cparams);
+    }
     if (!raw_ctx) {
         res.error_msg = "failed to create context";
         log_output("[xllama] failed to create context\n");

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -485,10 +485,13 @@ class LlamaSession final : public Session {
     LlamaSamplerPtr m_sampler;
     SamplingConfig m_sampler_cfg;
 
+    bool m_kv_q8 = false; // #171: q8_0 KV + forced flash attention
+
     explicit LlamaSession(LlamaModelPtr model, LlamaAdapterLoraPtr adapter, float lora_scale,
-                          int n_ctx, int n_threads, int n_batch, int n_ubatch)
+                          int n_ctx, int n_threads, int n_batch, int n_ubatch, bool kv_q8)
         : m_model(std::move(model)), m_adapter(std::move(adapter)), m_lora_scale(lora_scale),
-          m_n_ctx(n_ctx), m_n_threads(n_threads), m_n_batch(n_batch), m_n_ubatch(n_ubatch) {}
+          m_n_ctx(n_ctx), m_n_threads(n_threads), m_n_batch(n_batch), m_n_ubatch(n_ubatch),
+          m_kv_q8(kv_q8) {}
 
     InferenceResult generate(const GenerateParams& gp) override {
         InferenceResult res;
@@ -505,7 +508,24 @@ class LlamaSession final : public Session {
                 cparams.n_batch = static_cast<uint32_t>(m_n_batch);
             if (m_n_ubatch > 0)
                 cparams.n_ubatch = static_cast<uint32_t>(m_n_ubatch);
+            if (m_kv_q8) {
+                // #171: quantized V requires flash attention (the pin throws at
+                // context creation with FA disabled, and AUTO may resolve to
+                // disabled) — force it and fall back below if the arch refuses.
+                cparams.type_k = GGML_TYPE_Q8_0;
+                cparams.type_v = GGML_TYPE_Q8_0;
+                cparams.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_ENABLED;
+            }
             m_ctx.reset(llama_init_from_model(m_model.get(), cparams));
+            if (!m_ctx && m_kv_q8) {
+                log_output("[xllama] session: q8_0 KV context failed — falling back "
+                           "to default cache types (#171)\n");
+                cparams.type_k = llama_context_default_params().type_k;
+                cparams.type_v = llama_context_default_params().type_v;
+                cparams.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_AUTO;
+                m_kv_q8 = false;
+                m_ctx.reset(llama_init_from_model(m_model.get(), cparams));
+            }
             if (!m_ctx) {
                 res.error_msg = "failed to create context";
                 log_output("[xllama] session generate: failed to create context\n");
@@ -722,7 +742,8 @@ std::unique_ptr<Session> create_llama(const SessionParams& sp, std::string* err)
     int n_ctx = sp.n_ctx > 0 ? sp.n_ctx : kDefaultNCtx;
     log_output("[xllama] Session: GGUF model loaded via llama.cpp (persistent)\n");
     return std::make_unique<LlamaSession>(LlamaModelPtr(raw_model), std::move(adapter),
-                                          sp.lora_scale, n_ctx, n_threads, sp.n_batch, sp.n_ubatch);
+                                          sp.lora_scale, n_ctx, n_threads, sp.n_batch, sp.n_ubatch,
+                                          sp.kv_q8);
 }
 } // namespace detail
 

--- a/uwp/inference-bridge.cpp
+++ b/uwp/inference-bridge.cpp
@@ -185,6 +185,9 @@ void main_loop() {
     // column — a row that does not carry the variable under study is not
     // interpretable (the Phase 12 lesson, twice).
     const int bench_ubatch = read_local_int("bench_ubatch.txt", 0);
+    // #171: q8_0 KV cache + flash attention A/B. Host-column tag -kvq8, same
+    // rationale as -uN (the CSV schema carries no cache-type column).
+    const int bench_kvq8 = read_local_int("bench_kvq8.txt", 0);
     // W1.1: which repetition this run is, written by the bench driver before each
     // iteration. Echoed into the CSV run_index column so the driver can append
     // every repeat and the summary generator can report a spread. 0 = single run.
@@ -226,6 +229,7 @@ void main_loop() {
     params.max_length_override = bench_maxlen;
     params.n_threads = bench_threads;           // 0 = auto; set by bench-xbox-ort.sh
     params.n_ubatch = bench_ubatch;             // #172: 0 = llama default (512)
+    params.kv_q8 = bench_kvq8 != 0;             // #171: q8_0 KV + flash attention
     params.stop_sequences = fmt.stop_sequences; // clean stop for Gemma's <end_of_turn>
     params.run_index = bench_run_index;         // W1.1: echo into CSV (0 = single-run)
 
@@ -235,7 +239,10 @@ void main_loop() {
         host_len +=
             snprintf(host_buf + host_len, sizeof(host_buf) - host_len, "-t%d", bench_threads);
     if (bench_ubatch > 0)
-        snprintf(host_buf + host_len, sizeof(host_buf) - host_len, "-u%d", bench_ubatch);
+        host_len +=
+            snprintf(host_buf + host_len, sizeof(host_buf) - host_len, "-u%d", bench_ubatch);
+    if (bench_kvq8 != 0)
+        snprintf(host_buf + host_len, sizeof(host_buf) - host_len, "-kvq8");
 
     InferenceResult res = ::xllama::run_inference(params);
     xllama::write_bench_csv(params, res, host_buf);


### PR DESCRIPTION
Second half of #171 (consolidation landed in PR #177). The knob is shipped and the decision is made on measurement.

**Implementation**: `--kv-q8` (CLI) / `SessionParams::kv_q8` / `bench_kvq8.txt` (+ `-kvq8` host tag, driver guard, and staleness cleanup in the kv/profile scripts) set `type_k/type_v = q8_0` and force flash attention — quantized V requires it (the pin refuses context creation otherwise). Both paths fall back to F16 KV on a context-creation failure, so an architecture that refuses FA still loads.

**Measurement** (host, `compare-logits.py`, real catalogue GGUFs):

| Model | NMSE | top-1 | KV @2048 |
|---|---|---|---|
| LFM2.5-350M (default, hybrid) | 8.25e-03 | **flips** | 24 → 12.75 MiB |
| SmolLM2-360M | 2.13e-03 | stable (top-10 0.90) | 80 → 42.5 MiB |
| FA alone (control) | **0.0 — bit-identical** | stable | — |

**Verdict — default stays OFF**: the drift is entirely from the quantization, it flips the argmax on the default model at a trivial prompt, and at `n_ctx` 2048 the −47% KV is 11–40 MiB against 320–1600 MB of weights. The knob's payoff arrives with the #169 context raise — revisit there, gated on H9.

Host: 140/140 tests, clang-format pinned, shellcheck, coherence OK.

Closes #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)