### PR TITLE
fix(#170a): honor seq_rm failure on hybrid KV (LFM2 regenerate corruption)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   near-tie divergence documented as inherent to prefix caching (the
   resident prefix was accumulated in a different batch shape, so K/V last
   bits differ). The record is cleared whenever a decode failure makes the
-  cache untrustworthy.
+  cache untrustworthy. _Scope note (see the #170a Fixed entry below): the
+  full rewind regime applies to pure-attention models; hybrid models keep
+  the pure-extension reuse and degrade divergent-tail turns to a full
+  re-prefill._
 
 ### Added
 
@@ -96,6 +99,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   KV-cache quantization stays open on #171, gated on measurement.
 
 ### Fixed
+
+- **The #170a rewind honored on hybrid KV caches (PR #183).**
+  `llama_memory_seq_rm(0, kv_keep, -1)` — the divergent-tail rewind — returns
+  `false` **without mutating anything** on hybrid attn+recurrent models
+  (LFM2/LFM2.5, the default chat model): the recurrent state cannot be
+  partially rewound (`n_rs_seq` is 0 for every arch except Qwen3.5). The
+  return value was ignored, so a regenerate decoded on top of a cache still
+  holding the old tail — corrupted output, reproduced with the opt-in test on
+  LFM2.5-350M. Now a pure extension skips `seq_rm` entirely (works on both
+  regimes) and a refused tail erase degrades to a full clear + re-prefill,
+  correct by construction (single-batch prefill ≡ fresh session,
+  byte-identical, asserted by the regime-aware test).
 
 - **Context overflow is predicted instead of discovered by a failed turn
   (#173, PR #177).** A continuation turn that cannot fit (KV + delta + at

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -604,12 +604,25 @@ class LlamaSession final : public Session {
                    m_kv_tokens[kv_keep] == tokens[kv_keep])
                 ++kv_keep;
             if (kv_keep > 0) {
-                llama_memory_seq_rm(mem, 0, static_cast<llama_pos>(kv_keep), -1);
-                char pb[128];
-                snprintf(pb, sizeof(pb),
-                         "[xllama] session: KV prefix reuse — kept %zu of %zu tokens (#170)\n",
-                         kv_keep, tokens.size());
-                log_output(pb);
+                // Pure extension (no divergent tail) needs no removal. When a
+                // tail must go, honor seq_rm's result: hybrid caches (LFM2's
+                // attn+recurrent) refuse a partial tail erase — the recurrent
+                // state cannot be rewound — and mutate NOTHING on failure, so
+                // decoding on top would corrupt the output. Degrade to a full
+                // clear + re-prefill instead.
+                if (kv_keep < m_kv_tokens.size() &&
+                    !llama_memory_seq_rm(mem, 0, static_cast<llama_pos>(kv_keep), -1)) {
+                    llama_memory_clear(mem, true);
+                    kv_keep = 0;
+                    log_output("[xllama] session: KV rewind unsupported (hybrid cache) — "
+                               "full re-prefill (#170)\n");
+                } else {
+                    char pb[128];
+                    snprintf(pb, sizeof(pb),
+                             "[xllama] session: KV prefix reuse — kept %zu of %zu tokens (#170)\n",
+                             kv_keep, tokens.size());
+                    log_output(pb);
+                }
             } else {
                 llama_memory_clear(mem, true);
             }

--- a/tests/test_session.cpp
+++ b/tests/test_session.cpp
@@ -173,33 +173,45 @@ TEST_CASE("Session: KV prefix reuse collapses a repeated prefill (opt-in: XLLAMA
     REQUIRE(r_cold.success);
     REQUIRE(r_cold.n_p_eval > 1);
 
-    // Regenerate: identical prompt on the same session. Everything but the
-    // final token (the logits source) is already resident.
+    // Regenerate: identical prompt on the same session. Two legal regimes:
+    // pure-attention caches rewind and re-prefill exactly 1 token (the logits
+    // source); hybrid caches (LFM2) cannot erase a partial tail — seq_rm
+    // returns false — so the session degrades to a full clear + re-prefill.
+    // Byte-identical output is the correctness bar in both regimes.
     const auto r_regen = sess->generate(mkgp(prompt));
     REQUIRE(r_regen.success);
-    CHECK(r_regen.n_p_eval == 1);
+    CHECK(r_regen.n_p_eval <= r_cold.n_p_eval);
     CHECK(r_regen.output_text == r_cold.output_text);
 
-    // Extended prompt (the LAN-API shape): only the extension past the common
-    // prefix re-prefills, and the rewound cache must reproduce a cold session
-    // token-for-token — the correctness half of the claim.
+    // Extended prompt (the LAN-API shape). This prompt diverges from the
+    // resident generated tail right after the original prompt, so it exercises
+    // the tail-removal path in both regimes.
+    const bool full_rewind = r_regen.n_p_eval == 1;
     const std::string ext = prompt + " Paris, and the capital of Italy is";
     const auto r_ext = sess->generate(mkgp(ext));
     REQUIRE(r_ext.success);
-    CHECK(r_ext.n_p_eval < sess->count_tokens(ext));
 
     auto fresh = xllama::Session::create(sp, &err);
     REQUIRE_MESSAGE(fresh, err);
     const auto r_fresh = fresh->generate(mkgp(ext));
     REQUIRE(r_fresh.success);
-    // Exact equality is the wrong bar here (it holds for the regenerate case
-    // above, where the resident bytes are identical): the resident prefix was
-    // accumulated in a different batch shape than the fresh session's single
-    // prefill, so the K/V last bits differ and greedy can flip at a NEAR-TIE
-    // downstream — inherent to every prefix cache, observed as " Rome." vs
-    // " Rome.\n\nThe answer is Paris.". The correctness signal is the leading
-    // strong-signal token agreeing.
-    REQUIRE(r_fresh.output_text.size() >= 5);
-    REQUIRE(r_ext.output_text.size() >= 5);
-    CHECK(r_ext.output_text.substr(0, 5) == r_fresh.output_text.substr(0, 5));
+    if (full_rewind) {
+        // Pure-attention: only the extension past the common prefix re-prefills.
+        CHECK(r_ext.n_p_eval < sess->count_tokens(ext));
+        // Exact equality is the wrong bar here (it holds for the regenerate
+        // case above, where the resident bytes are identical): the resident
+        // prefix was accumulated in a different batch shape than the fresh
+        // session's single prefill, so the K/V last bits differ and greedy can
+        // flip at a NEAR-TIE downstream — inherent to every prefix cache,
+        // observed as " Rome." vs " Rome.\n\nThe answer is Paris.". The
+        // correctness signal is the leading strong-signal token agreeing.
+        REQUIRE(r_fresh.output_text.size() >= 5);
+        REQUIRE(r_ext.output_text.size() >= 5);
+        CHECK(r_ext.output_text.substr(0, 5) == r_fresh.output_text.substr(0, 5));
+    } else {
+        // Hybrid (LFM2): the divergent tail cannot be erased — seq_rm refuses —
+        // so the session must have degraded to a full clear + single-batch
+        // re-prefill, which is exactly a fresh session: byte-identical output.
+        CHECK(r_ext.output_text == r_fresh.output_text);
+    }
 }


### PR DESCRIPTION
## Bug

`llama_memory_seq_rm(mem, 0, kv_keep, -1)` — the #170a divergent-tail rewind — **returns false without mutating the cache** on hybrid attn+recurrent models, which includes **LFM2.5, the default chat model**. The recurrent branch requires a partial-rollback snapshot budget (`n_rs_seq`), which is 0 by default and force-clamped to 0 for every arch except Qwen3.5 (`llama-context.cpp:104`). The return value was ignored at `session.cpp:607`, so the tail decode landed on a cache still holding the old tail, with `m_kv_tokens` out of sync.

Reproduced on main (ca91b32): the opt-in test fails 2 assertions on LFM2.5 — regenerate output corrupted (`" correct?"` vs cold) and extended-prompt divergent. (The pass recorded in the #170a session is not reproducible with this binary/model; the mechanism is unambiguous from the pin source.) The console is **not** affected — it runs the pre-#170a PR-179 build — but this must land before any redeploy.

## Fix

- Pure extension (`kv_keep == m_kv_tokens.size()`, the LAN-API/new-turn shape): skip `seq_rm` — nothing to remove, and it avoids the hybrid false-negative. Works on both regimes.
- Divergent tail: honor the bool. On `false` → `llama_memory_clear` + `kv_keep = 0` + one-line log → correct full re-prefill.
- Net behavior: pure-attention models keep the full rewind (regenerate re-prefills 1 token); hybrids keep KV reuse for extensions and degrade regenerate/edit to a **correct** full re-prefill.

## Test

Opt-in test is now regime-aware (regime detected via `r_regen.n_p_eval == 1`):
- regenerate: `n_p_eval <= cold` + byte-identical output (both regimes);
- extended prompt: pure-attention keeps partial-prefill + near-tie-tolerant leading-token check; hybrid asserts **byte-identical to a fresh session** (full clear + single-batch prefill ≡ fresh) — a stronger bar than before.

Verified: opt-in PASS on LFM2.5-350M Q4_K_M (hybrid); full suite 141/141; clang-format 22.1.5 clean; coherence gate exit 0.

Refs #170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)