### PR TITLE
perf(#169): context shift — long chats keep KV reuse past the token budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Performance
 
+- **Context shift: long chats keep KV reuse past the token budget (#169).**
+  Once a conversation exceeded `kMaxPromptTokens` (1800), the UI trimmer set
+  `n_dropped > 0` on every later turn, which forced a full ~1800-token
+  re-prefill each time — exactly the regime where prefill costs the most.
+  Now a continuation turn that would overflow `n_ctx` evicts the oldest
+  resident tokens past the pinned system prefix (`GenerateParams::n_keep`,
+  computed from the new `ChatFormat::render_system_prefix`) with an
+  upstream-style front-drop `llama_memory_seq_rm` + RoPE `seq_add`, compacts
+  `m_kv_tokens`, and appends the delta; the UI's reuse decision drops the
+  `n_dropped == 0` requirement on the llama backend. Gated on
+  `llama_memory_can_shift` + no SWA — `seq_add` on an unsupported arch is a
+  `GGML_ASSERT` abort, and both catalogue GGUFs needed the gate's two sides:
+  LFM2.5 (hybrid, shiftable) evicts and keeps every overflowing turn alive
+  (host test at n_ctx 256); Qwen3.5 (imrope, not shiftable) keeps the clean
+  #173 fail-fast that the UI's full-prefill retry keys on. The sampler chain
+  survives a shift (it is a continuation — #175), and the hybrid recurrent
+  state retains its absorbed history across evictions (documented
+  approximation, console quality gates to confirm). `n_predict_eff` is now
+  clamped at 0 so an oversized full prompt yields a clean zero-token result.
+
 - **In-memory KV prefix matching (#170 step a).** A full-prompt turn on
   `LlamaSession` used to clear the cache and re-prefill everything;
   it now rewinds to the common token prefix with the resident KV

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -239,9 +239,18 @@ fix.
       P=298/1000, decode neutral, no livelock at 6 prefill threads
       (`bench/results/phase13b-threadsbatch-{before,after}.csv`, §5f). GGUF
       headline is now 438.1 prefill / 94.9 decode.
-- [ ] **#169 — the context trimmer permanently disables KV reuse** once a chat
-      exceeds `kMaxPromptTokens`: every later turn pays a full ~1800-token
-      re-prefill. Candidate: context shift (`llama_memory_seq_rm`/`seq_add`) + delta prefill. Highest impact, medium-high risk.
+- [~] **#169 — context shift lands: long chats keep KV reuse past the token
+  budget.** Landed 2026-07-26: when a continuation turn would overflow
+  `n_ctx`, `LlamaSession` evicts the oldest resident tokens past the
+  pinned system prefix (`GenerateParams::n_keep`, upstream-style
+  front-drop `seq_rm` + RoPE `seq_add`, `m_kv_tokens` compacted) instead
+  of failing, and the UI's `do_reuse` no longer requires `n_dropped == 0`
+  on the llama backend. Gated on `llama_memory_can_shift` + no SWA —
+  **both catalogue GGUF archs verified on host**: LFM2.5 (hybrid) shifts
+  (evicted 117 past keep=11 at n_ctx 256, 8 overflowing turns all
+  succeed); Qwen3.5 (imrope, cannot shift — `seq_add` would abort) keeps
+  the clean #173 fail-fast the UI retry keys on. Remaining: console
+  long-chat validation (TTFT O(delta) past 1800 tokens) at next deploy.
 - [~] **#170 — token-level KV prefix matching.** **Step (a) landed
   (2026-07-26): in-memory prefix diff in `LlamaSession`** — a full-prompt
   turn rewinds the resident KV to the common token prefix
@@ -251,10 +260,14 @@ fix.
   token — near-tie divergence downstream is inherent to any prefix
   cache, the resident prefix was accumulated in a different batch
   shape). Covers regenerate, edited last message, and LAN-API extension
-  requests through the resident hub session. Step (b) remains: KV
-  persisted to disk (`llama_state_seq_save_file`, eviction policy) for
-  conversation switch across sessions; folds the ex-#174 BuildPrompt
-  item too.
+  requests through the resident hub session. **Hybrid correction (PR
+  #183):** hybrid caches (both catalogue GGUFs) refuse the tail rewind at
+  the `llama_memory` layer — the ignored `seq_rm` return corrupted
+  regenerate output; now a pure extension skips `seq_rm` and a refused
+  erase degrades to a correct full re-prefill (regime-aware opt-in test).
+  Step (b) remains: KV persisted to disk (`llama_state_seq_save_file`,
+  eviction policy) for conversation switch across sessions; folds the
+  ex-#174 BuildPrompt item too.
 - [x] **#171 — KV quantization measured; verdict: knob shipped, default
       OFF.** Consolidation half landed first (PR #177: `kDefaultNCtx`, domain
       test). The q8_0+flash-attn knob (`--kv-q8`, `SessionParams::kv_q8`,

--- a/include/xllama/chat_prompt.h
+++ b/include/xllama/chat_prompt.h
@@ -88,6 +88,13 @@ struct ChatFormat {
     // the n_predict cap.
     std::string render_delta(const std::string& user, bool prev_ended_with_stop) const;
 
+    // #169: the exact prefix render_prompt emits before the first user turn —
+    // what a context shift must pin (GenerateParams::n_keep is its token
+    // count). Empty for MergeIntoFirstUser formats (Gemma), whose system text
+    // lives inside the first user turn and cannot be pinned separately;
+    // count_tokens("") still pins the BOS.
+    std::string render_system_prefix(const std::string& system) const;
+
     // Output post-processing before display/persist (strips empty <think> blocks;
     // no-op for Gemma).
     std::string postprocess_output(std::string text) const;

--- a/include/xllama/session.h
+++ b/include/xllama/session.h
@@ -89,8 +89,23 @@ struct GenerateParams {
     //                                reset_kv = false to reuse it.
     // On any failure of a continuation turn the session drops its chat state and
     // reports !success so the caller can retry with reset_kv + the full prompt.
+    // Exception (#169): when the session supports context shift
+    // (can_context_shift()), a continuation turn that would overflow n_ctx
+    // evicts the oldest tokens past n_keep from the resident KV instead of
+    // failing, so long chats stay in the reuse regime past the token budget.
     bool reuse_kv = false;
     bool reset_kv = false;
+
+    // #169: number of leading prompt tokens pinned across context shifts —
+    // the system prompt (plus BOS), which must survive any eviction. 0 = no
+    // pinned head. Callers compute it once per conversation via
+    // count_tokens() on the system-only render. Ignored by sessions that
+    // cannot shift (ORT, and any arch where llama_memory_can_shift is
+    // false — those keep the fail-fast path). Hybrid caches accept the
+    // front-drop erase (unlike #170a's tail rewind): the recurrent state
+    // holds no cells in the evicted range, only its absorbed history —
+    // an approximation the quality gates measure.
+    int n_keep = 0;
 
     // on_token receives a view into a per-iteration buffer: copy it before
     // the callback returns.
@@ -110,6 +125,15 @@ struct Session {
 
     // Token count for routing/heuristics (encode-only; no generation).
     virtual int count_tokens(const std::string& prompt) = 0;
+
+    // #169: whether a continuation turn that would overflow n_ctx evicts the
+    // oldest tokens (RoPE shift) instead of failing. False for ORT and for
+    // llama archs whose cache cannot shift (llama_memory_can_shift). Callers
+    // use it to keep the KV-reuse path for long chats instead of falling back
+    // to trimmed full prefills.
+    virtual bool can_context_shift() const {
+        return false;
+    }
 
     virtual ~Session() = default;
 };

--- a/src/bridge/chat_prompt.cpp
+++ b/src/bridge/chat_prompt.cpp
@@ -149,15 +149,20 @@ ChatFormat chat_format_for(const std::string& model_id) {
     return f;
 }
 
+std::string ChatFormat::render_system_prefix(const std::string& system) const {
+    // Must stay byte-identical to what render_prompt emits before the first
+    // user turn — a context shift pins exactly this many tokens (#169).
+    if (system_style == SystemStyle::DedicatedTurn)
+        return turn_open + system_tag + role_sep + system + turn_close;
+    return {};
+}
+
 std::string ChatFormat::render_prompt(const std::string& system,
                                       const std::vector<ChatTurn>& history,
                                       const std::string& final_user) const {
-    std::string p;
-
     // System: dedicated turn (ChatML / Llama-3, emitted unconditionally) or
     // merged into the first user turn (Gemma).
-    if (system_style == SystemStyle::DedicatedTurn)
-        p += turn_open + system_tag + role_sep + system + turn_close;
+    std::string p = render_system_prefix(system);
 
     bool sys_pending = (system_style == SystemStyle::MergeIntoFirstUser) && !system.empty();
     auto user_content = [&](const std::string& u) -> std::string {

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -495,6 +495,13 @@ class LlamaSession final : public Session {
 
     bool m_kv_q8 = false; // #171: q8_0 KV + forced flash attention
 
+    // #169: whether the resident KV supports front-drop eviction + RoPE shift.
+    // Known once the lazy context exists. Gated on llama_memory_can_shift —
+    // seq_add on an unsupported arch (mrope) is a GGML_ASSERT abort, not an
+    // error — and on the model not using SWA, where the resident window is
+    // not [0, kv_len) and the shift arithmetic below would lie.
+    bool m_can_shift = false;
+
     explicit LlamaSession(LlamaModelPtr model, LlamaAdapterLoraPtr adapter, float lora_scale,
                           int n_ctx, int n_threads, int n_batch, int n_ubatch, bool kv_q8)
         : m_model(std::move(model)), m_adapter(std::move(adapter)), m_lora_scale(lora_scale),
@@ -539,6 +546,8 @@ class LlamaSession final : public Session {
                 log_output("[xllama] session generate: failed to create context\n");
                 return res;
             }
+            m_can_shift = llama_memory_can_shift(llama_get_memory(m_ctx.get())) &&
+                          llama_model_n_swa(m_model.get()) == 0;
             // Apply runtime LoRA after context exists (llama_set_adapters_lora is
             // context-scoped). Must re-apply if context is ever recreated.
             if (m_adapter) {
@@ -635,18 +644,54 @@ class LlamaSession final : public Session {
         // retries with the trimmed full prompt. The same arithmetic clamps the
         // generation loop below so hitting the context end is a clean stop,
         // not a mid-generation decode failure.
-        const int kv_len = full_prompt ? static_cast<int>(kv_keep)
-                                       : static_cast<int>(llama_memory_seq_pos_max(mem, 0)) + 1;
+        int kv_len = full_prompt ? static_cast<int>(kv_keep)
+                                 : static_cast<int>(llama_memory_seq_pos_max(mem, 0)) + 1;
         // The slice that is not yet resident: the divergent tail on a full
         // prompt, the whole delta on a continuation.
         llama_token* pf = tokens.data() + (full_prompt ? kv_keep : 0);
         const int n_pf = static_cast<int>(tokens.size()) - (full_prompt ? (int)kv_keep : 0);
         if (!full_prompt && kv_len + n_pf + 1 > m_n_ctx) {
-            res.error_msg = "context full: kv=" + std::to_string(kv_len) +
-                            " + delta=" + std::to_string(n_pf) +
-                            " exceeds n_ctx=" + std::to_string(m_n_ctx);
-            log_output(("[xllama] session generate: " + res.error_msg + "\n").c_str());
-            return res;
+            // #169: context shift — evict the oldest tokens past the pinned
+            // head (gp.n_keep, the system prompt) and RoPE-shift the survivors
+            // down, so a long chat stays in the reuse regime instead of
+            // falling back to trimmed ~n_ctx re-prefills every turn. Eviction
+            // is upstream-style (server-context.cpp): at least half the
+            // movable region, or more when the delta + requested generation
+            // need it. The recurrent half of a hybrid cache holds no cells in
+            // the evicted range (its absorbed history survives — a documented
+            // approximation), so the front-drop seq_rm succeeds where #170a's
+            // tail rewind cannot.
+            bool shifted = false;
+            if (m_can_shift && kv_len > 0 && static_cast<int>(m_kv_tokens.size()) == kv_len) {
+                const int keep = std::min(std::max(gp.n_keep, 0), kv_len - 1);
+                const int movable = kv_len - keep;
+                const int need = kv_len + n_pf + std::max(gp.n_predict, 1) - m_n_ctx;
+                const int n_discard = std::min(std::max(need, movable / 2), movable);
+                if (n_discard > 0 && kv_len + n_pf + 1 - n_discard <= m_n_ctx &&
+                    llama_memory_seq_rm(mem, 0, keep, keep + n_discard)) {
+                    llama_memory_seq_add(mem, 0, keep + n_discard, -1, -n_discard);
+                    m_kv_tokens.erase(m_kv_tokens.begin() + keep,
+                                      m_kv_tokens.begin() + keep + n_discard);
+                    kv_len -= n_discard;
+                    shifted = true;
+                    char sb[160];
+                    snprintf(sb, sizeof(sb),
+                             "[xllama] session: context shift — evicted %d tokens past "
+                             "keep=%d, kv now %d of %d (#169)\n",
+                             n_discard, keep, kv_len, m_n_ctx);
+                    log_output(sb);
+                }
+            }
+            if (!shifted) {
+                // #173 fail-fast: the caller retries with the trimmed full
+                // prompt. Reached when the cache cannot shift, the bookkeeping
+                // is out of sync, or even a full eviction would not fit.
+                res.error_msg = "context full: kv=" + std::to_string(kv_len) +
+                                " + delta=" + std::to_string(n_pf) +
+                                " exceeds n_ctx=" + std::to_string(m_n_ctx);
+                log_output(("[xllama] session generate: " + res.error_msg + "\n").c_str());
+                return res;
+            }
         }
 
         // Prefill: positions continue automatically from the KV cache end, so a
@@ -691,8 +736,9 @@ class LlamaSession final : public Session {
         const auto t_decode0 = std::chrono::steady_clock::now();
 
         // Clean stop at the context end (#173): each generated token needs a KV
-        // slot, so the loop must not outrun n_ctx - (kv_len + prompt).
-        const int n_predict_eff = std::min(gp.n_predict, m_n_ctx - kv_len - n_pf);
+        // slot, so the loop must not outrun n_ctx - (kv_len + prompt). Clamped
+        // at 0 — an oversized full prompt yields a clean zero-token result.
+        const int n_predict_eff = std::max(0, std::min(gp.n_predict, m_n_ctx - kv_len - n_pf));
 
         while (n_generated < n_predict_eff) {
             if (gp.abort_flag && gp.abort_flag->load())
@@ -752,6 +798,10 @@ class LlamaSession final : public Session {
         if (n == INT32_MIN)
             return 0;
         return -n;
+    }
+
+    bool can_context_shift() const override {
+        return m_can_shift;
     }
 };
 

--- a/tests/test_chat_prompt.cpp
+++ b/tests/test_chat_prompt.cpp
@@ -272,3 +272,19 @@ TEST_CASE("kv-reuse invariant holds for chatml, gemma, llama3, and phi3") {
     check_kv_reuse_invariant(chat_format_for("llama32-3b"));
     check_kv_reuse_invariant(chat_format_for("phi35-mini"));
 }
+
+TEST_CASE("render_system_prefix is the exact head of render_prompt (#169)") {
+    const std::string sys = "You are terse.";
+    // DedicatedTurn formats: the prefix must be byte-identical to what
+    // render_prompt emits before the first user turn — a context shift pins
+    // exactly its token count.
+    for (const char* id : {"smollm2-360m-cpu-int4", "llama32-3b", "phi35-mini"}) {
+        const ChatFormat f = chat_format_for(id);
+        const std::string prefix = f.render_system_prefix(sys);
+        CHECK(!prefix.empty());
+        CHECK(f.render_prompt(sys, {}, "hi").rfind(prefix, 0) == 0);
+    }
+    // MergeIntoFirstUser (Gemma): no standalone system block exists — the
+    // prefix is empty and the caller pins only the BOS.
+    CHECK(chat_format_for("gemma3-270m").render_system_prefix(sys).empty());
+}

--- a/tests/test_session.cpp
+++ b/tests/test_session.cpp
@@ -215,3 +215,75 @@ TEST_CASE("Session: KV prefix reuse collapses a repeated prefill (opt-in: XLLAMA
         CHECK(r_ext.output_text == r_fresh.output_text);
     }
 }
+
+// #169: a continuation turn that would overflow n_ctx evicts the oldest
+// resident tokens past n_keep (front-drop + RoPE shift) instead of failing,
+// so a long chat never leaves the reuse regime. Opt-in — needs a real GGUF:
+//   XLLAMA_TEST_MODEL=/path/to/model.gguf ./xllama-tests
+TEST_CASE(
+    "Session: context shift keeps continuations alive past n_ctx (opt-in: XLLAMA_TEST_MODEL)") {
+    const char* model_env = std::getenv("XLLAMA_TEST_MODEL");
+    if (!model_env)
+        return;
+
+    xllama::SessionParams sp;
+    sp.model_path = model_env;
+    sp.n_ctx = 256; // small on purpose: a few turns must overflow it
+    std::string err;
+    auto sess = xllama::Session::create(sp, &err);
+    REQUIRE_MESSAGE(sess, err);
+
+    const std::string sys = "<|im_start|>system\nYou are terse.<|im_end|>\n";
+    const int n_keep = sess->count_tokens(sys);
+    REQUIRE(n_keep > 0);
+
+    // Seed the persistent context (reuse + reset).
+    xllama::GenerateParams seed;
+    seed.prompt = sys + "<|im_start|>user\nSay ok.<|im_end|>\n<|im_start|>assistant\n";
+    seed.n_predict = 32;
+    seed.temperature = 0.0f;
+    seed.reuse_kv = true;
+    seed.reset_kv = true;
+    seed.n_keep = n_keep;
+    const auto r_seed = sess->generate(seed);
+    REQUIRE_MESSAGE(r_seed.success, r_seed.error_msg);
+
+    // Enough continuation turns to overflow n_ctx=256 several times over.
+    // Capability decides the contract (known once the lazy context exists):
+    // LFM2 and pure-attention archs shift, so every turn must succeed;
+    // an arch that cannot shift (Qwen3.5's imrope cache — seq_add would be
+    // a GGML_ASSERT abort, which the gate must prevent) keeps the #173
+    // fail-fast, so the overflowing turn must fail CLEANLY with n_eval == 0 —
+    // the exact signature the UI's full-prefill retry keys on.
+    const bool shifts = sess->can_context_shift();
+    int total_tokens = sess->count_tokens(seed.prompt) + r_seed.n_eval;
+    bool saw_clean_overflow = false;
+    for (int i = 0; i < 8; ++i) {
+        xllama::GenerateParams cont;
+        cont.prompt = "<|im_end|>\n<|im_start|>user\nAnd again, tell me more "
+                      "about that, please.<|im_end|>\n<|im_start|>assistant\n";
+        cont.n_predict = 48;
+        cont.temperature = 0.0f;
+        cont.reuse_kv = true;
+        cont.reset_kv = false;
+        cont.n_keep = n_keep;
+        const auto rc = sess->generate(cont);
+        if (shifts) {
+            REQUIRE_MESSAGE(rc.success, rc.error_msg);
+            CHECK(rc.n_p_eval > 0);
+        } else if (!rc.success) {
+            CHECK(rc.n_eval == 0);
+            CHECK(rc.error_msg.find("context full") != std::string::npos);
+            saw_clean_overflow = true;
+            break;
+        }
+        total_tokens += rc.n_p_eval + rc.n_eval;
+    }
+    if (shifts) {
+        // The conversation genuinely outgrew the context — the loop above
+        // only proves the point if eviction actually had to happen.
+        CHECK(total_tokens > sp.n_ctx);
+    } else {
+        CHECK(saw_clean_overflow);
+    }
+}

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -2656,7 +2656,13 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
     // GGUF/llama.cpp (persistent llama_context in LlamaSession). ep_kv_ok still
     // excludes the DirectML routing model (continuous decoding unsupported there).
     const bool ep_kv_ok = ::xllama::kv_reuse_supported_for_model(routed_model);
-    bool do_reuse = m_kv_reuse && m_kv_valid && n_dropped == 0 && ep_kv_ok;
+    // #169: on the llama backend a trimmed round no longer forces a full
+    // re-prefill — the session evicts the oldest resident tokens (context
+    // shift) when the delta would overflow n_ctx, keeping long chats in the
+    // reuse regime. If the arch cannot shift, the continuation fail-fasts
+    // (#173) and the retry below re-seeds with the trimmed full prompt.
+    const bool shift_capable = ::xllama::model_uses_llama_backend(routed_model);
+    bool do_reuse = m_kv_reuse && m_kv_valid && (n_dropped == 0 || shift_capable) && ep_kv_ok;
     bool kv_reuse = m_kv_reuse && ep_kv_ok;
     std::string delta_prompt = do_reuse ? BuildDeltaPrompt(user_text) : std::string();
 
@@ -2677,8 +2683,14 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
     // on the UI thread (chat_format() reads m_model_filename) and captured by value.
     xllama::ChatFormat fmt = chat_format();
 
+    // #169: the pinned head a context shift must never evict — the system
+    // block render_prompt puts before the first user turn. Rendered here
+    // (m_system_prompt is UI-thread state) and tokenized per turn in the
+    // worker, where the session is available.
+    const std::string sys_prefix = fmt.render_system_prefix(m_system_prompt);
+
     std::thread([self, full_prompt, delta_prompt, do_reuse, kv_reuse, ep_kv_ok, model, fmt,
-                 dispatcher]() mutable {
+                 sys_prefix, dispatcher]() mutable {
         try {
             // One hub lock for the whole turn: the resident session cannot be
             // swapped from under us (LAN API requests report busy meanwhile,
@@ -2744,6 +2756,11 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
                 gp.stop_sequences = fmt.stop_sequences;
                 gp.reuse_kv = reuse;
                 gp.reset_kv = reset;
+                // count_tokens matches generate()'s full-prompt tokenization
+                // (BOS included), and the system block ends on a special
+                // token, so the boundary is exact. Ignored unless a context
+                // shift actually runs (#169).
+                gp.n_keep = self->m_turn_session->count_tokens(sys_prefix);
                 gp.on_status = on_status;
                 gp.on_token = on_token;
                 return self->m_turn_session->generate(gp);


### PR DESCRIPTION
## Problem

`do_reuse` requires `n_dropped == 0`, and `n_dropped` is recomputed every turn against `kMaxPromptTokens` (1800) — once a conversation exceeds the budget, **every** later turn pays a full ~1800-token re-prefill, exactly where prefill costs the most (#169).

## Design

Upstream-style context shift inside `LlamaSession` (`server-context.cpp` shape, graceful degradation, never `GGML_ABORT`):

- On a continuation overflow (`kv_len + n_pf + 1 > n_ctx`): evict `n_discard = max(need, movable/2)` tokens after the pinned head with `llama_memory_seq_rm(0, keep, keep+n_discard)` (bool honored) + `llama_memory_seq_add(..., -n_discard)`, compact `m_kv_tokens` (#170a's record is the position bookkeeping), recompute `kv_len`, proceed with the delta. `need` includes generation headroom (`n_predict`).
- **`GenerateParams::n_keep`** — the pinned head. The UI renders the system block via the new `ChatFormat::render_system_prefix` (byte-identical head of `render_prompt`, invariant-tested across ChatML/Llama3/Phi3; empty for Gemma's merge style → BOS-only pin) and tokenizes it per turn with `count_tokens` (BOS included → exact boundary, the block ends on a special token).
- **Capability gate** `Session::can_context_shift()`: `llama_memory_can_shift` + `llama_model_n_swa == 0`, cached at lazy context creation. Critical: `seq_add` on an mrope/imrope arch is a `GGML_ASSERT` **abort**.
- UI: `do_reuse` requires `(n_dropped == 0 || llama backend)`; if the arch can't shift, the #173 fail-fast still triggers the existing trimmed-full-prefill retry — no capability plumbing needed on the UI thread.
- Sampler chain survives a shift (a shift is a continuation — #175 state follows the KV).
- API server unchanged (stateless).

## Verified on host — both catalogue GGUF archs, both sides of the gate

- **LFM2.5-350M (hybrid, shiftable)**: at `n_ctx` 256, 8 overflowing continuation turns all succeed — `context shift — evicted 117 tokens past keep=11, kv now 128 of 256`. The recurrent state keeps its absorbed history across evictions (documented approximation; console quality gates to confirm).
- **Qwen3.5-0.8B (imrope, `can_shift == false`)**: the gate holds — no abort, the overflowing turn fails **cleanly** with `context full` and `n_eval == 0`, the exact signature the UI retry keys on.
- Full suite 143/143; `render_system_prefix` invariant test; clang-format 22.1.5 clean; coherence + bench-summary gates exit 0.

Also clamps `n_predict_eff` at 0 (oversized full prompt → clean zero-token result).

## Remaining

Console long-chat validation at next deploy (TTFT O(delta) past 1800 tokens, `bench-xbox-kv.sh` turn-2 speedup unchanged) — issue #169 stays open until measured.

Closes nothing yet. Refs #169, #170, #173, #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)