### PR TITLE
perf(#170b): persist per-conversation KV snapshots to disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Performance
 
+- **KV snapshots on disk: switching conversations no longer re-reads the
+  history (#170 step b).** Leaving a conversation now writes its resident KV
+  to `LocalState\kv\<id>.kv`, and the first turn after coming back restores it
+  instead of prefilling from scratch. Measured on host (LFM2.5, n*ctx 2048): a
+  1476-token conversation is a **17.6 MB file** (12 KiB/token) that saves in
+  **21 ms** and loads in **33 ms** — against the **4532 ms** full re-prefill
+  the same conversation costs on console. The restore changes nothing about
+  the turn itself: it stays a full-prompt turn whose #170a prefix diff
+  collapses to the new user message, which is also why a stale snapshot is
+  harmless — it can only degrade to the prefill that would have happened
+  anyway, never to a wrong reply. The file carries a fingerprint (model
+  identity, `n_ctx`, KV quantization, LoRA) because llama.cpp's per-sequence
+  state path validates cache \_shape* only, so two different models of the same
+  shape would otherwise load each other's cache and emit silent garbage.
+  Writes are atomic (temp + rename) and moved in 8 MB chunks, under the 16 MB
+  bound §9 established for AppContainer reads. The pool is capped by both file
+  count and total bytes (`KvStore`, 3 files / 192 MB, least-recently-modified
+  evicted first, host-tested) so it cannot eat the ~2.2 GB Dev Mode budget;
+  deleting a conversation deletes its snapshot.
+
 - **Context shift: long chats keep KV reuse past the token budget (#169).**
   Once a conversation exceeded `kMaxPromptTokens` (1800), the UI trimmer set
   `n_dropped > 0` on every later turn, which forced a full ~1800-token
@@ -128,6 +148,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   KV-cache quantization stays open on #171, gated on measurement.
 
 ### Fixed
+
+- **Deleting the conversation you are viewing no longer brings it back.**
+  Both "Delete" and "Clear all conversations" removed the files and then
+  called `NewChat()`, whose first act is `SaveCurrentConversation()` — and
+  `m_current` still held the deleted conversation, so it was written straight
+  back to disk and re-indexed. The in-memory copy is now dropped before
+  `NewChat()`. Found while wiring #170b, whose snapshot would have been
+  re-created by the same path.
 
 - **The #170a rewind honored on hybrid KV caches (PR #183).**
   `llama_memory_seq_rm(0, kv_keep, -1)` — the divergent-tail rewind — returns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,16 +35,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **KV snapshots on disk: switching conversations no longer re-reads the
   history (#170 step b).** Leaving a conversation now writes its resident KV
   to `LocalState\kv\<id>.kv`, and the first turn after coming back restores it
-  instead of prefilling from scratch. Measured on host (LFM2.5, n*ctx 2048): a
-  1476-token conversation is a **17.6 MB file** (12 KiB/token) that saves in
-  **21 ms** and loads in **33 ms** — against the **4532 ms** full re-prefill
-  the same conversation costs on console. The restore changes nothing about
+  instead of prefilling from scratch. Measured on host at `n_ctx` 2048 on both
+  catalogue GGUF models: LFM2.5 writes **17.6 MB** for 1476 tokens (12
+  KiB/token, save 21 ms, load 33 ms), Qwen3.5-0.8B **36.5 MB** for 1472 (25
+  KiB/token, save 124 ms, load 301 ms) — against the **4532 ms** full
+  re-prefill a conversation of that length costs on console. The restore changes nothing about
   the turn itself: it stays a full-prompt turn whose #170a prefix diff
   collapses to the new user message, which is also why a stale snapshot is
   harmless — it can only degrade to the prefill that would have happened
   anyway, never to a wrong reply. The file carries a fingerprint (model
   identity, `n_ctx`, KV quantization, LoRA) because llama.cpp's per-sequence
-  state path validates cache \_shape* only, so two different models of the same
+  state path validates cache **shape** only, so two different models of the same
   shape would otherwise load each other's cache and emit silent garbage.
   Writes are atomic (temp + rename) and moved in 8 MB chunks, under the 16 MB
   bound §9 established for AppContainer reads. The pool is capped by both file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ add_subdirectory(llama.cpp)
 add_library(xllama STATIC
     src/bridge/inference.cpp
     src/bridge/session.cpp
+    src/bridge/kv_store.cpp
     src/bridge/bench.cpp
     src/bridge/membw.cpp
     src/bridge/platform.cpp

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -270,9 +270,18 @@ fix.
   the `llama_memory` layer — the ignored `seq_rm` return corrupted
   regenerate output; now a pure extension skips `seq_rm` and a refused
   erase degrades to a correct full re-prefill (regime-aware opt-in test).
-  Step (b) remains: KV persisted to disk (`llama_state_seq_save_file`,
-  eviction policy) for conversation switch across sessions; folds the
-  ex-#174 BuildPrompt item too.
+  **Step (b) landed (2026-07-27):** leaving a conversation writes its KV
+  to `LocalState\kv\<id>.kv` and the first turn back restores it, so the
+  switch costs a delta prefill instead of the history. Host-measured on
+  LFM2.5 at n_ctx 2048: 17.6 MB for 1476 tokens (12 KiB/token), save 21
+  ms, load 33 ms, against the 4532 ms console re-prefill. Fingerprinted
+  (model, n_ctx, KV quant, LoRA) because the pin validates cache shape
+  only; atomic writes in 8 MB chunks (§9 AppContainer bound); `KvStore`
+  caps the pool at 3 files / 192 MB, LRU, host-tested. A stale snapshot
+  is harmless by construction — the #170a diff turns it into the prefill
+  that would have happened anyway. Remaining on this issue: the ex-#174
+  BuildPrompt-off-the-UI-thread item, and console confirmation of the
+  switch-and-return path at the next deploy.
 - [x] **#171 — KV quantization measured; verdict: knob shipped, default
       OFF.** Consolidation half landed first (PR #177: `kDefaultNCtx`, domain
       test). The q8_0+flash-attn knob (`--kv-q8`, `SessionParams::kv_q8`,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -272,9 +272,11 @@ fix.
   erase degrades to a correct full re-prefill (regime-aware opt-in test).
   **Step (b) landed (2026-07-27):** leaving a conversation writes its KV
   to `LocalState\kv\<id>.kv` and the first turn back restores it, so the
-  switch costs a delta prefill instead of the history. Host-measured on
-  LFM2.5 at n_ctx 2048: 17.6 MB for 1476 tokens (12 KiB/token), save 21
-  ms, load 33 ms, against the 4532 ms console re-prefill. Fingerprinted
+  switch costs a delta prefill instead of the history. Host-measured at
+  `n_ctx` 2048 on both catalogue GGUFs: LFM2.5 17.6 MB / 1476 tokens (12
+  KiB/token, save 21 ms, load 33 ms), Qwen3.5-0.8B 36.5 MB / 1472 (25
+  KiB/token, save 124 ms, load 301 ms) — against the 4532 ms console
+  re-prefill. Fingerprinted
   (model, n_ctx, KV quant, LoRA) because the pin validates cache shape
   only; atomic writes in 8 MB chunks (§9 AppContainer bound); `KvStore`
   caps the pool at 3 files / 192 MB, LRU, host-tested. A stale snapshot

--- a/include/xllama/kv_store.h
+++ b/include/xllama/kv_store.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2024 Gianluca Mazza
+// SPDX-License-Identifier: MIT
+// xllama::KvStore — on-disk KV snapshots, one per conversation (#170b).
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace xllama {
+
+// A snapshot is cached work, never a source of truth: any of them may be
+// missing, stale, or refused at load time, and every caller must fall back to
+// a normal prefill. That is what makes unconditional pruning safe — dropping a
+// snapshot costs a re-prefill, nothing else.
+//
+// Size discipline matters here: a snapshot is ~12 KiB per resident token
+// (measured: 17.6 MB for a 1476-token LFM2.5 conversation at n_ctx 2048), and
+// Dev Mode ships with ~2.2 GB free (uwp-constraints §9), so the pool is capped
+// both by file count and by total bytes.
+struct KvStore {
+    std::string dir;
+
+    // Conversation ids come from the chat UI. Refuse anything that is not a
+    // plain identifier, so an id can never reach outside `dir`.
+    static bool valid_id(const std::string& id);
+
+    // Empty string when the id is unusable.
+    std::string path_for(const std::string& id) const;
+
+    void erase(const std::string& id) const;
+
+    // Keep at most max_files snapshots and max_bytes in total, dropping the
+    // least recently modified first. Also removes .tmp files abandoned by an
+    // interrupted save.
+    void prune(size_t max_files, uint64_t max_bytes) const;
+
+    uint64_t total_bytes() const;
+};
+
+inline constexpr size_t kKvStoreMaxFiles = 3;
+inline constexpr uint64_t kKvStoreMaxBytes = 192ull << 20;
+
+} // namespace xllama

--- a/include/xllama/session.h
+++ b/include/xllama/session.h
@@ -135,6 +135,29 @@ struct Session {
         return false;
     }
 
+    // #170b: persist / restore the resident KV (sequence 0) so switching away
+    // from a conversation and back — or restarting the app — does not re-read
+    // the whole history. The file carries a fingerprint of the model and the
+    // context configuration: load_state refuses one that does not match,
+    // because the llama.cpp per-sequence state path validates cache SHAPE only
+    // (layer count, cell count, K/V types) — two different models of the same
+    // shape would load each other's cache and generate silent garbage.
+    // Both return false with *err on any failure, "unsupported backend"
+    // included; a caller must treat that as "no cache, prefill normally",
+    // never as a hard error.
+    virtual bool save_state(const std::string& path, std::string* err = nullptr) {
+        (void)path;
+        if (err)
+            *err = "state persistence not supported by this backend";
+        return false;
+    }
+    virtual bool load_state(const std::string& path, std::string* err = nullptr) {
+        (void)path;
+        if (err)
+            *err = "state persistence not supported by this backend";
+        return false;
+    }
+
     virtual ~Session() = default;
 };
 

--- a/src/bridge/kv_store.cpp
+++ b/src/bridge/kv_store.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) 2024 Gianluca Mazza
+// SPDX-License-Identifier: MIT
+
+#include "xllama/kv_store.h"
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <vector>
+
+namespace xllama {
+
+namespace {
+constexpr const char* kExt = ".kv";
+
+struct Snapshot {
+    std::filesystem::path path;
+    std::filesystem::file_time_type mtime;
+    uint64_t bytes;
+};
+
+// Snapshots newest-first, plus the abandoned .tmp files pruning has to clear.
+std::vector<Snapshot> scan(const std::string& dir, std::vector<std::filesystem::path>* tmps) {
+    std::vector<Snapshot> out;
+    std::error_code ec;
+    for (const auto& e : std::filesystem::directory_iterator(dir, ec)) {
+        if (ec)
+            break;
+        if (!e.is_regular_file(ec))
+            continue;
+        const auto ext = e.path().extension().string();
+        if (ext == ".tmp") {
+            if (tmps)
+                tmps->push_back(e.path());
+            continue;
+        }
+        if (ext != kExt)
+            continue;
+        std::error_code ec2;
+        const auto t = std::filesystem::last_write_time(e.path(), ec2);
+        const auto n = std::filesystem::file_size(e.path(), ec2);
+        if (ec2)
+            continue;
+        out.push_back({e.path(), t, static_cast<uint64_t>(n)});
+    }
+    std::sort(out.begin(), out.end(),
+              [](const Snapshot& a, const Snapshot& b) { return a.mtime > b.mtime; });
+    return out;
+}
+} // namespace
+
+bool KvStore::valid_id(const std::string& id) {
+    if (id.empty() || id.size() > 64)
+        return false;
+    for (const char c : id) {
+        const auto uc = static_cast<unsigned char>(c);
+        if (!std::isalnum(uc) && c != '-' && c != '_')
+            return false;
+    }
+    return true;
+}
+
+std::string KvStore::path_for(const std::string& id) const {
+    if (dir.empty() || !valid_id(id))
+        return {};
+    return (std::filesystem::path(dir) / (id + kExt)).string();
+}
+
+void KvStore::erase(const std::string& id) const {
+    const std::string p = path_for(id);
+    if (p.empty())
+        return;
+    std::error_code ec;
+    std::filesystem::remove(p, ec);
+    std::filesystem::remove(p + ".tmp", ec);
+}
+
+void KvStore::prune(size_t max_files, uint64_t max_bytes) const {
+    if (dir.empty())
+        return;
+    std::vector<std::filesystem::path> tmps;
+    const auto snaps = scan(dir, &tmps);
+    std::error_code ec;
+    for (const auto& t : tmps)
+        std::filesystem::remove(t, ec);
+
+    uint64_t kept_bytes = 0;
+    size_t kept = 0;
+    for (const auto& s : snaps) {
+        const bool fits = kept < max_files && kept_bytes + s.bytes <= max_bytes;
+        if (fits) {
+            ++kept;
+            kept_bytes += s.bytes;
+        } else {
+            std::filesystem::remove(s.path, ec);
+        }
+    }
+}
+
+uint64_t KvStore::total_bytes() const {
+    if (dir.empty())
+        return 0;
+    uint64_t sum = 0;
+    for (const auto& s : scan(dir, nullptr))
+        sum += s.bytes;
+    return sum;
+}
+
+} // namespace xllama

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -11,10 +11,12 @@
 #include "xllama/platform.h"
 #include "xllama/routing_policy.h"
 #include "xllama/session_hub.h"
+#include "xllama/utf8_utils.h"
 
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <filesystem>
 #include <string>
@@ -508,10 +510,13 @@ class LlamaSession final : public Session {
           m_n_ctx(n_ctx), m_n_threads(n_threads), m_n_batch(n_batch), m_n_ubatch(n_ubatch),
           m_kv_q8(kv_q8) {}
 
-    InferenceResult generate(const GenerateParams& gp) override {
-        InferenceResult res;
-
-        if (!m_ctx) {
+    // Lazy context creation, shared by generate() and the state-file entry
+    // points (#170b needs a context before the first turn). Returns false and
+    // sets *err on failure; m_ctx stays null.
+    bool ensure_ctx(std::string* err) {
+        if (m_ctx)
+            return true;
+        {
             llama_context_params cparams = llama_context_default_params();
             cparams.n_ctx = m_n_ctx;
             cparams.n_threads = m_n_threads;
@@ -542,9 +547,10 @@ class LlamaSession final : public Session {
                 m_ctx.reset(llama_init_from_model(m_model.get(), cparams));
             }
             if (!m_ctx) {
-                res.error_msg = "failed to create context";
-                log_output("[xllama] session generate: failed to create context\n");
-                return res;
+                if (err)
+                    *err = "failed to create context";
+                log_output("[xllama] session: failed to create context\n");
+                return false;
             }
             m_can_shift = llama_memory_can_shift(llama_get_memory(m_ctx.get())) &&
                           llama_model_n_swa(m_model.get()) == 0;
@@ -554,14 +560,23 @@ class LlamaSession final : public Session {
                 llama_adapter_lora* arr[1] = {m_adapter.get()};
                 float scales[1] = {m_lora_scale};
                 if (llama_set_adapters_lora(m_ctx.get(), arr, 1, scales) != 0) {
-                    res.error_msg = "llama_set_adapters_lora failed";
-                    log_output("[xllama] session generate: set_adapters_lora failed\n");
+                    if (err)
+                        *err = "llama_set_adapters_lora failed";
+                    log_output("[xllama] session: set_adapters_lora failed\n");
                     m_ctx.reset();
-                    return res;
+                    return false;
                 }
                 log_output("[xllama] session: runtime LoRA adapter applied\n");
             }
         }
+        return true;
+    }
+
+    InferenceResult generate(const GenerateParams& gp) override {
+        InferenceResult res;
+
+        if (!ensure_ctx(&res.error_msg))
+            return res;
         llama_context* ctx = m_ctx.get();
 
         // KV-cache reuse: a continuation turn (reuse_kv && !reset_kv) keeps the
@@ -802,6 +817,229 @@ class LlamaSession final : public Session {
 
     bool can_context_shift() const override {
         return m_can_shift;
+    }
+
+    // --- #170b: KV state files ---------------------------------------------
+    //
+    // Layout: one text header line, then the resident token ids, then the raw
+    // sequence state. Everything the pin does NOT check lives in the header —
+    // it validates cache shape only, so a re-quantized build of the same model
+    // or the same model with a LoRA applied would load this file and generate
+    // silent garbage.
+
+    static constexpr const char* kStateMagic = "xllama-kv";
+    static constexpr int kStateVersion = 1;
+    // AppContainer dislikes very large single reads: ORT's 1 GB
+    // ReadFileIntoBuffer had to come down to 16 MB before errcode 1450
+    // (ERROR_NO_SYSTEM_RESOURCES) stopped appearing (uwp-constraints §9), and
+    // llama_file's own path would move this blob in 64 MB slices. Stay well
+    // under the known-good bound.
+    static constexpr size_t kIoChunk = 8u << 20;
+    // A sane ceiling for a declared blob size: refuse to allocate for a
+    // corrupt or hostile header instead of trying and dying.
+    static constexpr size_t kMaxStateBytes = 512u << 20;
+
+    static FILE* open_state_file(const std::string& path, const char* mode) {
+    #ifdef XLLAMA_UWP
+        const std::string m(mode);
+        return _wfopen(utf8_to_wstring(path).c_str(), std::wstring(m.begin(), m.end()).c_str());
+    #else
+        return std::fopen(path.c_str(), mode);
+    #endif
+    }
+
+    static bool io_chunked(FILE* fp, void* data, size_t n, bool write) {
+        auto* p = static_cast<uint8_t*>(data);
+        for (size_t off = 0; off < n;) {
+            const size_t want = std::min(kIoChunk, n - off);
+            const size_t got =
+                write ? std::fwrite(p + off, 1, want, fp) : std::fread(p + off, 1, want, fp);
+            if (got != want)
+                return false;
+            off += want;
+        }
+        return true;
+    }
+
+    // Identity of the weights + context this cache was built on. Computed
+    // after ensure_ctx() so it reflects the kv_q8 fallback (#171), not the
+    // request.
+    std::string state_fingerprint() const {
+        char desc[192] = {};
+        llama_model_desc(m_model.get(), desc, sizeof(desc) - 1);
+        char buf[320];
+        snprintf(buf, sizeof(buf), "v%d n_ctx=%d kv_q8=%d lora=%.4f params=%llu %s", kStateVersion,
+                 m_n_ctx, m_kv_q8 ? 1 : 0, m_adapter ? m_lora_scale : 0.0f,
+                 static_cast<unsigned long long>(llama_model_n_params(m_model.get())), desc);
+        return buf;
+    }
+
+    bool save_state(const std::string& path, std::string* err) override {
+        if (!ensure_ctx(err))
+            return false;
+        if (m_kv_tokens.empty()) {
+            if (err)
+                *err = "no resident KV to save";
+            return false;
+        }
+
+        std::vector<uint8_t> blob;
+        size_t n_state = 0;
+        try {
+            blob.resize(llama_state_seq_get_size(m_ctx.get(), 0));
+            n_state = llama_state_seq_get_data(m_ctx.get(), blob.data(), blob.size(), 0);
+        } catch (const std::exception& e) {
+            if (err)
+                *err = std::string("state_seq_get_data threw: ") + e.what();
+            return false;
+        }
+        if (n_state == 0) {
+            if (err)
+                *err = "llama_state_seq_get_data failed";
+            return false;
+        }
+
+        // Write to a sibling temp and rename: a half-written file is tens of
+        // MB of garbage that the loader can only reject after reading it all,
+        // and a crash mid-write must not leave one behind.
+        const std::string tmp = path + ".tmp";
+        FILE* fp = open_state_file(tmp, "wb");
+        if (!fp) {
+            if (err)
+                *err = "cannot open " + tmp;
+            return false;
+        }
+        char hdr[512];
+        const int hn = snprintf(hdr, sizeof(hdr), "%s\t%zu\t%zu\t%s\n", kStateMagic, n_state,
+                                m_kv_tokens.size(), state_fingerprint().c_str());
+        bool ok = hn > 0 && static_cast<size_t>(hn) < sizeof(hdr) &&
+                  std::fwrite(hdr, 1, static_cast<size_t>(hn), fp) == static_cast<size_t>(hn);
+        ok = ok && io_chunked(fp, m_kv_tokens.data(), m_kv_tokens.size() * sizeof(llama_token),
+                              /*write=*/true);
+        ok = ok && io_chunked(fp, blob.data(), n_state, /*write=*/true);
+        ok = (std::fclose(fp) == 0) && ok;
+
+        std::error_code ec;
+        if (!ok) {
+            std::filesystem::remove(tmp, ec);
+            if (err)
+                *err = "write failed (disk full?)";
+            return false;
+        }
+        std::filesystem::rename(tmp, path, ec);
+        if (ec) {
+            std::filesystem::remove(tmp, ec);
+            if (err)
+                *err = "rename failed: " + ec.message();
+            return false;
+        }
+        char lb[160];
+        snprintf(lb, sizeof(lb), "[xllama] session: KV state saved — %zu tokens, %.1f MB (#170b)\n",
+                 m_kv_tokens.size(), (double)n_state / (1024.0 * 1024.0));
+        log_output(lb);
+        return true;
+    }
+
+    bool load_state(const std::string& path, std::string* err) override {
+        if (!ensure_ctx(err))
+            return false;
+        FILE* fp = open_state_file(path, "rb");
+        if (!fp) {
+            if (err)
+                *err = "no state file at " + path;
+            return false;
+        }
+        struct Closer {
+            FILE* f;
+            ~Closer() {
+                if (f)
+                    std::fclose(f);
+            }
+        } closer{fp};
+
+        char hdr[512] = {};
+        if (!std::fgets(hdr, sizeof(hdr), fp)) {
+            if (err)
+                *err = "empty state file";
+            return false;
+        }
+        std::string line(hdr);
+        while (!line.empty() && (line.back() == '\n' || line.back() == '\r'))
+            line.pop_back();
+        // magic \t n_state \t n_tokens \t fingerprint(rest of line)
+        std::string field[3];
+        size_t pos = 0;
+        for (auto& f : field) {
+            const size_t t = line.find('\t', pos);
+            if (t == std::string::npos) {
+                if (err)
+                    *err = "malformed state header";
+                return false;
+            }
+            f = line.substr(pos, t - pos);
+            pos = t + 1;
+        }
+        if (field[0] != kStateMagic) {
+            if (err)
+                *err = "not an xllama KV state file";
+            return false;
+        }
+        if (line.substr(pos) != state_fingerprint()) {
+            // The common, expected case: model / n_ctx / KV-quant / LoRA
+            // changed since the file was written. Not an error worth shouting
+            // about — the caller just prefills.
+            if (err)
+                *err = "state file belongs to a different model or context";
+            return false;
+        }
+        size_t n_state = 0, n_tokens = 0;
+        try {
+            n_state = std::stoull(field[1]);
+            n_tokens = std::stoull(field[2]);
+        } catch (const std::exception&) {
+            if (err)
+                *err = "malformed state header";
+            return false;
+        }
+        if (n_state == 0 || n_state > kMaxStateBytes || n_tokens == 0 ||
+            n_tokens > static_cast<size_t>(m_n_ctx)) {
+            if (err)
+                *err = "state header out of range";
+            return false;
+        }
+
+        std::vector<llama_token> tokens(n_tokens);
+        std::vector<uint8_t> blob(n_state);
+        if (!io_chunked(fp, tokens.data(), n_tokens * sizeof(llama_token), /*write=*/false) ||
+            !io_chunked(fp, blob.data(), n_state, /*write=*/false)) {
+            if (err)
+                *err = "state file truncated";
+            return false;
+        }
+
+        size_t used = 0;
+        try {
+            used = llama_state_seq_set_data(m_ctx.get(), blob.data(), blob.size(), 0);
+        } catch (const std::exception& e) {
+            used = 0;
+            if (err)
+                *err = std::string("state_seq_set_data threw: ") + e.what();
+        }
+        if (used == 0) {
+            // The pin rolls its own read back, but the bookkeeping is ours.
+            llama_memory_clear(llama_get_memory(m_ctx.get()), true);
+            m_kv_tokens.clear();
+            if (err && err->empty())
+                *err = "llama_state_seq_set_data rejected the file";
+            return false;
+        }
+        m_kv_tokens = std::move(tokens);
+        char lb[160];
+        snprintf(lb, sizeof(lb),
+                 "[xllama] session: KV state loaded — %zu tokens, %.1f MB (#170b)\n",
+                 m_kv_tokens.size(), (double)n_state / (1024.0 * 1024.0));
+        log_output(lb);
+        return true;
     }
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(xllama-tests
     test_path.cpp
     test_bench.cpp
     test_session.cpp
+    test_kv_store.cpp
     test_chat_history.cpp
     test_diffusion.cpp
     test_routing_policy.cpp

--- a/tests/test_kv_store.cpp
+++ b/tests/test_kv_store.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2024 Gianluca Mazza
+// SPDX-License-Identifier: MIT
+
+#include "xllama/kv_store.h"
+
+#include <doctest/doctest.h>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+
+namespace {
+
+std::filesystem::path fresh_dir(const char* name) {
+    auto d = std::filesystem::temp_directory_path() / name;
+    std::error_code ec;
+    std::filesystem::remove_all(d, ec);
+    std::filesystem::create_directories(d);
+    return d;
+}
+
+void write_bytes(const std::filesystem::path& p, size_t n) {
+    std::ofstream f(p, std::ios::binary);
+    const std::string chunk(n, 'x');
+    f << chunk;
+}
+
+} // namespace
+
+TEST_CASE("KvStore::valid_id refuses anything that is not a plain identifier") {
+    using xllama::KvStore;
+    CHECK(KvStore::valid_id("a1b2-c3d4_e5"));
+    CHECK_FALSE(KvStore::valid_id(""));
+    // Path traversal is the reason this function exists: ids come from the UI.
+    CHECK_FALSE(KvStore::valid_id(".."));
+    CHECK_FALSE(KvStore::valid_id("../../etc/passwd"));
+    CHECK_FALSE(KvStore::valid_id("a/b"));
+    CHECK_FALSE(KvStore::valid_id("a\\b"));
+    CHECK_FALSE(KvStore::valid_id("a b"));
+    CHECK_FALSE(KvStore::valid_id(std::string(65, 'a')));
+}
+
+TEST_CASE("KvStore::path_for stays inside the directory") {
+    const auto dir = fresh_dir("xllama-kvstore-path");
+    const xllama::KvStore store{dir.string()};
+    const std::string p = store.path_for("conv-1");
+    CHECK(p.find(dir.string()) == 0);
+    CHECK(p.substr(p.size() - 3) == ".kv");
+    CHECK(store.path_for("../escape").empty());
+    CHECK(xllama::KvStore{""}.path_for("conv-1").empty());
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
+}
+
+TEST_CASE("KvStore::prune keeps the newest snapshots within both caps") {
+    const auto dir = fresh_dir("xllama-kvstore-prune");
+    const xllama::KvStore store{dir.string()};
+
+    // Distinct mtimes: the eviction order is least-recently-modified first.
+    for (const char* id : {"old", "mid", "new"}) {
+        write_bytes(store.path_for(id), 1024);
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    // An interrupted save leaves a .tmp behind; pruning must clear it.
+    write_bytes(dir / "leftover.kv.tmp", 4096);
+
+    store.prune(/*max_files=*/2, /*max_bytes=*/xllama::kKvStoreMaxBytes);
+    CHECK_FALSE(std::filesystem::exists(store.path_for("old")));
+    CHECK(std::filesystem::exists(store.path_for("mid")));
+    CHECK(std::filesystem::exists(store.path_for("new")));
+    CHECK_FALSE(std::filesystem::exists(dir / "leftover.kv.tmp"));
+    CHECK(store.total_bytes() == 2048);
+
+    // The byte cap bites before the file cap when snapshots are large.
+    store.prune(/*max_files=*/10, /*max_bytes=*/1500);
+    CHECK(store.total_bytes() == 1024);
+    CHECK(std::filesystem::exists(store.path_for("new")));
+
+    store.erase("new");
+    CHECK(store.total_bytes() == 0);
+
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
+}
+
+TEST_CASE("KvStore tolerates a missing directory") {
+    const xllama::KvStore store{
+        (std::filesystem::temp_directory_path() / "xllama-kv-absent").string()};
+    CHECK(store.total_bytes() == 0);
+    store.prune(xllama::kKvStoreMaxFiles, xllama::kKvStoreMaxBytes); // must not throw
+    store.erase("whatever");
+}

--- a/tests/test_session.cpp
+++ b/tests/test_session.cpp
@@ -5,6 +5,7 @@
 #include "xllama/session.h"
 #include "xllama/session_hub.h"
 
+#include <chrono>
 #include <doctest/doctest.h>
 #include <filesystem>
 #include <fstream>
@@ -214,6 +215,104 @@ TEST_CASE("Session: KV prefix reuse collapses a repeated prefill (opt-in: XLLAMA
         // re-prefill, which is exactly a fresh session: byte-identical output.
         CHECK(r_ext.output_text == r_fresh.output_text);
     }
+}
+
+// #170b: the resident KV round-trips through a file, so a conversation the
+// session no longer holds resumes without re-reading its history. Opt-in —
+// needs a real GGUF:
+//   XLLAMA_TEST_MODEL=/path/to/model.gguf ./xllama-tests
+TEST_CASE("Session: KV state round-trips through a file (opt-in: XLLAMA_TEST_MODEL)") {
+    const char* model_env = std::getenv("XLLAMA_TEST_MODEL");
+    if (!model_env)
+        return;
+
+    const auto state_path = std::filesystem::temp_directory_path() / "xllama-kv-state.bin";
+    std::error_code ec;
+    std::filesystem::remove(state_path, ec);
+
+    xllama::SessionParams sp;
+    sp.model_path = model_env;
+    sp.n_ctx = 2048; // the shipping context: file size scales with it
+    std::string err;
+    auto a = xllama::Session::create(sp, &err);
+    REQUIRE_MESSAGE(a, err);
+
+    auto mkgp = [](const std::string& p, bool reset) {
+        xllama::GenerateParams gp;
+        gp.prompt = p;
+        gp.n_predict = 16;
+        gp.temperature = 0.0f; // greedy: the two sessions must agree exactly
+        gp.reuse_kv = true;
+        gp.reset_kv = reset;
+        return gp;
+    };
+    // A conversation of realistic length: re-reading exactly this is the cost
+    // the file exists to avoid, and its size is what the eviction policy has
+    // to budget for.
+    std::string filler;
+    for (int i = 0; i < 80; ++i)
+        filler += "Item " + std::to_string(i) +
+                  ": the harbour master filed a report on tide tables and cargo manifests. ";
+    const std::string seed_prompt =
+        "<|im_start|>system\nYou are terse.<|im_end|>\n<|im_start|>user\n" + filler +
+        "The capital of France is Paris. The capital of Italy is Rome. Remember "
+        "both.<|im_end|>\n<|im_start|>assistant\n";
+    const std::string follow = "<|im_end|>\n<|im_start|>user\nWhich city did I name "
+                               "first?<|im_end|>\n<|im_start|>assistant\n";
+
+    const auto r_seed = a->generate(mkgp(seed_prompt, /*reset=*/true));
+    REQUIRE_MESSAGE(r_seed.success, r_seed.error_msg);
+
+    const auto t0 = std::chrono::steady_clock::now();
+    const bool saved = a->save_state(state_path.string(), &err);
+    const double save_ms =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
+    REQUIRE_MESSAGE(saved, err);
+    const auto bytes = std::filesystem::file_size(state_path, ec);
+    MESSAGE("state file: " << bytes / 1024 << " KiB for " << r_seed.n_p_eval << " prompt tokens ("
+                           << bytes / 1024 / (r_seed.n_p_eval ? r_seed.n_p_eval : 1)
+                           << " KiB/token), save " << save_ms << " ms, prefill was "
+                           << r_seed.t_p_eval_ms << " ms");
+
+    // The continuation the resident session would produce, for comparison.
+    const auto r_cont_resident = a->generate(mkgp(follow, /*reset=*/false));
+    REQUIRE_MESSAGE(r_cont_resident.success, r_cont_resident.error_msg);
+
+    // A second session that never saw the conversation: restoring the file
+    // must put it in the same state, not merely a similar one.
+    auto b = xllama::Session::create(sp, &err);
+    REQUIRE_MESSAGE(b, err);
+    const auto t1 = std::chrono::steady_clock::now();
+    const bool loaded = b->load_state(state_path.string(), &err);
+    const double load_ms =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t1).count();
+    REQUIRE_MESSAGE(loaded, err);
+    MESSAGE("load " << load_ms << " ms");
+
+    const auto r_cont_restored = b->generate(mkgp(follow, /*reset=*/false));
+    REQUIRE_MESSAGE(r_cont_restored.success, r_cont_restored.error_msg);
+    // Only the follow-up is prefilled — the history came from the file.
+    CHECK(r_cont_restored.n_p_eval == r_cont_resident.n_p_eval);
+    CHECK(r_cont_restored.n_p_eval < r_seed.n_p_eval);
+    CHECK(r_cont_restored.output_text == r_cont_resident.output_text);
+
+    // A file whose fingerprint does not match must be refused, not fed to the
+    // cache: the pin checks shape only, so this is the whole defence against
+    // loading another model's KV.
+    xllama::SessionParams sp2 = sp;
+    sp2.n_ctx = 1024; // same weights, different context configuration
+    auto c = xllama::Session::create(sp2, &err);
+    REQUIRE_MESSAGE(c, err);
+    err.clear();
+    CHECK_FALSE(c->load_state(state_path.string(), &err));
+    CHECK(!err.empty());
+    // Refusal must leave the session usable.
+    const auto r_after = c->generate(mkgp("<|im_start|>user\nHi.<|im_end|>\n"
+                                          "<|im_start|>assistant\n",
+                                          /*reset=*/true));
+    CHECK(r_after.success);
+
+    std::filesystem::remove(state_path, ec);
 }
 
 // #169: a continuation turn that would overflow n_ctx evicts the oldest

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -12,6 +12,7 @@
     #include "chat-history.h"
     #include "inference-bridge.h"
     #include "xllama/chat_prompt.h"
+    #include "xllama/kv_store.h"
     #include "xllama/model_provision.h"
     #include "xllama/path_utils.h"
     #include "xllama/personalize.h"
@@ -59,6 +60,12 @@ static std::wstring DefaultChatModelId() {
 static std::wstring local_wpath(const wchar_t* filename_w) {
     auto folder = ApplicationData::Current().LocalFolder();
     return std::wstring(folder.Path().c_str()) + L"\\" + filename_w;
+}
+
+// #170b: where per-conversation KV snapshots live. Created on demand by the
+// save path; every reader tolerates its absence.
+static ::xllama::KvStore kv_store() {
+    return ::xllama::KvStore{::xllama::wstring_to_utf8(local_wpath(L"kv"))};
 }
 
 static std::string read_local_text_file(const wchar_t* name) {
@@ -742,10 +749,48 @@ void MainPageController::SaveCurrentConversation(bool partial) {
     m_history.Save(m_current);
 }
 
+// #170b: the KV of the conversation being left is worth ~12 KiB per resident
+// token of prefill we would otherwise repeat on return (measured: a 1476-token
+// conversation is a 17.6 MB file that loads in 33 ms against a 4.5 s
+// re-prefill on console). Written on a detached thread — the UI thread must
+// not wait on tens of MB — under the hub lock, and only while the resident
+// session is still the one this conversation was built on.
+//
+// The race with a turn starting right after the switch can only WASTE the
+// file, never corrupt a reply: the snapshot stores its own token list, and
+// load_state hands it to the #170a prefix diff, so a snapshot that no longer
+// matches the rendered prompt collapses to a normal prefill.
+void MainPageController::SaveKvSnapshotAsync() {
+    if (!m_kv_reuse || !m_kv_valid || m_current.messages.empty())
+        return;
+    const std::string routed =
+        ::xllama::wstring_to_utf8(m_active_model.empty() ? m_model_filename : m_active_model);
+    if (!::xllama::model_uses_llama_backend(routed))
+        return; // ORT keeps no serialisable per-sequence state
+    CreateDirectoryW(local_wpath(L"kv").c_str(), nullptr);
+    const auto store = kv_store();
+    const std::string path = store.path_for(m_current.id);
+    if (path.empty())
+        return;
+    const uint64_t gen = m_hub_generation;
+    std::thread([store, path, gen]() {
+        auto& hub = ::xllama::session_hub();
+        std::lock_guard<std::mutex> lk(hub.mtx);
+        if (!hub.session || hub.generation != gen)
+            return; // a different model is resident now — nothing of ours to save
+        std::string err;
+        if (hub.session->save_state(path, &err))
+            store.prune(::xllama::kKvStoreMaxFiles, ::xllama::kKvStoreMaxBytes);
+        else
+            ::xllama::log_output("[xllama] KV snapshot not saved: " + err + "\n");
+    }).detach();
+}
+
 void MainPageController::NewChat() {
     if (m_is_running.load())
         return;                // don't allow while running
     SaveCurrentConversation(); // save current (no-op if empty)
+    SaveKvSnapshotAsync();     // #170b: before m_kv_valid/m_active_model are cleared
     m_kv_valid = false;        // new conversation → discard reused KV
     m_active_model.clear();    // re-decide EP routing for the new conversation
     m_current = xllama::ui::Conversation{};
@@ -823,6 +868,7 @@ void MainPageController::FinalizeStreamedTurn(const std::string& output_text) {
 
 void MainPageController::LoadConversation(const std::string& id) {
     SaveCurrentConversation();
+    SaveKvSnapshotAsync();  // #170b: before m_kv_valid/m_active_model are cleared
     m_kv_valid = false;     // switching conversations → the reused KV no longer applies
     m_active_model.clear(); // re-decide EP routing for the loaded conversation
     m_current = m_history.Load(id);
@@ -951,8 +997,15 @@ winrt::fire_and_forget MainPageController::ShowHistory() {
         if (cr == winrt::Windows::UI::Xaml::Controls::ContentDialogResult::Primary) {
             bool was_current = (id_to_delete == self->m_current.id);
             self->m_history.Delete(id_to_delete);
-            if (was_current)
+            kv_store().erase(id_to_delete); // #170b: no orphan snapshot
+            if (was_current) {
+                // Drop the in-memory copy FIRST: NewChat starts by saving the
+                // current conversation, which would write the just-deleted one
+                // straight back to disk (and, with #170b, re-create its
+                // snapshot).
+                self->m_current = xllama::ui::Conversation{};
                 self->NewChat();
+            }
             self->SetStatus(L"Conversation deleted");
         }
         co_return;
@@ -972,6 +1025,12 @@ winrt::fire_and_forget MainPageController::ShowHistory() {
         auto cr = co_await confirm.ShowAsync();
         if (cr == winrt::Windows::UI::Xaml::Controls::ContentDialogResult::Primary) {
             self->m_history.Clear();
+            // #170b: snapshots are per-conversation caches — clearing the
+            // history must not leave their bytes on disk.
+            kv_store().prune(/*max_files=*/0, /*max_bytes=*/0);
+            // Same trap as the single delete: NewChat would save the current
+            // conversation back into the history we just cleared.
+            self->m_current = xllama::ui::Conversation{};
             self->NewChat();
             self->SetStatus(L"All conversations cleared");
         }
@@ -2689,8 +2748,11 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
     // worker, where the session is available.
     const std::string sys_prefix = fmt.render_system_prefix(m_system_prompt);
 
+    // #170b: the snapshot to try when this conversation's KV is not resident.
+    const std::string kv_path = kv_reuse ? kv_store().path_for(m_current.id) : std::string();
+
     std::thread([self, full_prompt, delta_prompt, do_reuse, kv_reuse, ep_kv_ok, model, fmt,
-                 sys_prefix, dispatcher]() mutable {
+                 sys_prefix, kv_path, dispatcher]() mutable {
         try {
             // One hub lock for the whole turn: the resident session cannot be
             // swapped from under us (LAN API requests report busy meanwhile,
@@ -2713,6 +2775,18 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
                     self->SetRunning(false);
                 });
                 return;
+            }
+
+            // #170b: this conversation's KV is not resident (switched away and
+            // back, or the app was restarted). Restoring the snapshot does not
+            // change the turn below — it stays a full-prompt turn, and the
+            // #170a prefix diff is what turns the restored cache into a delta
+            // prefill. A missing, stale or foreign snapshot just fails here and
+            // the turn prefills as it always did.
+            if (!do_reuse && !kv_path.empty()) {
+                std::string kv_err;
+                if (self->m_turn_session->load_state(kv_path, &kv_err))
+                    ::xllama::log_output("[xllama] KV snapshot restored (#170b)\n");
             }
 
             auto on_status = [self, dispatcher](const std::string& s) {

--- a/uwp/MainPage.h
+++ b/uwp/MainPage.h
@@ -132,6 +132,9 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     void PollDiffuseProgress();
     void FinishDiffusion();
     void SaveCurrentConversation(bool partial = false);
+    // #170b: hand the KV of the conversation we are leaving to disk, off the UI
+    // thread. Call BEFORE the switch clears m_kv_valid / m_active_model.
+    void SaveKvSnapshotAsync();
     // Must be called from background thread; builds/rebuilds m_session if needed.
     bool EnsureSession(const std::string& model, std::string* err_out = nullptr);
 

--- a/uwp/xllama.vcxproj
+++ b/uwp/xllama.vcxproj
@@ -295,6 +295,7 @@
   <ItemGroup>
     <ClCompile Include="..\src\bridge\inference.cpp" />
     <ClCompile Include="..\src\bridge\session.cpp" />
+    <ClCompile Include="..\src\bridge\kv_store.cpp" />
     <ClCompile Include="..\src\bridge\bench.cpp" />
     <ClCompile Include="..\src\bridge\membw.cpp" />
     <ClCompile Include="..\src\bridge\platform.cpp" />


### PR DESCRIPTION
Step (b) of #170. Leaving a conversation writes its resident KV to `LocalState\kv\<id>.kv`; the first turn after coming back restores it instead of re-reading the history.

## Why the numbers justify it

Host measurement (LFM2.5, n_ctx 2048, new opt-in test):

| | |
|---|---|
| snapshot size | **17.6 MB** for 1476 tokens (12 KiB/token) |
| save | **21 ms** |
| load | **33 ms** |
| what it replaces | **4532 ms** full re-prefill (console-measured, #169 gate) |

## Design

- **The restore changes nothing about the turn.** It stays a full-prompt turn; the #170a prefix diff is what collapses it to the new user message. Consequence: a stale, raced or foreign snapshot can only degrade to the prefill that would have happened anyway — never to a wrong reply. That property is what makes the detached save safe.
- **Fingerprint** (model identity, `n_ctx`, KV quant, LoRA) in the file header: llama.cpp's per-sequence state path validates cache *shape* only (layers, cell count, K/V types), so a re-quantized build or a LoRA-applied session would otherwise load another cache and emit silent garbage. Tested: a session differing only in `n_ctx` is refused and stays usable.
- **Atomic writes** (temp + rename) and 8 MB I/O chunks — under the 16 MB bound §9 established for AppContainer after ORT's errcode 1450 (llama's own file path would have used 64 MB slices).
- **`KvStore`** caps the pool at 3 files / 192 MB against the ~2.2 GB Dev Mode budget, evicts least-recently-modified first, and clears `.tmp` files left by an interrupted save. Pure filesystem logic with host tests, including id path-traversal refusal.
- Deleting a conversation deletes its snapshot; "clear all" empties the pool.

## Adjacent bug found and fixed

Deleting the conversation you are viewing — or "Clear all conversations" — removed the files and then called `NewChat()`, whose first act is `SaveCurrentConversation()`. `m_current` still held the deleted conversation, so it was written straight back to disk and re-indexed. The in-memory copy is now dropped first. (Without this, #170b would have re-created the snapshot too.)

## Verification

Host: full suite 148/148 (4 new `KvStore` cases run in CI, no model needed); opt-in round-trip test on LFM2.5 asserts the restored session prefills exactly the delta and produces byte-identical output to the resident one. clang-format 22.1.5, coherence and benchmark-summary gates clean.

Console confirmation of switch-and-return is pending the next deploy — noted on #170.

Refs #170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Conversation state is now saved and restored when switching conversations, reducing repeated processing and improving return-to-chat performance.
  - State restoration safely falls back to normal processing when unavailable or incompatible.

- **Bug Fixes**
  - Deleting the active conversation or clearing all conversations no longer recreates deleted chat data.
  - Removed conversation state is now cleaned up along with its chat history.

- **Performance**
  - Snapshot storage is managed automatically with size and retention limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->