### PR TITLE
release: v1.5.1.0 — Phase 13 CPU prefill + KV reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.5.1.0] - 2026-07-27
+
+The Phase 13 CPU-prefill and KV-reuse campaign, shipped. Every turn a chat
+takes is cheaper: the prefill runs on all six threads, a regenerate or an
+edited message reuses the resident cache, long chats stop re-reading their
+history, and leaving a conversation no longer throws its cache away.
+
+**Upgrading from 1.5.0.0 is a normal in-place update** (same package identity
+`GianlucaMazza.xllama`). Coming from ≤1.4.x still requires the identity
+migration described in `docs/install-release.md`.
+
 ### Performance
 
 - **GGUF prefill now runs on the configured thread count (#168, PR #177).**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,11 +5,12 @@ performance belongs in `docs/benchmarks.md`.
 
 ## Current product state
 
-- Current manifest: **1.5.0.0** under the new **`GianlucaMazza.xllama`**
-  identity (PR #163 — breaking: no in-place update from ≤1.4.x, see
-  `docs/install-release.md`). Released as **v1.5.0.0** (2026-07-26): the
-  2026-07-25 perf campaign + rebrand (PR #155-#165), shipping the
-  console-validated MSIX 1.5.0.698 (all gates PASS).
+- Current manifest: **1.5.1.0** under the **`GianlucaMazza.xllama`** identity
+  (in-place update from 1.5.0.0; still breaking vs ≤1.4.x, see
+  `docs/install-release.md`). Released as **v1.5.1.0** (2026-07-27): the
+  Phase 13 CPU-prefill + KV-reuse campaign (#168, #169, #170a/b, #171,
+  #173-#175). The previous release, **v1.5.0.0** (2026-07-26), carried the
+  perf campaign + rebrand (PR #155-#165) on console-validated MSIX 1.5.0.698.
 - Shipping artifact: unified ORT GenAI + llama.cpp, with pinned patched runtime
   DLLs while upstream fixes have not reached NuGet. The UWP ggml build now
   enables `GGML_USE_CPU_REPACK` (PR #155): **GGUF prefill +62%** on Q4_K.
@@ -277,13 +278,20 @@ fix.
   KiB/token, save 21 ms, load 33 ms), Qwen3.5-0.8B 36.5 MB / 1472 (25
   KiB/token, save 124 ms, load 301 ms) — against the 4532 ms console
   re-prefill. Fingerprinted
-  (model, n_ctx, KV quant, LoRA) because the pin validates cache shape
+  (model, n*ctx, KV quant, LoRA) because the pin validates cache shape
   only; atomic writes in 8 MB chunks (§9 AppContainer bound); `KvStore`
   caps the pool at 3 files / 192 MB, LRU, host-tested. A stale snapshot
   is harmless by construction — the #170a diff turns it into the prefill
-  that would have happened anyway. Remaining on this issue: the ex-#174
-  BuildPrompt-off-the-UI-thread item, and console confirmation of the
-  switch-and-return path at the next deploy.
+  that would have happened anyway. **Step (c), the ex-#174
+  BuildPrompt-off-the-UI-thread item: won't do, measured.** The deep copy
+  plus the full render of a prompt at the trimmer ceiling (10 KB) costs
+  **11.2 µs** on host — call it 30–50 µs on Zen2, once per turn, against a
+  16.7 ms frame. Moving it to the worker means snapshotting the
+  \_untrimmed* conversation on the UI thread (more copying than the render
+  it replaces) or putting a mutex on conversation state that the
+  token-streaming path would then contend on. The real #174 costs — the
+  per-turn provisioning I/O and the per-message `chat_format()` — were the
+  ones worth fixing, and PR #177 fixed them.
 - [x] **#171 — KV quantization measured; verdict: knob shipped, default
       OFF.** Consolidation half landed first (PR #177: `kDefaultNCtx`, domain
       test). The q8_0+flash-attn knob (`--kv-q8`, `SessionParams::kv_q8`,

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,7 +115,7 @@ Spot-checked against code + evidence:
 | GPU allowlist `-v2` only                            | `dml_text_model_ok`                                       | OK                                                        |
 | NuGet 0.14.1 / 1.24.4 / DML 1.15.4                  | `packages.config`                                         | OK                                                        |
 | Decode table (94.9 / 37.9 / 18.4 / 74.8 / 44.4 / …) | `generate-benchmark-summary.py --check`                   | OK (2026-07-26: LFM post-#168 median, ORT CPU shipped-t6) |
-| Package identity `GianlucaMazza.xllama` (1.5.0.0)   | `uwp/AppxManifest.xml`; migration in `install-release.md` | OK (breaking vs ≤1.4.x)                                   |
+| Package identity `GianlucaMazza.xllama` (1.5.1.0)   | `uwp/AppxManifest.xml`; migration in `install-release.md` | OK (in-place from 1.5.0.0; breaking vs ≤1.4.x)            |
 | One resident Session (GUI+API)                      | `include/xllama/session_hub.h`                            | OK (PR #161/#164)                                         |
 | H9 6/8 · 7/8 · 4/8 · 5/8                            | `phase7-h9.jsonl`                                         | OK                                                        |
 | Lane B peak_ws 1195 MB, wall 446 s                  | `phase10-console-devtrain-result.json`                    | OK                                                        |

--- a/docs/install-release.md
+++ b/docs/install-release.md
@@ -49,7 +49,9 @@ Notes:
 - **Upgrades within the same identity**: a higher version installs over the
   old one and **preserves** LocalState (models, settings, history). WDP
   refuses a same-version install with different contents.
-- ⚠️ **Upgrading from ≤1.4.x to 1.5.0.0 is NOT an in-place update.** 1.5.0.0
+- **1.5.0.0 → 1.5.1.0 is a normal in-place update**: same identity, LocalState
+  (models, settings, history, KV snapshots) is preserved.
+- ⚠️ **Upgrading from ≤1.4.x to 1.5.x is NOT an in-place update.** 1.5.0.0
   changed the package identity (`VenereLabs.xllama` → `GianlucaMazza.xllama`):
   it installs as a **new app**, and the old app's LocalState — downloaded
   models, chat history, settings, training output — does **not** carry over.

--- a/scripts/check-coherence.py
+++ b/scripts/check-coherence.py
@@ -123,8 +123,14 @@ def main() -> int:
     if not ver:
         err("AppxManifest Version missing")
     else:
-        if ver.group(1) != "1.5.0":
-            warn(f"Appx semantic {ver.group(1)} (ROADMAP may need bump)")
+        # Derive the expected version from the manifest instead of hardcoding
+        # it: a pinned literal here goes stale at the next release and the
+        # warning it emits is about itself, not about the docs.
+        roadmap_head = (ROOT / "ROADMAP.md").read_text(encoding="utf-8")[:2000]
+        if f"**{ver.group(1)}.0**" not in roadmap_head:
+            warn(f"Appx semantic {ver.group(1)} not in the ROADMAP head (bump it)")
+        else:
+            good(f"ROADMAP states the shipping version {ver.group(1)}.0")
         good(f"Appx Version={ver.group(0)}")
 
     # --- build wiring ---

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -15,7 +15,7 @@
   <Identity
     Name="GianlucaMazza.xllama"
     Publisher="CN=xllama-dev"
-    Version="1.5.0.0"
+    Version="1.5.1.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity


### PR DESCRIPTION
Cuts **v1.5.1.0**: the Phase 13 campaign, all of it console- or host-measured.

- manifest `1.5.0.0` → `1.5.1.0` (same identity → **in-place update** from 1.5.0.0; ≤1.4.x still needs the identity migration)
- CHANGELOG `[Unreleased]` → `[1.5.1.0]`
- docs (`docs/README.md`, `install-release.md`, ROADMAP head) updated

## Also in this PR

**#170 step (c) — won't do, measured.** Moving `BuildPrompt` off the UI thread: the deep copy plus full render of a 10 KB prompt at the trimmer ceiling is **11.2 µs** on host (~30–50 µs on Zen2), once per turn against a 16.7 ms frame. Every way of moving it is worse — snapshotting the *untrimmed* conversation on the UI thread copies more than the render does, and the alternative is a mutex on state the token-streaming path touches. The #174 costs that mattered (per-turn provisioning I/O, per-message `chat_format()`) were fixed in PR #177.

**`check-coherence.py` no longer hardcodes the shipping version.** It pinned `1.5.0` literally, so the first thing this release did was make the checker warn about itself. It now derives the version from the manifest and asserts the ROADMAP head states it — the same stale-literal failure the hardcoded headline list produced during #168.

## Verification

Suite 148/148, coherence 36 OK / 0 WARN / 0 ERR, clang-format clean.

Console validation of the resulting CI build runs before the release is published; the published MSIX will be that exact validated artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app package to version 1.5.1.0.
  * Added release notes covering CPU-prefill and KV-reuse improvements.

* **Documentation**
  * Clarified upgrade guidance, including in-place updates from 1.5.0.0 and migration requirements from earlier 1.4.x releases.
  * Updated the roadmap and documentation to reflect the latest release and product status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->