### PR TITLE
fix: prompt-length aborts, silent truncation, and thinking-model turn loss

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,8 +77,13 @@ xllama/
 ```
 
 **Doc ownership (do not invent a second SSOT):** see `docs/README.md`. Structure →
-`architecture.md`; training → `training-architecture.md`; numbers →
-`bench/results` + generated `benchmarks.md`; UI steps → `using-the-app.md`.
+`architecture.md` (incl. catalogue `n_ctx`/`role`, ChatFormat, deferred surfaces);
+training → `training-architecture.md`; inventory/status → `model-matrix.md`;
+numbers → `bench/results` + generated `benchmarks.md`; UI steps → `using-the-app.md`.
+
+**Catalogue policy:** optional `n_ctx` and `role` (`coding`) are session knobs only
+— not a second backend. Gate: host Release smoke → console bench → then manifest.
+Measured ≠ shipped. No Settings magic for system prompts.
 
 ## Build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Coding + chat + thinking tier (phase14), architecture-first.** Catalogue
+  `n_ctx` / `role: coding`; no Settings system-prompt rewrite. Catalogue:
+  `qwen25-coder-0.5b` / `1.5b` / `3b`, `qwen3-1.7b`, **`lfm25-1.2b-thinking`**.
+  Console: Coder-0.5B **62.4** tok/s / 533 MB, Thinking **36.7** / 811 MB,
+  Coder-1.5B **26.1** / 1179 MB, Qwen3-1.7B **21.8** / 1398 MB, Coder-3B
+  **14.0** / 2116 MB (`phase14-console.csv`).
+- **Thinking product path:** `model_is_thinking` + `strip_thinking_blocks` in
+  `ChatFormat::postprocess_output` (display/persist answer only; no UI magic).
+- **`model_is_qwen3`:** no-think prefill only for Qwen3 (not Coder / Thinking).
+- **Design / BP docs:** catalogue policy, validation ladder, deferred FIM/tools.
+- **Linux peak RSS.** `peak_working_set_mb()` via `/proc` VmHWM.
+
 ## [1.5.1.0] - 2026-07-27
 
 The Phase 13 CPU-prefill and KV-reuse campaign, shipped. Every turn a chat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,43 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Design / BP docs:** catalogue policy, validation ladder, deferred FIM/tools.
 - **Linux peak RSS.** `peak_working_set_mb()` via `/proc` VmHWM.
 
+### Fixed
+
+- **A long prompt aborted the process instead of failing (llama.cpp backend).**
+  Both prefills (`LlamaSession::generate` and `run_inference`) submitted the whole
+  prompt as ONE logical batch, and `llama_decode` does not return an error for an
+  oversized batch — it trips `GGML_ASSERT(n_tokens_all <= cparams.n_batch)`, which
+  aborts in Release too. `n_batch` defaults to `min(n_ctx, 2048)`, so ~2049 real
+  tokens were enough: reachable from the chat UI (the coding tier's 4096-token
+  session lets the trimmer pass 3846 tokens) and from the LAN API, which caps the
+  body at 8 MB and the token count not at all. The prefill is now chunked at
+  `llama_n_batch`; the physical ubatch (512, the #172 optimum the prefill rate was
+  measured on) is unchanged. A full prompt that cannot fit `n_ctx` at all now
+  fails fast with an actionable message, the way a continuation already did (#173).
+- **Replies were silently truncated at ~250 tokens on a full context.** The
+  trimmer ceiling reserved a flat 250 tokens for generation while the UI default
+  `n_predict` is 512 (slider up to 2048), and the generation loop clamps
+  `n_predict` to what the context has left — so a prompt sitting on the ceiling
+  got a cut-off answer with no error and no log, instead of the trimmer dropping
+  one more turn of history. `max_prompt_tokens_for_n_ctx` now reserves the
+  requested generation length (250 stays the floor, 256 the prompt floor).
+- **A thinking model could lose a whole turn.** When the reasoning block ran out
+  of tokens, `postprocess_output` correctly returned an empty answer — and the UI
+  then saved no message and never replaced the streamed paragraph, leaving raw
+  chain of thought on screen, a user turn with no reply in the history, and a
+  status of "Done". It now stores an explicit "reasoning only" turn and says so.
+- **`strip_thinking_blocks` handles a closer with no opener** (`reasoning…</think>
+answer`, when the template opens the block): previously the whole chain of
+  thought and the raw tag reached the screen and the saved history.
+- **No KV snapshot for thinking models (#170b).** The saved history is stripped
+  while the resident KV holds the full CoT, so on return the #170a prefix diff
+  always diverges (a full re-prefill on LFM's hybrid cache): the snapshot cost
+  tens of MB of writes to buy nothing. In-conversation delta reuse is unaffected.
+- **LAN chat no longer parses the catalogue on every request** — the manifest
+  (bundled file + LocalState override) was read under `hub.mtx` in front of every
+  model load; it is cached now, with a re-read on a miss so a model published
+  while the server runs is still picked up.
+
 ## [1.5.1.0] - 2026-07-27
 
 The Phase 13 CPU-prefill and KV-reuse campaign, shipped. Every turn a chat

--- a/README.md
+++ b/README.md
@@ -266,7 +266,8 @@ Text backends: **ORT GenAI** (ONNX catalogue dirs) and **llama.cpp GGUF** on
 `unified` builds; diffusion is plain ORT DirectML. Catalogue data lives in
 `uwp/models/manifest.json` ([models-v1 Release](https://github.com/gianlucamazza/xllama/releases/tag/models-v1));
 first launch downloads the default chat model. Roles and how to add a model:
-[docs/model-selection.md](./docs/model-selection.md). Operator defaults:
+[docs/model-selection.md](./docs/model-selection.md). Full tested/shipping
+inventory: [docs/model-matrix.md](./docs/model-matrix.md). Operator defaults:
 [docs/recommended-config.md](./docs/recommended-config.md). **Performance
 numbers:** [docs/benchmarks.md](./docs/benchmarks.md) only.
 
@@ -274,6 +275,9 @@ numbers:** [docs/benchmarks.md](./docs/benchmarks.md) only.
 | ------------------------------------ | --------------------------------------------------- |
 | Default chat (unified)               | `lfm25-350m`                                        |
 | Balanced / quality chat              | `lfm25-1.2b-instruct`, `lfm2-2.6b`                  |
+| Coding chat (GGUF · n_ctx 4096)      | `qwen25-coder-0.5b` / `1.5b` / `3b`                  |
+| Chat upgrade (Qwen3)                 | `qwen3-1.7b`                                         |
+| Reasoning (think stripped for UI)    | `lfm25-1.2b-thinking`                                |
 | ORT CPU / DML routing base           | `smollm2-360m-cpu-int4`, `smollm2-360m-dml-fp16-v2` |
 | Image gen                            | `sd-turbo-fp16`                                     |
 | Personalized (after on-device train) | `personalized` (LocalState override)                |

--- a/bench/benchmark-summary.json
+++ b/bench/benchmark-summary.json
@@ -62,6 +62,19 @@
       "tag": "#91 fixed (rmsfix)"
     },
     {
+      "label": "Qwen2.5-Coder-0.5B",
+      "params": "0.5B",
+      "source": "phase14-console.csv",
+      "selector": {
+        "model": "qwen25-coder-0.5b",
+        "n_threads": "6"
+      },
+      "backend_key": "llama",
+      "backend_label": "llama.cpp CPU · t6",
+      "quant_label": "Q4_K_M",
+      "tag": "coding · n_ctx 4096"
+    },
+    {
       "label": "Qwen3.5-0.8B",
       "params": "0.8B",
       "source": "phase5-gguf.csv",
@@ -82,6 +95,45 @@
       },
       "backend_key": "llama",
       "backend_label": "llama.cpp CPU · t6"
+    },
+    {
+      "label": "LFM2.5-1.2B-Thinking",
+      "params": "1.2B",
+      "source": "phase14-console.csv",
+      "selector": {
+        "model": "lfm25-1.2b-thinking",
+        "n_threads": "6"
+      },
+      "backend_key": "llama",
+      "backend_label": "llama.cpp CPU · t6",
+      "quant_label": "Q4_K_M",
+      "tag": "reasoning · think blocks stripped for display"
+    },
+    {
+      "label": "Qwen2.5-Coder-1.5B",
+      "params": "1.5B",
+      "source": "phase14-console.csv",
+      "selector": {
+        "model": "qwen25-coder-1.5b",
+        "n_threads": "6"
+      },
+      "backend_key": "llama",
+      "backend_label": "llama.cpp CPU · t6",
+      "quant_label": "Q4_K_M",
+      "tag": "coding · n_ctx 4096"
+    },
+    {
+      "label": "Qwen3-1.7B",
+      "params": "1.7B",
+      "source": "phase14-console.csv",
+      "selector": {
+        "model": "qwen3-1.7b",
+        "n_threads": "6"
+      },
+      "backend_key": "llama",
+      "backend_label": "llama.cpp CPU · t6",
+      "quant_label": "Q4_K_M",
+      "tag": "chat upgrade"
     },
     {
       "label": "SmolLM2-1.7B",
@@ -116,6 +168,19 @@
       },
       "backend_key": "llama",
       "backend_label": "llama.cpp CPU · t6"
+    },
+    {
+      "label": "Qwen2.5-Coder-3B",
+      "params": "3B",
+      "source": "phase14-console.csv",
+      "selector": {
+        "model": "qwen25-coder-3b",
+        "n_threads": "6"
+      },
+      "backend_key": "llama",
+      "backend_label": "llama.cpp CPU · t6",
+      "quant_label": "Q4_K_M",
+      "tag": "coding advanced · n_ctx 4096"
     },
     {
       "label": "Llama-3.2-3B",

--- a/bench/results/phase14-console.csv
+++ b/bench/results/phase14-console.csv
@@ -1,0 +1,11 @@
+model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,n_prompt_tok,n_gen_tok,max_length,host,date,run_index
+qwen25-coder-0.5b,Q4_K_M,cpu,4096,6,148.11,68.00,533,2783,0,0,298,6,0,xbox-series-s,2026-07-27T22:19:06Z,2
+qwen25-coder-0.5b,Q4_K_M,cpu,4096,6,148.34,56.82,533,2813,0,0,298,6,0,xbox-series-s,2026-07-27T22:19:21Z,3
+lfm25-1.2b-thinking,Q4_K_M,cpu,2048,6,130.42,36.80,811,3653,0,0,298,153,0,xbox-series-s,2026-07-27T22:20:12Z,2
+lfm25-1.2b-thinking,Q4_K_M,cpu,2048,6,130.46,36.69,811,3663,0,0,298,215,0,xbox-series-s,2026-07-27T22:20:29Z,3
+qwen25-coder-1.5b,Q4_K_M,cpu,4096,6,96.65,26.52,1179,5052,0,0,298,119,0,xbox-series-s,2026-07-27T22:21:09Z,2
+qwen25-coder-1.5b,Q4_K_M,cpu,4096,6,96.57,25.73,1179,5129,0,0,298,512,0,xbox-series-s,2026-07-27T22:21:39Z,3
+qwen3-1.7b,Q4_K_M,cpu,2048,6,89.55,21.85,1398,5521,0,0,296,425,0,xbox-series-s,2026-07-27T22:22:50Z,2
+qwen3-1.7b,Q4_K_M,cpu,2048,6,89.53,21.70,1398,5510,0,0,296,491,0,xbox-series-s,2026-07-27T22:23:28Z,3
+qwen25-coder-3b,Q4_K_M,cpu,4096,6,46.18,14.07,2116,9949,0,0,298,360,0,xbox-series-s,2026-07-27T22:24:56Z,2
+qwen25-coder-3b,Q4_K_M,cpu,4096,6,46.16,13.87,2116,9930,0,0,298,6,0,xbox-series-s,2026-07-27T22:25:16Z,3

--- a/bench/results/phase14-host-validation.csv
+++ b/bench/results/phase14-host-validation.csv
@@ -1,0 +1,7 @@
+model,quant,backend,n_ctx,n_threads,prompt_tok_s,decode_tok_s,peak_ws_mb,load_ms,gpu_mem_mb,gpu_budget_mb,n_prompt_tok,n_gen_tok,max_length,host,date,run_index,notes,quality
+qwen25-coder-0.5b,Q4_K_M,cpu,4096,6,81.0,30.9,513,1226,0,0,56,0,0,lenovo-release-t6,2026-07-27T20:07:29Z,1,host-release-fib-smoke,PASS
+qwen25-coder-1.5b,Q4_K_M,cpu,4096,6,40.3,17.2,1703,2666,0,0,56,0,0,lenovo-release-t6,2026-07-27T20:07:29Z,1,host-release-fib-smoke,PASS
+qwen25-coder-3b,Q4_K_M,cpu,4096,6,17.7,9.7,3301,5175,0,0,56,0,0,lenovo-release-t6,2026-07-27T20:07:29Z,1,host-release-fib-smoke-Q4,PASS
+qwen3-1.7b,Q4_K_M,cpu,2048,6,39.0,17.2,1976,2314,0,0,37,0,0,lenovo-release-t6,2026-07-27T20:07:29Z,1,host-release-2plus2,PASS
+lfm25-1.2b-thinking,Q4_K_M,cpu,2048,6,48.4,11.9,1228,1429,0,0,34,0,0,lenovo-release-t6,2026-07-27T20:08:20Z,1,host-release-think-n256,PASS
+qwen25-coder-3b-q3,Q3_K_M,cpu,4096,6,1.9,1.3,2232,29759,0,0,52,0,0,lenovo-debug-t6,2026-07-27T19:48:40Z,1,host-debug-Q3-quality-FAIL,FAIL

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Technical notes and design decisions for xllama.
 | Generated performance summary                                                          | [benchmarks.md](./benchmarks.md) + [benchmarks-charts.html](./benchmarks-charts.html)                                        |
 | Bench methodology / CSV schema                                                         | [`../bench/README.md`](../bench/README.md)                                                                                   |
 | Model catalogue + backend selection                                                    | [model-selection.md](./model-selection.md) (narrative) + [`../uwp/models/manifest.json`](../uwp/models/manifest.json) (data) |
+| Full model inventory (tested / shipping / rejected, roles, H9, coding)                 | [model-matrix.md](./model-matrix.md) (status SSOT; numbers still link to benchmarks.md)                                  |
 | UWP/AppContainer constraints (§1–§13)                                                  | [uwp-constraints.md](./uwp-constraints.md)                                                                                   |
 | Runtime NuGet pins                                                                     | [recommended-config.md](./recommended-config.md) (narrative) + [`../uwp/packages.config`](../uwp/packages.config) (data)     |
 | Patched-DLL lifecycle                                                                  | [vendor-lifecycle-plan.md](./vendor-lifecycle-plan.md)                                                                       |
@@ -73,6 +74,7 @@ path checklist for discovery — descriptions are not repeated.
 [../bench/README.md](../bench/README.md)
 
 **Evidence / history:** [benchmarks.md](./benchmarks.md) ·
+[model-matrix.md](./model-matrix.md) ·
 [phase7-hypotheses.md](./phase7-hypotheses.md) ·
 [technical-report.md](./technical-report.md) (frozen v1.0) ·
 [phase1-runbook.md](./phase1-runbook.md) (compat redirect) ·

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,12 +92,12 @@ Prompt formatting is data-driven, not hard-coded. `chat_format_for(model_id)`
 Detection uses the **basename only** (never path segments — a cache dir named
 `xllama` must not select Llama-3). Families:
 
-| Kind | Markers | System style | Typical catalogue |
-| --- | --- | --- | --- |
-| **ChatML** | `<\|im_start\|>` … `<\|im_end\|>` | Dedicated system turn | SmolLM2, LFM, Qwen2.5-Coder, Qwen3 |
-| **Gemma** | `<start_of_turn>` … `<end_of_turn>` | Merge system into first user | `gemma3-270m`, `gemma4-e2b` |
-| **Llama-3** | header / `eot` tokens | Dedicated system turn | `llama32-3b` |
-| **Phi-3** | `<\|user\|>` … `<\|end\|>` | Dedicated system turn | Phi GGUFs (campaign / override) |
+| Kind        | Markers                             | System style                 | Typical catalogue                  |
+| ----------- | ----------------------------------- | ---------------------------- | ---------------------------------- |
+| **ChatML**  | `<\|im_start\|>` … `<\|im_end\|>`   | Dedicated system turn        | SmolLM2, LFM, Qwen2.5-Coder, Qwen3 |
+| **Gemma**   | `<start_of_turn>` … `<end_of_turn>` | Merge system into first user | `gemma3-270m`, `gemma4-e2b`        |
+| **Llama-3** | header / `eot` tokens               | Dedicated system turn        | `llama32-3b`                       |
+| **Phi-3**   | `<\|user\|>` … `<\|end\|>`          | Dedicated system turn        | Phi GGUFs (campaign / override)    |
 
 **Qwen3 vs Qwen2.5 (no-think prefill).** Qwen3.x with `enable_thinking=false`
 expects an empty `<think>\n\n</think>` block after the assistant header.
@@ -191,10 +191,10 @@ Optional per-entry fields used at **session open** (not only download). Helpers
 live next to the prompt budget in `routing_policy.h` so the trimmer and
 `kDefaultNCtx` cannot drift independently (#171 / #133 class):
 
-| Field | Contract |
-| --- | --- |
-| **`n_ctx`** | `0`/omit → `kDefaultNCtx` (2048). Else clamped by `resolve_n_ctx` to **[512, 8192]**. Applied in `EnsureSession` and the LAN chat handler when opening the hub session. Coding catalogue entries use **4096**. |
-| **`role`** | `""` (default chat) or **`"coding"`**. Effects only: (1) UI trimmer uses `kEstimatedCharsPerTokenCoding` (3.5) instead of prose 5.0; (2) LAN `POST /v1/chat/completions` with **empty** `system` fills `kCodingSystemPrompt` instead of `kDefaultSystemPrompt`. |
+| Field       | Contract                                                                                                                                                                                                                                                        |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`n_ctx`** | `0`/omit → `kDefaultNCtx` (2048). Else clamped by `resolve_n_ctx` to **[512, 8192]**. Applied in `EnsureSession` and the LAN chat handler when opening the hub session. Coding catalogue entries use **4096**.                                                  |
+| **`role`**  | `""` (default chat) or **`"coding"`**. Effects only: (1) UI trimmer uses `kEstimatedCharsPerTokenCoding` (3.5) instead of prose 5.0; (2) LAN `POST /v1/chat/completions` with **empty** `system` fills `kCodingSystemPrompt` instead of `kDefaultSystemPrompt`. |
 
 **Explicit non-effects (do not re-introduce):**
 
@@ -205,10 +205,19 @@ live next to the prompt budget in `routing_policy.h` so the trimmer and
 - There is **no** third “coding” pillar or FIM path. Coding chat is the same
   GGUF/`Session`/`ChatFormat` stack as general chat.
 
-Trimmer ceiling for a non-default context: `max_prompt_tokens_for_n_ctx(n_ctx)`
-→ `n_ctx − kReservedGenerationTokens` (250), with the shipping default kept as
-the historical constant `kMaxPromptTokens` (1800) so the #171 pin does not drift
-by arithmetic alone.
+Trimmer ceiling: `max_prompt_tokens_for_n_ctx(n_ctx, reserved)` →
+`n_ctx − reserved`, where `reserved` is the requested generation length with
+`kReservedGenerationTokens` (250) as its floor and 256 tokens as the prompt floor.
+The shipping default with the default reserve keeps the historical constant
+`kMaxPromptTokens` (1800) so the #171 pin does not drift by arithmetic alone.
+Reserving the actual `n_predict` matters because the generation loop clamps it to
+what the context has left (#173): a ceiling that reserves less cuts the reply
+silently instead of dropping one more turn of history.
+
+The prefill itself is chunked at `llama_n_batch` (`LlamaSession::generate`,
+`run_inference`): an oversized logical batch is not an error return from
+`llama_decode` but a `GGML_ASSERT` abort, and `n_batch` defaults to
+`min(n_ctx, 2048)` — well below the 4096-token coding ceiling.
 
 Inventory / ship status of models: [model-matrix.md](model-matrix.md). Ops for
 adding entries: [model-selection.md](model-selection.md).
@@ -340,13 +349,26 @@ The shipping product is **multi-turn chat** (UI + optional LAN OpenAI-compat
 chat) on a **single resident session**. The following are **not** implemented
 and must not be half-added:
 
-| Surface | Status | Why deferred / rule |
-| --- | --- | --- |
-| Chat instruct (all catalogue text models) | **In scope** | One `ChatFormat` + `Session::generate` |
-| Coding **chat** (`role: coding`, larger `n_ctx`) | **In scope** | Same path; catalogue policy only |
-| Thinking models (basename `thinking`) | **In scope** | ChatML; `strip_thinking_content` → `postprocess_output` drops `<think>…</think>` for display/persist (KV still saw full stream). Catalogue: `lfm25-1.2b-thinking` |
-| FIM / fill-in-middle / IDE completion | **Out** | Second prompt surface (`render_fim` + completions route); not wired |
-| Tool-calling / agent loops | **Out** | Schema + multi-step orchestration above `Session` |
+| Surface                                          | Status       | Why deferred / rule                                                                                                                                               |
+| ------------------------------------------------ | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Chat instruct (all catalogue text models)        | **In scope** | One `ChatFormat` + `Session::generate`                                                                                                                            |
+| Coding **chat** (`role: coding`, larger `n_ctx`) | **In scope** | Same path; catalogue policy only                                                                                                                                  |
+| Thinking models (basename `thinking`)            | **In scope** | ChatML; `strip_thinking_content` → `postprocess_output` drops `<think>…</think>` for display/persist (KV still saw full stream). Catalogue: `lfm25-1.2b-thinking` |
+| FIM / fill-in-middle / IDE completion            | **Out**      | Second prompt surface (`render_fim` + completions route); not wired                                                                                               |
+| Tool-calling / agent loops                       | **Out**      | Schema + multi-step orchestration above `Session`                                                                                                                 |
+
+Two consequences of "the history is stripped, the KV is not", both deliberate:
+
+- **No KV snapshot (#170b) for thinking models.** On return, the rendered prompt
+  (stripped) diverges from the resident tokens (full CoT) inside the first
+  assistant turn, so the #170a prefix diff collapses — on LFM's hybrid cache, to a
+  full re-prefill. `SaveKvSnapshotAsync` returns early instead of writing tens of MB
+  to buy nothing. In-conversation delta reuse is unaffected: there the KV is the
+  truth and `render_delta` only closes the turn.
+- **An answer can postprocess to empty** when the reasoning block is truncated
+  (`n_predict` exhausted). The UI substitutes an explicit "reasoning only" turn:
+  before, the message was dropped silently, leaving the raw CoT orphaned on screen
+  and a user turn with no reply in the saved history.
 
 **Gate to catalogue:** measure on host Release → console headless bench → only
 then a `manifest.json` entry with a **complete** product path (template, load,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,11 +88,29 @@ is the one path that does **not** stream — it returns a completed response.
 ## Chat templates (`ChatFormat`)
 
 Prompt formatting is data-driven, not hard-coded. `chat_format_for(model_id)`
-(`src/bridge/chat_prompt.cpp`) returns a `ChatFormat` describing the template:
+(`src/bridge/chat_prompt.cpp`) returns a `ChatFormat` describing the template.
+Detection uses the **basename only** (never path segments — a cache dir named
+`xllama` must not select Llama-3). Families:
 
-- **ChatML** (`<|im_start|>…<|im_end|>`) — SmolLM2, Qwen, LFM.
-- **Gemma** (`<start_of_turn>…<end_of_turn>`, no system role — the system prompt is
-  merged into the first user turn, stop `<end_of_turn>`, `<bos>` via `add_bos`).
+| Kind | Markers | System style | Typical catalogue |
+| --- | --- | --- | --- |
+| **ChatML** | `<\|im_start\|>` … `<\|im_end\|>` | Dedicated system turn | SmolLM2, LFM, Qwen2.5-Coder, Qwen3 |
+| **Gemma** | `<start_of_turn>` … `<end_of_turn>` | Merge system into first user | `gemma3-270m`, `gemma4-e2b` |
+| **Llama-3** | header / `eot` tokens | Dedicated system turn | `llama32-3b` |
+| **Phi-3** | `<\|user\|>` … `<\|end\|>` | Dedicated system turn | Phi GGUFs (campaign / override) |
+
+**Qwen3 vs Qwen2.5 (no-think prefill).** Qwen3.x with `enable_thinking=false`
+expects an empty `<think>\n\n</think>` block after the assistant header.
+`qwen_no_think_gen_suffix` applies that **only** when `model_is_qwen3` and not
+`model_is_thinking` (basename `qwen3` / `qwen-3` — catalogue `qwen35-0.8b`,
+`qwen3-1.7b`). It must **not** apply to Qwen2.5-Coder or to LFM Thinking:
+those either are plain ChatML or emit real CoT (stripped at display time).
+
+**Thinking models.** Basename contains `thinking` → `strip_thinking_content` on
+the `ChatFormat`. After each turn, UI and LAN call `postprocess_output`, which
+runs `strip_thinking_blocks` so history and screen keep the final answer only.
+Streaming may briefly show raw CoT until the turn finishes and the paragraph is
+replaced — no second Settings path, no n_predict special-case in policy.
 
 `render_prompt` / `render_delta` build the full prompt or the KV-reuse delta;
 `apply_stop_sequences` is the one shared suffix-match helper used by both the ORT
@@ -166,6 +184,34 @@ The catalogue is `uwp/models/manifest.json` (bundled base) merged with an option
 reinstall-free `LocalState\manifest.json` override, per entry, by
 `merge_manifest_entries` (`manifest_merge.h`): a same-`name` entry replaces the base
 one, a new name is appended, unmentioned entries stay.
+
+### Catalogue session policy (`n_ctx`, `role`)
+
+Optional per-entry fields used at **session open** (not only download). Helpers
+live next to the prompt budget in `routing_policy.h` so the trimmer and
+`kDefaultNCtx` cannot drift independently (#171 / #133 class):
+
+| Field | Contract |
+| --- | --- |
+| **`n_ctx`** | `0`/omit → `kDefaultNCtx` (2048). Else clamped by `resolve_n_ctx` to **[512, 8192]**. Applied in `EnsureSession` and the LAN chat handler when opening the hub session. Coding catalogue entries use **4096**. |
+| **`role`** | `""` (default chat) or **`"coding"`**. Effects only: (1) UI trimmer uses `kEstimatedCharsPerTokenCoding` (3.5) instead of prose 5.0; (2) LAN `POST /v1/chat/completions` with **empty** `system` fills `kCodingSystemPrompt` instead of `kDefaultSystemPrompt`. |
+
+**Explicit non-effects (do not re-introduce):**
+
+- Settings system-prompt text is **never** rewritten when the model or role
+  changes. The box is user-owned; magic string-equality swaps are debt.
+- `role` does **not** select a backend, a template, or a sampler. Backend stays
+  `kind` + `Backend::Auto`; template stays `chat_format_for(model_id)`.
+- There is **no** third “coding” pillar or FIM path. Coding chat is the same
+  GGUF/`Session`/`ChatFormat` stack as general chat.
+
+Trimmer ceiling for a non-default context: `max_prompt_tokens_for_n_ctx(n_ctx)`
+→ `n_ctx − kReservedGenerationTokens` (250), with the shipping default kept as
+the historical constant `kMaxPromptTokens` (1800) so the #171 pin does not drift
+by arithmetic alone.
+
+Inventory / ship status of models: [model-matrix.md](model-matrix.md). Ops for
+adding entries: [model-selection.md](model-selection.md).
 
 `EnsureModelNamedAsync` (`uwp/MainPage.cpp`) provisions a model through the chain
 LocalState → bundled InstalledPath → USB → **catalogue download** (from the entry's
@@ -288,11 +334,50 @@ in [training-architecture.md §11](training-architecture.md). Pad steps:
 [using-the-app.md](using-the-app.md). Headless harness remains `train.flag` /
 `validate-console-training.sh device-train`.
 
+## Inference surfaces: in scope vs deferred
+
+The shipping product is **multi-turn chat** (UI + optional LAN OpenAI-compat
+chat) on a **single resident session**. The following are **not** implemented
+and must not be half-added:
+
+| Surface | Status | Why deferred / rule |
+| --- | --- | --- |
+| Chat instruct (all catalogue text models) | **In scope** | One `ChatFormat` + `Session::generate` |
+| Coding **chat** (`role: coding`, larger `n_ctx`) | **In scope** | Same path; catalogue policy only |
+| Thinking models (basename `thinking`) | **In scope** | ChatML; `strip_thinking_content` → `postprocess_output` drops `<think>…</think>` for display/persist (KV still saw full stream). Catalogue: `lfm25-1.2b-thinking` |
+| FIM / fill-in-middle / IDE completion | **Out** | Second prompt surface (`render_fim` + completions route); not wired |
+| Tool-calling / agent loops | **Out** | Schema + multi-step orchestration above `Session` |
+
+**Gate to catalogue:** measure on host Release → console headless bench → only
+then a `manifest.json` entry with a **complete** product path (template, load,
+session policy, and for thinking: postprocess). Measured ≠ shipped without that.
+
+## Model validation ladder (best practice)
+
+One direction, no parallel “truths”:
+
+```text
+host Release smoke (quality + peak)
+    → console headless bench (tok/s, peak, n_ctx)
+        → phase*.csv under bench/results/
+            → optional row in bench/benchmark-summary.json
+                → generate-benchmark-summary.py
+                    → docs/benchmarks.md (numbers SSOT)
+    → if product-complete: uwp/models/manifest.json
+        → docs/model-matrix.md (status SSOT)
+```
+
+- **Do not** invent a second performance table in README or model-selection.
+- **Do not** catalogue on host-only evidence for Series S claims.
+- **Do not** special-case Settings when a catalogue field already owns the
+  policy (`n_ctx`, `role`).
+
 ## See also
 
 - Performance numbers → [benchmarks.md](benchmarks.md)
 - AppContainer constraints (§1–§13) → [uwp-constraints.md](uwp-constraints.md)
 - Model catalogue / selection → [model-selection.md](model-selection.md) + `uwp/models/manifest.json`
+- Inventory / ship status → [model-matrix.md](model-matrix.md)
 - App UI (incl. personalize) → [using-the-app.md](using-the-app.md)
 - LAN protocol → [api-endpoint.md](api-endpoint.md)
 - v1.0 narrative snapshot → [technical-report.md](technical-report.md)

--- a/docs/benchmarks-charts.html
+++ b/docs/benchmarks-charts.html
@@ -302,6 +302,16 @@
     "tag": "#91 fixed (rmsfix)"
   },
   {
+    "model": "Qwen2.5-Coder-0.5B",
+    "quant": "Q4_K_M",
+    "be": "llama",
+    "prefill": 148.23,
+    "decode": 62.41,
+    "ram": 533,
+    "src": "phase14-console",
+    "tag": "coding \u00b7 n_ctx 4096"
+  },
+  {
     "model": "Qwen3.5-0.8B",
     "quant": "Q4_K_M",
     "be": "llama",
@@ -318,6 +328,36 @@
     "decode": 37.88,
     "ram": 811,
     "src": "phase7-lfm"
+  },
+  {
+    "model": "LFM2.5-1.2B-Thinking",
+    "quant": "Q4_K_M",
+    "be": "llama",
+    "prefill": 130.44,
+    "decode": 36.74,
+    "ram": 811,
+    "src": "phase14-console",
+    "tag": "reasoning \u00b7 think blocks stripped for display"
+  },
+  {
+    "model": "Qwen2.5-Coder-1.5B",
+    "quant": "Q4_K_M",
+    "be": "llama",
+    "prefill": 96.61,
+    "decode": 26.12,
+    "ram": 1179,
+    "src": "phase14-console",
+    "tag": "coding \u00b7 n_ctx 4096"
+  },
+  {
+    "model": "Qwen3-1.7B",
+    "quant": "Q4_K_M",
+    "be": "llama",
+    "prefill": 89.54,
+    "decode": 21.77,
+    "ram": 1398,
+    "src": "phase14-console",
+    "tag": "chat upgrade"
   },
   {
     "model": "SmolLM2-1.7B",
@@ -346,6 +386,16 @@
     "decode": 18.36,
     "ram": 1623,
     "src": "phase7-lfm"
+  },
+  {
+    "model": "Qwen2.5-Coder-3B",
+    "quant": "Q4_K_M",
+    "be": "llama",
+    "prefill": 46.17,
+    "decode": 13.97,
+    "ram": 2116,
+    "src": "phase14-console",
+    "tag": "coding advanced \u00b7 n_ctx 4096"
   },
   {
     "model": "Llama-3.2-3B",
@@ -420,7 +470,7 @@
   }
 ];
   const MAX_KV_REUSE = 20.02;
-  const LATEST_RUN = "2026-07-26";
+  const LATEST_RUN = "2026-07-27";
   // END GENERATED BENCHMARK DATA
   const METRICS = {
     decode:  { label: "Decode", unit: "tok/s", cap: "Generation throughput — the rate a user feels. Higher is better.", better: "high" },

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -54,18 +54,28 @@ generated from the committed raw results by `scripts/generate-benchmark-summary.
 | Gemma-3-270M | 270M | Q4_K_M | llama.cpp CPU · t6 | 395.0 | **76.8** | _single run_ | 368 | `phase6-gemma` |
 | SmolLM2-360M | 360M | int4 | ORT-GenAI CPU · t6 | 262.4 | **74.8** | 74.4–75.0 (n=3) | 708 | `t6-shipped-confirm` |
 | SmolLM2-360M | 360M | Q4_K_M | llama.cpp CPU · t6 | 141.5 | **62.9** | _single run_ | 402 | `phase35-llamacpp-scaling` |
+| Qwen2.5-Coder-0.5B | 0.5B | Q4_K_M | llama.cpp CPU · t6 | 148.2 | **62.4** | 56.8–68.0 (n=2) | 533 | `phase14-console` |
 | SmolLM2-360M | 360M | fp16 | ORT DirectML · RMSNorm fixed | 236.7 | **44.4** | _single run_ | 1268 | `phase2-dml` |
 | LFM2.5-1.2B | 1.2B | Q4_K_M | llama.cpp CPU · t6 | 76.2 | **37.9** | _single run_ | 811 | `phase7-lfm` |
+| LFM2.5-1.2B-Thinking | 1.2B | Q4_K_M | llama.cpp CPU · t6 | 130.4 | **36.7** | 36.7–36.8 (n=2) | 811 | `phase14-console` |
 | Qwen3.5-0.8B | 0.8B | Q4_K_M | llama.cpp CPU · t6 | 98.1 | **35.1** | _single run_ | 718 | `phase5-gguf` |
+| Qwen2.5-Coder-1.5B | 1.5B | Q4_K_M | llama.cpp CPU · t6 | 96.6 | **26.1** | 25.7–26.5 (n=2) | 1179 | `phase14-console` |
+| Qwen3-1.7B | 1.7B | Q4_K_M | llama.cpp CPU · t6 | 89.5 | **21.8** | 21.7–21.9 (n=2) | 1398 | `phase14-console` |
 | SmolLM2-1.7B | 1.7B | int4 | ORT-GenAI CPU | 54.9 | **20.6** | _single run_ | 2423 | `phase35-1b-cpu` |
 | LFM2-2.6B | 2.6B | Q4_K_M | llama.cpp CPU · t6 | 32.0 | **18.4** | _single run_ | 1623 | `phase7-lfm` |
 | Gemma-4-E2B | ~5B raw (2B eff) | Q3_K_S | llama.cpp CPU · t6 | 26.1 | **15.3** | _single run_ | 2742 | `phase6-gemma` |
 | Llama-3.2-3B | 3B | Q3_K_S | llama.cpp CPU · t6 | 19.5 | **14.2** | _single run_ | 1824 | `phase7-scale` |
+| Qwen2.5-Coder-3B | 3B | Q4_K_M | llama.cpp CPU · t6 | 46.2 | **14.0** | 13.9–14.1 (n=2) | 2116 | `phase14-console` |
 | Phi-3.5-mini | 3.8B | Q3_K_S | llama.cpp CPU · t6 | 15.3 | **11.3** | _single run_ | 2453 | `phase7-scale` |
 | Gemma-4-E2B | ~5B raw (2B eff) | IQ2_M | llama.cpp CPU · t6 | 13.5 | **9.9** | _single run_ | 2534 | `phase6-gemma` |
 | SmolLM2-360M | 360M | int4 | ORT DirectML int4 | 0.0 | **8.8** | _single run_ | 999 | `phase2-dml` |
 <!-- END GENERATED MODEL SUMMARY -->
 <!-- prettier-ignore-end -->
+
+- **Phase 14 coding/chat (2026-07-27, Series S):** Qwen2.5-Coder 0.5B/1.5B/3B,
+  Qwen3-1.7B, LFM2.5-1.2B-Thinking console-validated (`phase14-console.csv`).
+  Coder-0.5B lands next to SmolLM2 GGUF at ~62 tok/s; Coder-3B matches Llama-3.2-3B
+  decode (~14) with peak **2116 MB**. Thinking equals LFM 1.2B instruct peak RAM.
 
 Notes:
 

--- a/docs/model-matrix.md
+++ b/docs/model-matrix.md
@@ -1,34 +1,34 @@
 # Model matrix — xllama inventory
 
 **SSOT for “what have we tested / shipped / rejected” across text models.**
-Performance *numbers* for comparison rows remain generated in
+Performance _numbers_ for comparison rows remain generated in
 [benchmarks.md](./benchmarks.md) from `bench/results/` +
 `bench/benchmark-summary.json`. This page owns **status, roles, catalogue
 ids, templates, licenses, and campaign notes** — not runtime contracts.
 
-| Concern | Home |
-| --- | --- |
-| Structure (`n_ctx`, `role`, ChatFormat, out-of-scope surfaces) | [architecture.md](./architecture.md) |
-| How to add / select models | [model-selection.md](./model-selection.md) |
-| Catalogue data | [`../uwp/models/manifest.json`](../uwp/models/manifest.json) |
-| Tok/s tables | [benchmarks.md](./benchmarks.md) only |
+| Concern                                                        | Home                                                         |
+| -------------------------------------------------------------- | ------------------------------------------------------------ |
+| Structure (`n_ctx`, `role`, ChatFormat, out-of-scope surfaces) | [architecture.md](./architecture.md)                         |
+| How to add / select models                                     | [model-selection.md](./model-selection.md)                   |
+| Catalogue data                                                 | [`../uwp/models/manifest.json`](../uwp/models/manifest.json) |
+| Tok/s tables                                                   | [benchmarks.md](./benchmarks.md) only                        |
 
 Last updated: **2026-07-27** (phase14 **console** validation on Series S).
 
 ## How to read the columns
 
-| Column | Meaning |
-| --- | --- |
-| **Catalogue** | Id in `uwp/models/manifest.json` (`—` = not shipped) |
-| **Status** | `shipping` / `catalogue` / `campaign-only` / `host-smoke` / `rejected` |
-| **Console metrics** | Xbox Series S Dev Mode (see [benchmarks.md](./benchmarks.md)) |
-| **H9** | Deterministic 8-task suite (`phase7-h9.jsonl`), temperature 0 |
-| **Template** | `chat_format_for` selection |
-| **Role** | Catalogue `role` (`coding` → denser token estimate + coding system default) |
-| **n_ctx** | Session context (0/omit → `kDefaultNCtx` 2048) |
+| Column              | Meaning                                                                     |
+| ------------------- | --------------------------------------------------------------------------- |
+| **Catalogue**       | Id in `uwp/models/manifest.json` (`—` = not shipped)                        |
+| **Status**          | `shipping` / `catalogue` / `campaign-only` / `host-smoke` / `rejected`      |
+| **Console metrics** | Xbox Series S Dev Mode (see [benchmarks.md](./benchmarks.md))               |
+| **H9**              | Deterministic 8-task suite (`phase7-h9.jsonl`), temperature 0               |
+| **Template**        | `chat_format_for` selection                                                 |
+| **Role**            | Catalogue `role` (`coding` → denser token estimate + coding system default) |
+| **n_ctx**           | Session context (0/omit → `kDefaultNCtx` 2048)                              |
 
 Host figures are **not comparable** to console tok/s (different CPU, build type,
-and thermal). They only prove *load + generate + template*.
+and thermal). They only prove _load + generate + template_.
 
 ---
 
@@ -39,22 +39,22 @@ and thermal). They only prove *load + generate + template*.
 Headline metrics match the generated table in [benchmarks.md](./benchmarks.md).
 All rows below are **CPU-bound decode** unless backend says DirectML.
 
-| Model | Catalogue | Params | Quant | Backend | Prefill | Decode | Peak MB | H9 | Template | Role | n_ctx | Evidence |
-| --- | ---: | ---: | --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | --- |
-| LFM2.5-350M | `lfm25-350m` | 350M | Q4_K_M | llama.cpp | **438.1** | **94.9** | 320 | 4/8 | ChatML | — | 2048 | `phase13b-threadsbatch-after` · **default chat** |
-| Gemma-3-270M | `gemma3-270m` | 270M | Q4_K_M | llama.cpp | 395.0 | 76.8 | 368 | — | Gemma | — | 2048 | `phase6-gemma` |
-| SmolLM2-360M | `smollm2-360m-cpu-int4` | 360M | int4 | ORT CPU | 262.4 | 74.8 | 708 | — | ChatML | — | 2048 | `t6-shipped-confirm` |
-| SmolLM2-360M | (same family) | 360M | Q4_K_M | llama.cpp | 141.5 | 62.9 | 402 | — | ChatML | — | 2048 | `phase35-llamacpp-scaling` |
-| SmolLM2-360M DML v2 | `smollm2-360m-dml-fp16-v2` | 360M | fp16 | ORT DML | 236.7 | 44.4 | 1268 | — | ChatML | — | 2048 | `phase2-dml` · #91 parity OK |
-| LFM2.5-1.2B Instruct | `lfm25-1.2b-instruct` | 1.2B | Q4_K_M | llama.cpp | 76.2 | **37.9** | 811 | **6/8** | ChatML | — | 2048 | `phase7-lfm` · H1 PASS balanced |
-| Qwen3.5-0.8B | `qwen35-0.8b` | 0.8B | Q4_K_M | llama.cpp | 98.1 | 35.1 | 718 | — | ChatML + no-think | — | 2048 | `phase5-gguf` |
-| SmolLM2-1.7B | `smollm2-1.7b-cpu-int4` | 1.7B | int4 | ORT CPU | 54.9 | 20.6 | 2423 | — | ChatML | — | 2048 | `phase35-1b-cpu` |
-| LFM2-2.6B | `lfm2-2.6b` | 2.6B | Q4_K_M | llama.cpp | 32.0 | **18.4** | 1623 | **7/8** | ChatML | — | 2048 | `phase7-lfm` · H1 PASS quality |
-| Gemma-4-E2B | `gemma4-e2b` | ~2B eff | Q3_K_S | llama.cpp | 26.1 | 15.3 | 2742 | 6/8 | Gemma | — | 2048 | `phase6-gemma` |
-| Llama-3.2-3B Instruct | `llama32-3b` | 3B | Q3_K_S | llama.cpp | 19.5 | **14.2** | 1824 | 5/8 | Llama-3 | — | 2048 | `phase7-scale` · H4 preferred |
-| Phi-3.5-mini | — | 3.8B | Q3_K_S | llama.cpp | 15.3 | 11.3 | 2453 | — | Phi-3 | — | 2048 | `phase7-scale` · H4 PASS, loses A/B |
-| Gemma-4-E2B IQ2 | (upgraded away) | ~2B eff | IQ2_M | llama.cpp | 13.5 | 9.9 | 2534 | — | Gemma | — | 2048 | historical; EOG on long prompts |
-| SmolLM2-360M DML int4 | — | 360M | int4 | ORT DML | 0–153 | **8.8** | 999 | — | ChatML | — | 2048 | **rejected** wrong logits / slow |
+| Model                 |                  Catalogue |  Params | Quant  | Backend   |   Prefill |   Decode | Peak MB | H9      | Template          | Role | n_ctx | Evidence                                         |
+| --------------------- | -------------------------: | ------: | ------ | --------- | --------: | -------: | ------: | ------- | ----------------- | ---- | ----: | ------------------------------------------------ |
+| LFM2.5-350M           |               `lfm25-350m` |    350M | Q4_K_M | llama.cpp | **438.1** | **94.9** |     320 | 4/8     | ChatML            | —    |  2048 | `phase13b-threadsbatch-after` · **default chat** |
+| Gemma-3-270M          |              `gemma3-270m` |    270M | Q4_K_M | llama.cpp |     395.0 |     76.8 |     368 | —       | Gemma             | —    |  2048 | `phase6-gemma`                                   |
+| SmolLM2-360M          |    `smollm2-360m-cpu-int4` |    360M | int4   | ORT CPU   |     262.4 |     74.8 |     708 | —       | ChatML            | —    |  2048 | `t6-shipped-confirm`                             |
+| SmolLM2-360M          |              (same family) |    360M | Q4_K_M | llama.cpp |     141.5 |     62.9 |     402 | —       | ChatML            | —    |  2048 | `phase35-llamacpp-scaling`                       |
+| SmolLM2-360M DML v2   | `smollm2-360m-dml-fp16-v2` |    360M | fp16   | ORT DML   |     236.7 |     44.4 |    1268 | —       | ChatML            | —    |  2048 | `phase2-dml` · #91 parity OK                     |
+| LFM2.5-1.2B Instruct  |      `lfm25-1.2b-instruct` |    1.2B | Q4_K_M | llama.cpp |      76.2 | **37.9** |     811 | **6/8** | ChatML            | —    |  2048 | `phase7-lfm` · H1 PASS balanced                  |
+| Qwen3.5-0.8B          |              `qwen35-0.8b` |    0.8B | Q4_K_M | llama.cpp |      98.1 |     35.1 |     718 | —       | ChatML + no-think | —    |  2048 | `phase5-gguf`                                    |
+| SmolLM2-1.7B          |    `smollm2-1.7b-cpu-int4` |    1.7B | int4   | ORT CPU   |      54.9 |     20.6 |    2423 | —       | ChatML            | —    |  2048 | `phase35-1b-cpu`                                 |
+| LFM2-2.6B             |                `lfm2-2.6b` |    2.6B | Q4_K_M | llama.cpp |      32.0 | **18.4** |    1623 | **7/8** | ChatML            | —    |  2048 | `phase7-lfm` · H1 PASS quality                   |
+| Gemma-4-E2B           |               `gemma4-e2b` | ~2B eff | Q3_K_S | llama.cpp |      26.1 |     15.3 |    2742 | 6/8     | Gemma             | —    |  2048 | `phase6-gemma`                                   |
+| Llama-3.2-3B Instruct |               `llama32-3b` |      3B | Q3_K_S | llama.cpp |      19.5 | **14.2** |    1824 | 5/8     | Llama-3           | —    |  2048 | `phase7-scale` · H4 preferred                    |
+| Phi-3.5-mini          |                          — |    3.8B | Q3_K_S | llama.cpp |      15.3 |     11.3 |    2453 | —       | Phi-3             | —    |  2048 | `phase7-scale` · H4 PASS, loses A/B              |
+| Gemma-4-E2B IQ2       |            (upgraded away) | ~2B eff | IQ2_M  | llama.cpp |      13.5 |      9.9 |    2534 | —       | Gemma             | —    |  2048 | historical; EOG on long prompts                  |
+| SmolLM2-360M DML int4 |                          — |    360M | int4   | ORT DML   |     0–153 |  **8.8** |     999 | —       | ChatML            | —    |  2048 | **rejected** wrong logits / slow                 |
 
 Notes:
 
@@ -68,13 +68,13 @@ MSIX **1.5.1.737** (unified), t6, `standard-512` prompt, 2 recorded runs after
 warmup. Source: `bench/results/phase14-console.csv` (also in generated
 [benchmarks.md](./benchmarks.md)).
 
-| Model | Catalogue | Quant | n_ctx | Prefill | Decode | Decode spread | Peak MB | Status |
-| --- | --- | --- | ---: | ---: | ---: | --- | ---: | --- |
-| Qwen2.5-Coder-0.5B | `qwen25-coder-0.5b` | Q4_K_M | 4096 | **148.2** | **62.4** | 56.8–68.0 | 533 | **console PASS** · coding fast |
-| LFM2.5-1.2B-Thinking | `lfm25-1.2b-thinking` | Q4_K_M | 2048 | **130.4** | **36.7** | 36.7–36.8 | 811 | **console PASS** · `strip_thinking_content` for display |
-| Qwen2.5-Coder-1.5B | `qwen25-coder-1.5b` | Q4_K_M | 4096 | **96.6** | **26.1** | 25.7–26.5 | 1179 | **console PASS** · coding balanced |
-| Qwen3-1.7B | `qwen3-1.7b` | Q4_K_M | 2048 | **89.5** | **21.8** | 21.7–21.9 | 1398 | **console PASS** · chat upgrade |
-| Qwen2.5-Coder-3B | `qwen25-coder-3b` | Q4_K_M | 4096 | **46.2** | **14.0** | 13.9–14.1 | **2116** | **console PASS** · coding quality (under 3.5 GB) |
+| Model                | Catalogue             | Quant  | n_ctx |   Prefill |   Decode | Decode spread |  Peak MB | Status                                                  |
+| -------------------- | --------------------- | ------ | ----: | --------: | -------: | ------------- | -------: | ------------------------------------------------------- |
+| Qwen2.5-Coder-0.5B   | `qwen25-coder-0.5b`   | Q4_K_M |  4096 | **148.2** | **62.4** | 56.8–68.0     |      533 | **console PASS** · coding fast                          |
+| LFM2.5-1.2B-Thinking | `lfm25-1.2b-thinking` | Q4_K_M |  2048 | **130.4** | **36.7** | 36.7–36.8     |      811 | **console PASS** · `strip_thinking_content` for display |
+| Qwen2.5-Coder-1.5B   | `qwen25-coder-1.5b`   | Q4_K_M |  4096 |  **96.6** | **26.1** | 25.7–26.5     |     1179 | **console PASS** · coding balanced                      |
+| Qwen3-1.7B           | `qwen3-1.7b`          | Q4_K_M |  2048 |  **89.5** | **21.8** | 21.7–21.9     |     1398 | **console PASS** · chat upgrade                         |
+| Qwen2.5-Coder-3B     | `qwen25-coder-3b`     | Q4_K_M |  4096 |  **46.2** | **14.0** | 13.9–14.1     | **2116** | **console PASS** · coding quality (under 3.5 GB)        |
 
 Host Release cross-check (`phase14-host-validation.csv`): quality PASS for the
 coding tier + Qwen3-1.7B (Q3_K_M Coder-3B FAIL; **Q4 only** ships). Console peaks
@@ -93,8 +93,8 @@ DeepSeek-Coder-V2-Lite, LFM2.5-8B-A1B (~5 GB), StarCoder2 / DS-Coder 1.3B.
 
 ## B. Diffusion
 
-| Model | Catalogue | Role | Console | Notes |
-| --- | --- | --- | --- | --- |
+| Model         | Catalogue       | Role  | Console        | Notes                            |
+| ------------- | --------------- | ----- | -------------- | -------------------------------- |
 | SD-Turbo fp16 | `sd-turbo-fp16` | image | PASS (Phase 5) | 3-stage DirectML; optional TAESD |
 
 Numbers: [benchmarks.md](./benchmarks.md) / `phase5-diffuse.csv`.
@@ -103,54 +103,54 @@ Numbers: [benchmarks.md](./benchmarks.md) / `phase5-diffuse.csv`.
 
 ## C. Training / personalize
 
-| Artefact | Catalogue | Status |
-| --- | --- | --- |
+| Artefact                    | Catalogue                            | Status                          |
+| --------------------------- | ------------------------------------ | ------------------------------- |
 | Personalized adapter/merged | `personalized` (LocalState override) | Phase 11 UI + Lane B gates PASS |
-| Runtime LoRA | any `kind:gguf` + `lora` field | Supported (llama.cpp only) |
+| Runtime LoRA                | any `kind:gguf` + `lora` field       | Supported (llama.cpp only)      |
 
 ---
 
 ## D. Capability matrix by architecture class
 
-| Arch class | Examples in tree | KV shift | KV tail rewind | ORT | GGUF | Notes |
-| --- | --- | --- | --- | --- | --- | --- |
-| Dense standard | Llama-3.2, Qwen2.5-Coder, SmolLM2 GGUF | yes\* | yes | if ONNX | yes | \*if not SWA |
-| Hybrid attn+recurrent | LFM2 / LFM2.5 / Thinking | yes (front-drop) | **no** | no | yes | #170a degrade |
-| imrope / mrope | Qwen3 / Qwen3.5 | **no** | N/A | no | yes | #169 fail-fast |
-| SWA | some modern | **no** | careful | — | if arch in pin | `n_swa==0` gate |
-| MoE small active | (none shipping) | TBD | TBD | no | H2 open | need ≤~3.5 GB GGUF |
-| BitNet 1.58 | — | — | — | no | H5 desk | not shipping |
+| Arch class            | Examples in tree                       | KV shift         | KV tail rewind | ORT     | GGUF           | Notes                                                                 |
+| --------------------- | -------------------------------------- | ---------------- | -------------- | ------- | -------------- | --------------------------------------------------------------------- |
+| Dense standard        | Llama-3.2, Qwen2.5-Coder, SmolLM2 GGUF | yes\*            | yes            | if ONNX | yes            | \*if not SWA                                                          |
+| Hybrid attn+recurrent | LFM2 / LFM2.5 / Thinking               | yes (front-drop) | **no**         | no      | yes            | #170a degrade                                                         |
+| imrope / mrope        | Qwen3.5 (measured), Qwen3 (assumed)    | **no**           | N/A            | no      | yes            | #169 fail-fast; `can_shift` is runtime — only `qwen35-0.8b` was gated |
+| SWA                   | some modern                            | **no**           | careful        | —       | if arch in pin | `n_swa==0` gate                                                       |
+| MoE small active      | (none shipping)                        | TBD              | TBD            | no      | H2 open        | need ≤~3.5 GB GGUF                                                    |
+| BitNet 1.58           | —                                      | —                | —              | no      | H5 desk        | not shipping                                                          |
 
 ---
 
 ## E. Product roles (picker intent)
 
-| Role | Catalogue ids | Product note |
-| --- | --- | --- |
-| Default chat (unified) | `lfm25-350m` | First launch |
-| Balanced / quality chat | `lfm25-1.2b-instruct`, `lfm2-2.6b` | H1 tiers |
-| Peer dense chat | `llama32-3b`, `gemma4-e2b` | Advanced / heavy |
-| Coding fast / balanced / quality | `qwen25-coder-0.5b`, `…-1.5b`, `…-3b` | `role:coding`, `n_ctx` 4096 |
-| Chat upgrade (Qwen3) | `qwen3-1.7b` | no-think; no context shift |
-| Reasoning | `lfm25-1.2b-thinking` | CoT stripped for display |
-| ORT routing pair | `smollm2-360m-cpu-int4` + `…-dml-fp16-v2` | Auto GPU only on long first turn |
-| Image | `sd-turbo-fp16` | Image dialog |
-| Personalized | `personalized` | After on-device train |
+| Role                             | Catalogue ids                             | Product note                     |
+| -------------------------------- | ----------------------------------------- | -------------------------------- |
+| Default chat (unified)           | `lfm25-350m`                              | First launch                     |
+| Balanced / quality chat          | `lfm25-1.2b-instruct`, `lfm2-2.6b`        | H1 tiers                         |
+| Peer dense chat                  | `llama32-3b`, `gemma4-e2b`                | Advanced / heavy                 |
+| Coding fast / balanced / quality | `qwen25-coder-0.5b`, `…-1.5b`, `…-3b`     | `role:coding`, `n_ctx` 4096      |
+| Chat upgrade (Qwen3)             | `qwen3-1.7b`                              | no-think; shift unmeasured       |
+| Reasoning                        | `lfm25-1.2b-thinking`                     | CoT stripped for display         |
+| ORT routing pair                 | `smollm2-360m-cpu-int4` + `…-dml-fp16-v2` | Auto GPU only on long first turn |
+| Image                            | `sd-turbo-fp16`                           | Image dialog                     |
+| Personalized                     | `personalized`                            | After on-device train            |
 
 ---
 
 ## F. Survey rejected / deferred (desk 2026-07-27)
 
-| Candidate | Decision | Reason |
-| --- | --- | --- |
-| Qwen3-Coder-30B-A3B GGUF | reject for console | weight size |
-| Devstral Small | reject | weight size |
-| DeepSeek-Coder-V2-Lite | reject | weight size |
-| Qwen2.5-Coder-7B | defer | interactive decode too low |
-| StarCoder2-3B | defer | weaker than Qwen2.5-Coder-3B |
-| Phi-4-mini | defer (chat peer) | not coding; re-open if H9 peer needed |
-| Qwen3-1.7B/4B general | defer | chat upgrade, not coding |
-| Granite 3.1 2B / 4.0 micro | defer | generalist; lower priority |
+| Candidate                  | Decision           | Reason                                |
+| -------------------------- | ------------------ | ------------------------------------- |
+| Qwen3-Coder-30B-A3B GGUF   | reject for console | weight size                           |
+| Devstral Small             | reject             | weight size                           |
+| DeepSeek-Coder-V2-Lite     | reject             | weight size                           |
+| Qwen2.5-Coder-7B           | defer              | interactive decode too low            |
+| StarCoder2-3B              | defer              | weaker than Qwen2.5-Coder-3B          |
+| Phi-4-mini                 | defer (chat peer)  | not coding; re-open if H9 peer needed |
+| Qwen3-1.7B/4B general      | defer              | chat upgrade, not coding              |
+| Granite 3.1 2B / 4.0 micro | defer              | generalist; lower priority            |
 
 ---
 

--- a/docs/model-matrix.md
+++ b/docs/model-matrix.md
@@ -1,0 +1,174 @@
+# Model matrix — xllama inventory
+
+**SSOT for “what have we tested / shipped / rejected” across text models.**
+Performance *numbers* for comparison rows remain generated in
+[benchmarks.md](./benchmarks.md) from `bench/results/` +
+`bench/benchmark-summary.json`. This page owns **status, roles, catalogue
+ids, templates, licenses, and campaign notes** — not runtime contracts.
+
+| Concern | Home |
+| --- | --- |
+| Structure (`n_ctx`, `role`, ChatFormat, out-of-scope surfaces) | [architecture.md](./architecture.md) |
+| How to add / select models | [model-selection.md](./model-selection.md) |
+| Catalogue data | [`../uwp/models/manifest.json`](../uwp/models/manifest.json) |
+| Tok/s tables | [benchmarks.md](./benchmarks.md) only |
+
+Last updated: **2026-07-27** (phase14 **console** validation on Series S).
+
+## How to read the columns
+
+| Column | Meaning |
+| --- | --- |
+| **Catalogue** | Id in `uwp/models/manifest.json` (`—` = not shipped) |
+| **Status** | `shipping` / `catalogue` / `campaign-only` / `host-smoke` / `rejected` |
+| **Console metrics** | Xbox Series S Dev Mode (see [benchmarks.md](./benchmarks.md)) |
+| **H9** | Deterministic 8-task suite (`phase7-h9.jsonl`), temperature 0 |
+| **Template** | `chat_format_for` selection |
+| **Role** | Catalogue `role` (`coding` → denser token estimate + coding system default) |
+| **n_ctx** | Session context (0/omit → `kDefaultNCtx` 2048) |
+
+Host figures are **not comparable** to console tok/s (different CPU, build type,
+and thermal). They only prove *load + generate + template*.
+
+---
+
+## A. Shipping / catalogue text models (console or host)
+
+### A1. Console-validated performance (Series S)
+
+Headline metrics match the generated table in [benchmarks.md](./benchmarks.md).
+All rows below are **CPU-bound decode** unless backend says DirectML.
+
+| Model | Catalogue | Params | Quant | Backend | Prefill | Decode | Peak MB | H9 | Template | Role | n_ctx | Evidence |
+| --- | ---: | ---: | --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | --- |
+| LFM2.5-350M | `lfm25-350m` | 350M | Q4_K_M | llama.cpp | **438.1** | **94.9** | 320 | 4/8 | ChatML | — | 2048 | `phase13b-threadsbatch-after` · **default chat** |
+| Gemma-3-270M | `gemma3-270m` | 270M | Q4_K_M | llama.cpp | 395.0 | 76.8 | 368 | — | Gemma | — | 2048 | `phase6-gemma` |
+| SmolLM2-360M | `smollm2-360m-cpu-int4` | 360M | int4 | ORT CPU | 262.4 | 74.8 | 708 | — | ChatML | — | 2048 | `t6-shipped-confirm` |
+| SmolLM2-360M | (same family) | 360M | Q4_K_M | llama.cpp | 141.5 | 62.9 | 402 | — | ChatML | — | 2048 | `phase35-llamacpp-scaling` |
+| SmolLM2-360M DML v2 | `smollm2-360m-dml-fp16-v2` | 360M | fp16 | ORT DML | 236.7 | 44.4 | 1268 | — | ChatML | — | 2048 | `phase2-dml` · #91 parity OK |
+| LFM2.5-1.2B Instruct | `lfm25-1.2b-instruct` | 1.2B | Q4_K_M | llama.cpp | 76.2 | **37.9** | 811 | **6/8** | ChatML | — | 2048 | `phase7-lfm` · H1 PASS balanced |
+| Qwen3.5-0.8B | `qwen35-0.8b` | 0.8B | Q4_K_M | llama.cpp | 98.1 | 35.1 | 718 | — | ChatML + no-think | — | 2048 | `phase5-gguf` |
+| SmolLM2-1.7B | `smollm2-1.7b-cpu-int4` | 1.7B | int4 | ORT CPU | 54.9 | 20.6 | 2423 | — | ChatML | — | 2048 | `phase35-1b-cpu` |
+| LFM2-2.6B | `lfm2-2.6b` | 2.6B | Q4_K_M | llama.cpp | 32.0 | **18.4** | 1623 | **7/8** | ChatML | — | 2048 | `phase7-lfm` · H1 PASS quality |
+| Gemma-4-E2B | `gemma4-e2b` | ~2B eff | Q3_K_S | llama.cpp | 26.1 | 15.3 | 2742 | 6/8 | Gemma | — | 2048 | `phase6-gemma` |
+| Llama-3.2-3B Instruct | `llama32-3b` | 3B | Q3_K_S | llama.cpp | 19.5 | **14.2** | 1824 | 5/8 | Llama-3 | — | 2048 | `phase7-scale` · H4 preferred |
+| Phi-3.5-mini | — | 3.8B | Q3_K_S | llama.cpp | 15.3 | 11.3 | 2453 | — | Phi-3 | — | 2048 | `phase7-scale` · H4 PASS, loses A/B |
+| Gemma-4-E2B IQ2 | (upgraded away) | ~2B eff | IQ2_M | llama.cpp | 13.5 | 9.9 | 2534 | — | Gemma | — | 2048 | historical; EOG on long prompts |
+| SmolLM2-360M DML int4 | — | 360M | int4 | ORT DML | 0–153 | **8.8** | 999 | — | ChatML | — | 2048 | **rejected** wrong logits / slow |
+
+Notes:
+
+- Hybrid LFM: KV tail-rewind unsupported (#170a); front-drop context shift OK (#169).
+- Qwen3.5: `can_shift` false (imrope) — overflow fail-fast + trim, no RoPE shift.
+- DML text routing allowlist: only `smollm2-360m-dml-fp16-v2` (`dml_text_model_ok`).
+
+### A2. Phase 14 — console-validated (Series S, 2026-07-27)
+
+MSIX **1.5.1.737** (unified), t6, `standard-512` prompt, 2 recorded runs after
+warmup. Source: `bench/results/phase14-console.csv` (also in generated
+[benchmarks.md](./benchmarks.md)).
+
+| Model | Catalogue | Quant | n_ctx | Prefill | Decode | Decode spread | Peak MB | Status |
+| --- | --- | --- | ---: | ---: | ---: | --- | ---: | --- |
+| Qwen2.5-Coder-0.5B | `qwen25-coder-0.5b` | Q4_K_M | 4096 | **148.2** | **62.4** | 56.8–68.0 | 533 | **console PASS** · coding fast |
+| LFM2.5-1.2B-Thinking | `lfm25-1.2b-thinking` | Q4_K_M | 2048 | **130.4** | **36.7** | 36.7–36.8 | 811 | **console PASS** · `strip_thinking_content` for display |
+| Qwen2.5-Coder-1.5B | `qwen25-coder-1.5b` | Q4_K_M | 4096 | **96.6** | **26.1** | 25.7–26.5 | 1179 | **console PASS** · coding balanced |
+| Qwen3-1.7B | `qwen3-1.7b` | Q4_K_M | 2048 | **89.5** | **21.8** | 21.7–21.9 | 1398 | **console PASS** · chat upgrade |
+| Qwen2.5-Coder-3B | `qwen25-coder-3b` | Q4_K_M | 4096 | **46.2** | **14.0** | 13.9–14.1 | **2116** | **console PASS** · coding quality (under 3.5 GB) |
+
+Host Release cross-check (`phase14-host-validation.csv`): quality PASS for the
+coding tier + Qwen3-1.7B (Q3_K_M Coder-3B FAIL; **Q4 only** ships). Console peaks
+are the product figures (Coder-3B **2116 MB**).
+
+Thinking: catalogue `lfm25-1.2b-thinking` with `model_is_thinking` +
+`strip_thinking_blocks` in `postprocess_output` (display/persist answer only).
+
+Caveats on console MSIX 1.5.1.737 (pre-phase14 code): tok/s valid; new MSIX
+needed for catalogue download, n_ctx/role, clean templates, and think stripping.
+
+**Out of budget / deferred:** Qwen2.5-Coder-7B+, Qwen3-Coder MoE 30B+, Devstral 24B,
+DeepSeek-Coder-V2-Lite, LFM2.5-8B-A1B (~5 GB), StarCoder2 / DS-Coder 1.3B.
+
+---
+
+## B. Diffusion
+
+| Model | Catalogue | Role | Console | Notes |
+| --- | --- | --- | --- | --- |
+| SD-Turbo fp16 | `sd-turbo-fp16` | image | PASS (Phase 5) | 3-stage DirectML; optional TAESD |
+
+Numbers: [benchmarks.md](./benchmarks.md) / `phase5-diffuse.csv`.
+
+---
+
+## C. Training / personalize
+
+| Artefact | Catalogue | Status |
+| --- | --- | --- |
+| Personalized adapter/merged | `personalized` (LocalState override) | Phase 11 UI + Lane B gates PASS |
+| Runtime LoRA | any `kind:gguf` + `lora` field | Supported (llama.cpp only) |
+
+---
+
+## D. Capability matrix by architecture class
+
+| Arch class | Examples in tree | KV shift | KV tail rewind | ORT | GGUF | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| Dense standard | Llama-3.2, Qwen2.5-Coder, SmolLM2 GGUF | yes\* | yes | if ONNX | yes | \*if not SWA |
+| Hybrid attn+recurrent | LFM2 / LFM2.5 / Thinking | yes (front-drop) | **no** | no | yes | #170a degrade |
+| imrope / mrope | Qwen3 / Qwen3.5 | **no** | N/A | no | yes | #169 fail-fast |
+| SWA | some modern | **no** | careful | — | if arch in pin | `n_swa==0` gate |
+| MoE small active | (none shipping) | TBD | TBD | no | H2 open | need ≤~3.5 GB GGUF |
+| BitNet 1.58 | — | — | — | no | H5 desk | not shipping |
+
+---
+
+## E. Product roles (picker intent)
+
+| Role | Catalogue ids | Product note |
+| --- | --- | --- |
+| Default chat (unified) | `lfm25-350m` | First launch |
+| Balanced / quality chat | `lfm25-1.2b-instruct`, `lfm2-2.6b` | H1 tiers |
+| Peer dense chat | `llama32-3b`, `gemma4-e2b` | Advanced / heavy |
+| Coding fast / balanced / quality | `qwen25-coder-0.5b`, `…-1.5b`, `…-3b` | `role:coding`, `n_ctx` 4096 |
+| Chat upgrade (Qwen3) | `qwen3-1.7b` | no-think; no context shift |
+| Reasoning | `lfm25-1.2b-thinking` | CoT stripped for display |
+| ORT routing pair | `smollm2-360m-cpu-int4` + `…-dml-fp16-v2` | Auto GPU only on long first turn |
+| Image | `sd-turbo-fp16` | Image dialog |
+| Personalized | `personalized` | After on-device train |
+
+---
+
+## F. Survey rejected / deferred (desk 2026-07-27)
+
+| Candidate | Decision | Reason |
+| --- | --- | --- |
+| Qwen3-Coder-30B-A3B GGUF | reject for console | weight size |
+| Devstral Small | reject | weight size |
+| DeepSeek-Coder-V2-Lite | reject | weight size |
+| Qwen2.5-Coder-7B | defer | interactive decode too low |
+| StarCoder2-3B | defer | weaker than Qwen2.5-Coder-3B |
+| Phi-4-mini | defer (chat peer) | not coding; re-open if H9 peer needed |
+| Qwen3-1.7B/4B general | defer | chat upgrade, not coding |
+| Granite 3.1 2B / 4.0 micro | defer | generalist; lower priority |
+
+---
+
+## G. Gaps still open
+
+1. ~~Console campaign phase14~~ — **done**.
+2. ~~Thinking product path~~ — **done** (`model_is_thinking` + strip for display).
+3. **Ship MSIX** with phase14 code (catalogue download, n_ctx/role, think strip).
+4. **H3 speculative decoding** (Coder-0.5B draft + 1.5B/3B target).
+5. **FIM / completions API** — out of scope (second prompt surface).
+6. Optional next models: Qwen3-4B-2507, Phi-4-mini, Gemma-3-1B, LFM2.5-230M.
+
+---
+
+## See also
+
+- Generated tok/s table → [benchmarks.md](./benchmarks.md)
+- Catalogue data → [`../uwp/models/manifest.json`](../uwp/models/manifest.json)
+- Selection / add-your-own → [model-selection.md](./model-selection.md)
+- Phase 7 research → [phase7-hypotheses.md](./phase7-hypotheses.md)
+- Runtime structure → [architecture.md](./architecture.md)

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -145,9 +145,12 @@ catalogue grows:
    for each file on selection. Without it, the entry expects the directory at
    `LocalState\models\<name>` (Device Portal upload) or USB `E:\xllama\models\<name>`.
    Optional fields: `kind` (`"ort-genai"` default; `"diffusion"` entries feed the
-   Image dialog and are hidden from the chat picker) and per-file `remote` (the
-   flat asset name in the release when `filename` carries a subpath, e.g.
-   `"filename": "unet/model.onnx"` + `"remote": "sd-turbo-fp16_unet_model.onnx"`).
+   Image dialog and are hidden from the chat picker); `n_ctx` (session context size,
+   `0`/omit = shipping default 2048; coding models use `4096`); `role`
+   (`""` or `"coding"` — denser prompt-token estimate + coding system default on
+   the LAN API); and per-file `remote` (the flat asset name in the release when
+   `filename` carries a subpath, e.g. `"filename": "unet/model.onnx"` +
+   `"remote": "sd-turbo-fp16_unet_model.onnx"`).
 
 2. Upload the override and (if needed) the model files:
 
@@ -163,6 +166,52 @@ catalogue grows:
 Constraints: `model.onnx` must be **self-contained** (< 2 GB, external data merged —
 `uwp-constraints.md §8`) and fit the Dev Mode disk budget. For diffusion models the
 contract is different (three components + CLIP assets): see `diffusion/README.md`.
+
+### Coding model entry (GGUF)
+
+**Design (SSOT structure):** [architecture.md](./architecture.md) — catalogue
+session policy + “inference surfaces”. **No third backend.** Coding is chat on
+the existing GGUF/`Session`/`ChatFormat` path with optional catalogue knobs.
+
+```json
+{
+  "models": [
+    {
+      "name": "qwen25-coder-1.5b",
+      "display": "Qwen2.5 Coder 1.5B (GGUF · CPU · coding)",
+      "kind": "gguf",
+      "role": "coding",
+      "n_ctx": 4096,
+      "hf_base_url": "https://huggingface.co/unsloth/Qwen2.5-Coder-1.5B-Instruct-GGUF/resolve/main",
+      "files": [
+        {
+          "filename": "Qwen2.5-Coder-1.5B-Instruct-Q4_K_M.gguf",
+          "approx_bytes": 986048032
+        }
+      ]
+    }
+  ]
+}
+```
+
+| Field | Effect | Non-effect |
+| --- | --- | --- |
+| `role: "coding"` | Trimmer 3.5 chars/token; LAN empty `system` → `kCodingSystemPrompt` | Does **not** rewrite Settings system prompt; does not pick backend/template |
+| `n_ctx: 4096` | Session + trimmer ceiling (`resolve_n_ctx` / `max_prompt_tokens_for_n_ctx`) | Does not change sampling or routing (GGUF has no EP routing) |
+| Chat template | `chat_format_for` by family — Qwen2.5-Coder = ChatML **without** Qwen3 no-think prefill | Qwen3 only gets empty-`<think>` via `model_is_qwen3` |
+
+**Best practices before shipping a new GGUF (any role):**
+
+1. Host **Release** smoke (`xllama-cli --chat --greedy`) — coherent output, peak RSS.
+2. Console headless (`bench-xbox-ort.sh`, set `--ctx` if non-default) → `bench/results/`.
+3. Only then: `manifest.json` entry + inventory line in [model-matrix.md](./model-matrix.md).
+4. Numbers go only through `benchmark-summary.json` → `generate-benchmark-summary.py`.
+5. Prefer 0.5–3B Q3/Q4 on Series S; reject 7B+ interactive for BW reasons (Phase 7).
+
+**Shipped (console phase14):** coding `qwen25-coder-0.5b` / `1.5b` / `3b`;
+chat `qwen3-1.7b`; reasoning `lfm25-1.2b-thinking` (CoT stripped for display via
+`model_is_thinking`). **Not catalogue:** FIM, tools/agents. Metrics:
+[benchmarks.md](./benchmarks.md), status: [model-matrix.md](./model-matrix.md).
 
 ### Runtime LoRA entry (GGUF only)
 

--- a/include/xllama/chat_prompt.h
+++ b/include/xllama/chat_prompt.h
@@ -8,8 +8,18 @@
 
 namespace xllama {
 
+// Shared system prompts (UI default, LAN API empty-system fill, CLI --chat).
+inline constexpr const char kDefaultSystemPrompt[] = "You are a helpful AI assistant.";
+// Applied when catalogue role is "coding" and the user has not set a custom system.
+inline constexpr const char kCodingSystemPrompt[] =
+    "You are a concise coding assistant. Prefer correct, complete code and brief explanations.";
+
 // True for catalogue ids or filenames that refer to a Qwen GGUF chat model.
 bool model_is_qwen(const std::string& model_id);
+
+// True for Qwen3.x (thinking-capable) ids — not Qwen2.5 / Qwen2.5-Coder.
+// Substring "qwen3" / "qwen-3" on the basename (catalogue id qwen35-0.8b matches).
+bool model_is_qwen3(const std::string& model_id);
 
 // True for catalogue ids or filenames that refer to a Gemma chat model
 // (substring "gemma", case-insensitive).
@@ -23,12 +33,23 @@ bool model_is_llama(const std::string& model_id);
 // case-insensitive). Selects the Phi-3 instruct template (<|user|>…<|end|>).
 bool model_is_phi(const std::string& model_id);
 
+// True for models that emit chain-of-thought inside <think>…</think> before the
+// user-visible answer (basename contains "thinking", e.g. lfm25-1.2b-thinking).
+// These keep plain ChatML with no Qwen3 no-think prefill; postprocess strips
+// think blocks for display/persist.
+bool model_is_thinking(const std::string& model_id);
+
 // Qwen3.x no-think generation prefill (matches Qwen3.5 Jinja with enable_thinking=false).
-// Empty when the model is not Qwen.
+// Empty when the model is not Qwen3 (Qwen2.5-Coder must not receive <think> markers).
 std::string qwen_no_think_gen_suffix(const std::string& model_id);
 
 // Remove leading empty </think> blocks (whitespace-only inside tags).
 std::string strip_empty_thinking_tags(std::string text);
+
+// Remove complete <think>…</think> blocks (any content). If an unclosed
+// <think> remains (n_predict cut mid-thought), drop from that open to EOF so
+// the UI does not keep raw reasoning. Leading/trailing whitespace cleaned.
+std::string strip_thinking_blocks(std::string text);
 
 // Stop-sequence check for streamed generation. Call after each token is appended
 // to `output`: if `output` now ENDS WITH any (non-empty) stop sequence, trim that
@@ -76,6 +97,10 @@ struct ChatFormat {
     std::vector<std::string> stop_sequences; // stop token(s); may be a prefix of turn_close
     std::string gen_suffix;                  // Qwen no-think prefill; else ""
 
+    // When true, postprocess_output strips full <think>…</think> reasoning
+    // (thinking models). Empty-think stripping for Qwen3 no-think always runs.
+    bool strip_thinking_content = false;
+
     // Full multi-turn prompt ending with the assistant generation header +
     // gen_suffix. gen_suffix is appended ONLY to the final (trailing) assistant
     // header, never to completed history turns. History turns are complete
@@ -95,8 +120,8 @@ struct ChatFormat {
     // count_tokens("") still pins the BOS.
     std::string render_system_prefix(const std::string& system) const;
 
-    // Output post-processing before display/persist (strips empty <think> blocks;
-    // no-op for Gemma).
+    // Output post-processing before display/persist: empty Qwen3 no-think tags;
+    // full think blocks when strip_thinking_content (thinking catalogue models).
     std::string postprocess_output(std::string text) const;
 };
 

--- a/include/xllama/chat_prompt.h
+++ b/include/xllama/chat_prompt.h
@@ -48,7 +48,11 @@ std::string strip_empty_thinking_tags(std::string text);
 
 // Remove complete <think>…</think> blocks (any content). If an unclosed
 // <think> remains (n_predict cut mid-thought), drop from that open to EOF so
-// the UI does not keep raw reasoning. Leading/trailing whitespace cleaned.
+// the UI does not keep raw reasoning — which can leave an EMPTY string, and
+// callers must handle that (see the empty-after-postprocess path in
+// MainPage.cpp). A </think> with no opener before it (the model's template
+// opened the reasoning) drops everything up to and including that closer.
+// Leading/trailing whitespace cleaned.
 std::string strip_thinking_blocks(std::string text);
 
 // Stop-sequence check for streamed generation. Call after each token is appended

--- a/include/xllama/routing_policy.h
+++ b/include/xllama/routing_policy.h
@@ -49,8 +49,12 @@ inline constexpr double kEstimatedCharsPerTokenCoding = 3.5;
 // tests/test_routing_policy.cpp pins the relation (#171).
 inline constexpr int kMaxPromptTokens = 1800;
 
-// Reserved room for the model reply when deriving a per-session trimmer ceiling
-// from a non-default n_ctx (catalogue coding models use 4096).
+// Floor for the room reserved to the model reply when deriving a per-session
+// trimmer ceiling from a non-default n_ctx (catalogue coding models use 4096).
+// Callers that know the requested generation length pass it instead: the
+// generation loop clamps n_predict to what the context has left
+// (session.cpp, #173), so a ceiling that reserves less than n_predict truncates
+// the reply silently rather than trimming one more turn of history.
 inline constexpr int kReservedGenerationTokens = 250;
 
 // Catalogue n_ctx bounds. 0 / omit → kDefaultNCtx. Above the max is clamped so
@@ -69,14 +73,18 @@ inline constexpr int resolve_n_ctx(int requested) {
     return requested;
 }
 
-// Trimmer ceiling for a session opened at |n_ctx|. The shipping default keeps
+// Trimmer ceiling for a session opened at |n_ctx|, leaving |reserved| tokens
+// (at least kReservedGenerationTokens) for the reply. The shipping default keeps
 // the historical kMaxPromptTokens constant (not n-250) so the #171 pin cannot
 // drift by arithmetic alone when kDefaultNCtx is retuned carefully with it.
-inline constexpr int max_prompt_tokens_for_n_ctx(int n_ctx) {
+inline constexpr int max_prompt_tokens_for_n_ctx(int n_ctx,
+                                                 int reserved = kReservedGenerationTokens) {
     const int n = resolve_n_ctx(n_ctx);
-    if (n == kDefaultNCtx)
+    if (reserved < kReservedGenerationTokens)
+        reserved = kReservedGenerationTokens;
+    if (n == kDefaultNCtx && reserved == kReservedGenerationTokens)
         return kMaxPromptTokens;
-    const int budget = n - kReservedGenerationTokens;
+    const int budget = n - reserved;
     return budget < 256 ? 256 : budget;
 }
 

--- a/include/xllama/routing_policy.h
+++ b/include/xllama/routing_policy.h
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: MIT
 // Per-workload EP routing policy (ORT GenAI only). GGUF models disable routing
 // and KV reuse at the UI layer; this header encodes the token threshold only.
+// Also owns the prompt-budget helpers used by catalogue roles (e.g. coding).
 #pragma once
+
+#include "xllama/inference_params.h" // kDefaultNCtx
 
 #include <cstddef>
 #include <string>
@@ -36,13 +39,77 @@ namespace xllama {
 // estimate does not model them.
 inline constexpr double kEstimatedCharsPerToken = 5.0;
 
+// Coding workloads (source, diffs, stack traces) tokenize denser / less
+// predictably than prose. A lower chars-per-token overestimates tokens and
+// trims earlier — same safety direction as the prose constant.
+inline constexpr double kEstimatedCharsPerTokenCoding = 3.5;
+
 // Token budget for the prompt itself, sized against kDefaultNCtx
 // (inference_params.h) with ~250 tokens left for generation —
 // tests/test_routing_policy.cpp pins the relation (#171).
 inline constexpr int kMaxPromptTokens = 1800;
 
+// Reserved room for the model reply when deriving a per-session trimmer ceiling
+// from a non-default n_ctx (catalogue coding models use 4096).
+inline constexpr int kReservedGenerationTokens = 250;
+
+// Catalogue n_ctx bounds. 0 / omit → kDefaultNCtx. Above the max is clamped so
+// a bad override cannot OOM the console KV pool.
+inline constexpr int kMinSessionNCtx = 512;
+inline constexpr int kMaxSessionNCtx = 8192;
+
+// Resolve a catalogue (or CLI) n_ctx request: 0 means shipping default.
+inline constexpr int resolve_n_ctx(int requested) {
+    if (requested <= 0)
+        return kDefaultNCtx;
+    if (requested < kMinSessionNCtx)
+        return kMinSessionNCtx;
+    if (requested > kMaxSessionNCtx)
+        return kMaxSessionNCtx;
+    return requested;
+}
+
+// Trimmer ceiling for a session opened at |n_ctx|. The shipping default keeps
+// the historical kMaxPromptTokens constant (not n-250) so the #171 pin cannot
+// drift by arithmetic alone when kDefaultNCtx is retuned carefully with it.
+inline constexpr int max_prompt_tokens_for_n_ctx(int n_ctx) {
+    const int n = resolve_n_ctx(n_ctx);
+    if (n == kDefaultNCtx)
+        return kMaxPromptTokens;
+    const int budget = n - kReservedGenerationTokens;
+    return budget < 256 ? 256 : budget;
+}
+
+// Catalogue `role` field (ASCII, case-insensitive). Only "coding" is special
+// today: denser token estimate in the UI trimmer, and the LAN API empty-system
+// fill (kCodingSystemPrompt). The Settings system-prompt box is never rewritten
+// from this flag — that would be string-magic debt.
+inline bool role_is_coding(std::string_view role) {
+    if (role.size() != 6)
+        return false;
+    constexpr char kCoding[] = "coding";
+    for (size_t i = 0; i < 6; ++i) {
+        char c = role[i];
+        if (c >= 'A' && c <= 'Z')
+            c = static_cast<char>(c - 'A' + 'a');
+        if (c != kCoding[i])
+            return false;
+    }
+    return true;
+}
+
+inline double chars_per_token_for_role(std::string_view role) {
+    return role_is_coding(role) ? kEstimatedCharsPerTokenCoding : kEstimatedCharsPerToken;
+}
+
+inline constexpr int estimate_tokens_from_chars(std::size_t chars, double chars_per_token) {
+    if (chars_per_token <= 0.0)
+        chars_per_token = kEstimatedCharsPerToken;
+    return static_cast<int>(static_cast<double>(chars) / chars_per_token);
+}
+
 inline constexpr int estimate_tokens_from_chars(std::size_t chars) {
-    return static_cast<int>(static_cast<double>(chars) / kEstimatedCharsPerToken);
+    return estimate_tokens_from_chars(chars, kEstimatedCharsPerToken);
 }
 
 enum class RoutingMode {

--- a/src/bridge/chat_prompt.cpp
+++ b/src/bridge/chat_prompt.cpp
@@ -122,6 +122,12 @@ std::string strip_thinking_blocks(std::string text) {
         }
         text.erase(o, (c + sizeof(kClose) - 1) - o);
     }
+    // A closer still standing after the balanced pass is a stray tag, not a
+    // block boundary ("<think>a</think>answer</think>"): drop the tag and keep
+    // the answer. Everything BEFORE the first closer was already dropped above
+    // when no opener preceded it.
+    for (size_t c = text.find(kClose); c != std::string::npos; c = text.find(kClose))
+        text.erase(c, sizeof(kClose) - 1);
     ltrim_inplace(text);
     // Trailing whitespace after the answer.
     while (!text.empty() && std::isspace(static_cast<unsigned char>(text.back())))

--- a/src/bridge/chat_prompt.cpp
+++ b/src/bridge/chat_prompt.cpp
@@ -97,7 +97,19 @@ std::string strip_empty_thinking_tags(std::string text) {
 std::string strip_thinking_blocks(std::string text) {
     constexpr char kOpen[] = "<think>";
     constexpr char kClose[] = "</think>";
-    // Complete blocks first (may appear more than once).
+    // Unbalanced closer first: a model whose template opens the reasoning for it
+    // (or a stop sequence that ate the opener) streams "reasoning…</think>answer"
+    // with no <think> at all. Without this the whole chain of thought AND the raw
+    // tag reach the screen and the saved history.
+    {
+        const size_t first_close = text.find(kClose);
+        if (first_close != std::string::npos) {
+            const size_t first_open = text.find(kOpen);
+            if (first_open == std::string::npos || first_open > first_close)
+                text.erase(0, first_close + sizeof(kClose) - 1);
+        }
+    }
+    // Complete blocks (may appear more than once).
     for (;;) {
         const size_t o = text.find(kOpen);
         if (o == std::string::npos)

--- a/src/bridge/chat_prompt.cpp
+++ b/src/bridge/chat_prompt.cpp
@@ -51,6 +51,13 @@ bool model_is_qwen(const std::string& model_id) {
     return to_lower(model_basename(model_id)).find("qwen") != std::string::npos;
 }
 
+bool model_is_qwen3(const std::string& model_id) {
+    // Qwen3 / Qwen3.5 thinking models. Must NOT match Qwen2.5 / Qwen2.5-Coder
+    // (basename "qwen25-coder-1.5b", "Qwen2.5-Coder-…").
+    const std::string b = to_lower(model_basename(model_id));
+    return b.find("qwen3") != std::string::npos || b.find("qwen-3") != std::string::npos;
+}
+
 bool model_is_gemma(const std::string& model_id) {
     return to_lower(model_basename(model_id)).find("gemma") != std::string::npos;
 }
@@ -63,8 +70,16 @@ bool model_is_phi(const std::string& model_id) {
     return to_lower(model_basename(model_id)).find("phi") != std::string::npos;
 }
 
+bool model_is_thinking(const std::string& model_id) {
+    // Catalogue / file ids like lfm25-1.2b-thinking, LFM2.5-1.2B-Thinking-….
+    return to_lower(model_basename(model_id)).find("thinking") != std::string::npos;
+}
+
 std::string qwen_no_think_gen_suffix(const std::string& model_id) {
-    if (!model_is_qwen(model_id))
+    // Only Qwen3.x uses the enable_thinking=false empty-<think> prefill.
+    // Applying it to Qwen2.5-Coder injects alien special tokens into ChatML.
+    // Thinking models must NOT get this suffix either (they produce real CoT).
+    if (!model_is_qwen3(model_id) || model_is_thinking(model_id))
         return {};
     return empty_think_block() + "\n\n";
 }
@@ -76,6 +91,29 @@ std::string strip_empty_thinking_tags(std::string text) {
         text.erase(0, kEmpty.size());
         ltrim_inplace(text);
     }
+    return text;
+}
+
+std::string strip_thinking_blocks(std::string text) {
+    constexpr char kOpen[] = "<think>";
+    constexpr char kClose[] = "</think>";
+    // Complete blocks first (may appear more than once).
+    for (;;) {
+        const size_t o = text.find(kOpen);
+        if (o == std::string::npos)
+            break;
+        const size_t c = text.find(kClose, o + sizeof(kOpen) - 1);
+        if (c == std::string::npos) {
+            // Truncated mid-thought: drop the open and everything after.
+            text.erase(o);
+            break;
+        }
+        text.erase(o, (c + sizeof(kClose) - 1) - o);
+    }
+    ltrim_inplace(text);
+    // Trailing whitespace after the answer.
+    while (!text.empty() && std::isspace(static_cast<unsigned char>(text.back())))
+        text.pop_back();
     return text;
 }
 
@@ -145,6 +183,7 @@ ChatFormat chat_format_for(const std::string& model_id) {
         f.system_style = SystemStyle::DedicatedTurn;
         f.stop_sequences = {"<|im_end|>"};
         f.gen_suffix = qwen_no_think_gen_suffix(model_id);
+        f.strip_thinking_content = model_is_thinking(model_id);
     }
     return f;
 }
@@ -207,6 +246,8 @@ std::string ChatFormat::render_delta(const std::string& user, bool prev_ended_wi
 }
 
 std::string ChatFormat::postprocess_output(std::string text) const {
+    if (strip_thinking_content)
+        text = strip_thinking_blocks(std::move(text));
     return strip_empty_thinking_tags(std::move(text));
 }
 

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -544,11 +544,19 @@ InferenceResult run_inference_llama(const InferenceParams& params) {
 
     log_output(("[xllama] prompt tokens: " + std::to_string(tokens.size()) + "\n").c_str());
     const auto t_prompt0 = std::chrono::steady_clock::now();
-    llama_batch batch = llama_batch_get_one(tokens.data(), static_cast<int32_t>(tokens.size()));
-    if (llama_decode(ctx.get(), batch) != 0) {
-        res.error_msg = "prompt decode failed";
-        log_output("[xllama] prompt decode failed\n");
-        return res;
+    // Chunked at n_batch: an oversized logical batch is a GGML_ASSERT abort in
+    // llama_decode, not an error code (same fix as LlamaSession::generate).
+    // n_ubatch — the chunk the prefill rate was measured on (#172) — is untouched.
+    const int n_prompt_batch = std::max(1, static_cast<int>(llama_n_batch(ctx.get())));
+    const int n_prompt_tokens = static_cast<int>(tokens.size());
+    for (int off = 0; off < n_prompt_tokens; off += n_prompt_batch) {
+        llama_batch batch = llama_batch_get_one(tokens.data() + off,
+                                                std::min(n_prompt_batch, n_prompt_tokens - off));
+        if (llama_decode(ctx.get(), batch) != 0) {
+            res.error_msg = "prompt decode failed";
+            log_output("[xllama] prompt decode failed\n");
+            return res;
+        }
     }
     const double prompt_ms =
         std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_prompt0)

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -549,6 +549,17 @@ InferenceResult run_inference_llama(const InferenceParams& params) {
     // n_ubatch — the chunk the prefill rate was measured on (#172) — is untouched.
     const int n_prompt_batch = std::max(1, static_cast<int>(llama_n_batch(ctx.get())));
     const int n_prompt_tokens = static_cast<int>(tokens.size());
+    // Chunking makes an oversized batch safe, not an oversized CONTEXT: a prompt
+    // past n_ctx would fail somewhere inside the loop with a bare "decode
+    // failed". Say what is actually wrong, before touching the cache — same
+    // message as LlamaSession::generate.
+    const int n_ctx_active = static_cast<int>(llama_n_ctx(ctx.get()));
+    if (n_prompt_tokens + 1 > n_ctx_active) {
+        res.error_msg = "prompt too long: " + std::to_string(n_prompt_tokens) +
+                        " tokens exceed n_ctx=" + std::to_string(n_ctx_active);
+        log_output(("[xllama] " + res.error_msg + "\n").c_str());
+        return res;
+    }
     for (int off = 0; off < n_prompt_tokens; off += n_prompt_batch) {
         llama_batch batch = llama_batch_get_one(tokens.data() + off,
                                                 std::min(n_prompt_batch, n_prompt_tokens - off));

--- a/src/bridge/platform.cpp
+++ b/src/bridge/platform.cpp
@@ -5,6 +5,8 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <mutex>
 #include <thread>
 
@@ -77,7 +79,21 @@ std::size_t peak_working_set_mb() noexcept {
         return pmc.PeakWorkingSetSize / (1024 * 1024);
     return 0;
 #else
-    return 0;
+    // Linux host: peak RSS from /proc (VmHWM is in kB). Was a hard 0 before —
+    // host coding/campaign benches then reported peak=0MB and looked broken.
+    FILE* fp = std::fopen("/proc/self/status", "r");
+    if (!fp)
+        return 0;
+    char line[256];
+    std::size_t kb = 0;
+    while (std::fgets(line, sizeof(line), fp)) {
+        if (std::strncmp(line, "VmHWM:", 6) == 0) {
+            kb = static_cast<std::size_t>(std::strtoul(line + 6, nullptr, 10));
+            break;
+        }
+    }
+    std::fclose(fp);
+    return kb / 1024;
 #endif
 }
 

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -748,8 +748,11 @@ class LlamaSession final : public Session {
                 res.error_msg = "prompt decode failed";
                 log_output("[xllama] session generate: prompt decode failed\n");
                 // The cache now holds a partial batch — nothing about it is
-                // trustworthy for a future prefix diff.
+                // trustworthy, so drop the record AND the cells. Clearing both
+                // keeps a continuation turn (which reads the cache length, not
+                // m_kv_tokens) from decoding on top of half a prefill.
                 m_kv_tokens.clear();
+                llama_memory_clear(mem, true);
                 return res;
             }
         }

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -665,6 +665,27 @@ class LlamaSession final : public Session {
         // prompt, the whole delta on a continuation.
         llama_token* pf = tokens.data() + (full_prompt ? kv_keep : 0);
         const int n_pf = static_cast<int>(tokens.size()) - (full_prompt ? (int)kv_keep : 0);
+        if (n_pf <= 0) {
+            // Both callers always render at least one token (a delta carries the
+            // turn close + user turn; a full prompt keeps size-1 at most), so
+            // this is a programming error, not a user-reachable state. Fail
+            // rather than sample on whatever logits the last decode left.
+            res.error_msg = "nothing to prefill";
+            log_output("[xllama] session generate: nothing to prefill\n");
+            return res;
+        }
+        if (full_prompt && kv_len + n_pf + 1 > m_n_ctx) {
+            // A full prompt has nothing older to evict — the UI trimmer
+            // (kMaxPromptTokens / max_prompt_tokens_for_n_ctx) owns that, and
+            // its char-based estimate can undershoot on dense code or CJK.
+            // Fail here: reaching llama_decode with more tokens than the
+            // context is not an error code but a GGML_ASSERT abort.
+            res.error_msg = "prompt too long: " + std::to_string(n_pf) +
+                            " tokens exceed n_ctx=" + std::to_string(m_n_ctx) +
+                            " — shorten the message or start a new chat";
+            log_output(("[xllama] session generate: " + res.error_msg + "\n").c_str());
+            return res;
+        }
         if (!full_prompt && kv_len + n_pf + 1 > m_n_ctx) {
             // #169: context shift — evict the oldest tokens past the pinned
             // head (gp.n_keep, the system prompt) and RoPE-shift the survivors
@@ -711,15 +732,26 @@ class LlamaSession final : public Session {
 
         // Prefill: positions continue automatically from the KV cache end, so a
         // reuse turn appends after the retained context.
+        //
+        // Chunked at llama_n_batch: llama_decode does not return an error for an
+        // oversized batch, it ASSERTS (GGML_ASSERT(n_tokens_all <= n_batch) in
+        // llama-context.cpp → abort, Release included). n_batch defaults to
+        // min(n_ctx, 2048) while the trimmer ceiling of a 4096-token coding
+        // session is 3846, so a long paste used to kill the process. This is the
+        // LOGICAL batch only — the physical ubatch stays 512 (#172 optimum),
+        // which is what the prefill rate was measured on.
         const auto t_prefill0 = std::chrono::steady_clock::now();
-        llama_batch batch = llama_batch_get_one(pf, n_pf);
-        if (llama_decode(ctx, batch) != 0) {
-            res.error_msg = "prompt decode failed";
-            log_output("[xllama] session generate: prompt decode failed\n");
-            // The cache now holds a partial batch — nothing about it is
-            // trustworthy for a future prefix diff.
-            m_kv_tokens.clear();
-            return res;
+        const int n_batch = std::max(1, static_cast<int>(llama_n_batch(ctx)));
+        for (int off = 0; off < n_pf; off += n_batch) {
+            llama_batch batch = llama_batch_get_one(pf + off, std::min(n_batch, n_pf - off));
+            if (llama_decode(ctx, batch) != 0) {
+                res.error_msg = "prompt decode failed";
+                log_output("[xllama] session generate: prompt decode failed\n");
+                // The cache now holds a partial batch — nothing about it is
+                // trustworthy for a future prefix diff.
+                m_kv_tokens.clear();
+                return res;
+            }
         }
         res.t_p_eval_ms =
             std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_prefill0)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 Gianluca Mazza
 // SPDX-License-Identifier: MIT
 
-#include "xllama/chat_prompt.h"
+#include "xllama/chat_prompt.h" // kDefaultSystemPrompt
 #include "xllama/cli.h"
 #include "xllama/inference.h"
 #include "xllama/membw.h"
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
         // endpoint, because an empty system turn makes small instruct models
         // hallucinate the next role instead of answering (see api-server.cpp).
         const std::string system = params.system_prompt.empty()
-                                       ? std::string("You are a helpful AI assistant.")
+                                       ? std::string(xllama::kDefaultSystemPrompt)
                                        : params.system_prompt;
         params.prompt = fmt.render_prompt(system, /*history=*/{}, params.prompt);
         params.stop_sequences = fmt.stop_sequences;

--- a/tests/test_chat_prompt.cpp
+++ b/tests/test_chat_prompt.cpp
@@ -10,8 +10,17 @@ using namespace xllama;
 TEST_CASE("qwen detection") {
     CHECK(model_is_qwen("qwen35-0.8b"));
     CHECK(model_is_qwen("Qwen3.5-0.8B-Q4_K_M.gguf"));
+    CHECK(model_is_qwen("qwen25-coder-1.5b"));
     CHECK_FALSE(model_is_qwen("lfm25-350m"));
     CHECK_FALSE(model_is_qwen("smollm2-360m-cpu-int4"));
+}
+
+TEST_CASE("qwen3 detection excludes Qwen2.5-Coder") {
+    CHECK(model_is_qwen3("qwen35-0.8b"));
+    CHECK(model_is_qwen3("Qwen3.5-0.8B-Q4_K_M.gguf"));
+    CHECK_FALSE(model_is_qwen3("qwen25-coder-1.5b"));
+    CHECK_FALSE(model_is_qwen3("Qwen2.5-Coder-1.5B-Instruct-Q4_K_M.gguf"));
+    CHECK_FALSE(model_is_qwen3("lfm25-350m"));
 }
 
 TEST_CASE("qwen no-think generation suffix") {
@@ -20,6 +29,17 @@ TEST_CASE("qwen no-think generation suffix") {
     CHECK(suffix.find("qwen35") == std::string::npos);
     CHECK(suffix.find('\n') != std::string::npos);
     CHECK(qwen_no_think_gen_suffix("lfm25-350m").empty());
+    // Qwen2.5-Coder is plain ChatML — no empty <think> prefill.
+    CHECK(qwen_no_think_gen_suffix("qwen25-coder-1.5b").empty());
+    CHECK(qwen_no_think_gen_suffix("Qwen2.5-Coder-1.5B-Instruct-Q4_K_M.gguf").empty());
+}
+
+TEST_CASE("coding models use ChatML without think suffix") {
+    const auto fmt = chat_format_for("qwen25-coder-1.5b");
+    CHECK(fmt.kind == ChatFormatKind::ChatML);
+    CHECK(fmt.gen_suffix.empty());
+    CHECK(fmt.stop_sequences.size() == 1);
+    CHECK(fmt.stop_sequences[0] == "<|im_end|>");
 }
 
 TEST_CASE("strip empty thinking tags") {
@@ -27,6 +47,35 @@ TEST_CASE("strip empty thinking tags") {
     CHECK(strip_empty_thinking_tags(block + "\n\nCiao!") == "Ciao!");
     CHECK(strip_empty_thinking_tags("  \n" + block + "  \n  Risposta") == "Risposta");
     CHECK(strip_empty_thinking_tags("plain text") == "plain text");
+}
+
+TEST_CASE("thinking model detection and postprocess") {
+    CHECK(model_is_thinking("lfm25-1.2b-thinking"));
+    CHECK(model_is_thinking("LFM2.5-1.2B-Thinking-Q4_K_M.gguf"));
+    CHECK_FALSE(model_is_thinking("lfm25-1.2b-instruct"));
+    CHECK_FALSE(model_is_thinking("qwen35-0.8b"));
+
+    const auto fmt = chat_format_for("lfm25-1.2b-thinking");
+    CHECK(fmt.kind == ChatFormatKind::ChatML);
+    CHECK(fmt.gen_suffix.empty()); // no Qwen3 no-think prefill
+    CHECK(fmt.strip_thinking_content);
+
+    const std::string raw =
+        std::string("<think>") + " step by step\n" + "</think>" + "\n\n4";
+    CHECK(fmt.postprocess_output(raw) == "4");
+    // Truncated mid-thought: no answer left.
+    CHECK(fmt.postprocess_output(std::string("<think>") + " still going").empty());
+    // Non-thinking ChatML still only strips empty think blocks.
+    const auto plain = chat_format_for("lfm25-350m");
+    CHECK_FALSE(plain.strip_thinking_content);
+    CHECK(plain.postprocess_output(raw).find("<think>") != std::string::npos);
+}
+
+TEST_CASE("strip_thinking_blocks complete and truncated") {
+    CHECK(strip_thinking_blocks("<think>a</think>\n\nanswer") == "answer");
+    CHECK(strip_thinking_blocks("<think>a</think><think>b</think>ok") == "ok");
+    CHECK(strip_thinking_blocks("no tags") == "no tags");
+    CHECK(strip_thinking_blocks("<think>cut off").empty());
 }
 
 TEST_CASE("apply_stop_sequences: suffix match trims and reports") {

--- a/tests/test_chat_prompt.cpp
+++ b/tests/test_chat_prompt.cpp
@@ -88,6 +88,11 @@ TEST_CASE("strip_thinking_blocks handles a closer with no opener") {
     // Reasoning only, no answer yet.
     CHECK(strip_thinking_blocks("reasoning, no closer").empty() == false);
     CHECK(strip_thinking_blocks("thoughts</think>").empty());
+    // A stray closer after a balanced block is a tag, not a boundary: the answer
+    // stays, the tag goes.
+    CHECK(strip_thinking_blocks("<think>a</think>answer</think>") == "answer");
+    CHECK(strip_thinking_blocks("<think>a<think>b</think>c</think>d") == "cd");
+    CHECK(strip_thinking_blocks("answer</think>trailing").find("</think>") == std::string::npos);
 }
 
 TEST_CASE("apply_stop_sequences: suffix match trims and reports") {

--- a/tests/test_chat_prompt.cpp
+++ b/tests/test_chat_prompt.cpp
@@ -78,6 +78,19 @@ TEST_CASE("strip_thinking_blocks complete and truncated") {
     CHECK(strip_thinking_blocks("<think>cut off").empty());
 }
 
+TEST_CASE("strip_thinking_blocks handles a closer with no opener") {
+    // The model's own template can open the reasoning, so the stream carries
+    // only the closing tag: everything up to it is chain of thought.
+    CHECK(strip_thinking_blocks("reasoning first</think>\n\nanswer") == "answer");
+    CHECK(strip_thinking_blocks("</think>answer") == "answer");
+    CHECK(strip_thinking_blocks("a</think>b<think>c</think>d") == "bd");
+    // An opener before the closer is the normal balanced case, untouched.
+    CHECK(strip_thinking_blocks("<think>a</think>b") == "b");
+    // Reasoning only, no answer yet.
+    CHECK(strip_thinking_blocks("reasoning, no closer").empty() == false);
+    CHECK(strip_thinking_blocks("thoughts</think>").empty());
+}
+
 TEST_CASE("apply_stop_sequences: suffix match trims and reports") {
     // Ends with the stop -> true, trailing match trimmed.
     std::string a = "Hello there<end_of_turn>";

--- a/tests/test_chat_prompt.cpp
+++ b/tests/test_chat_prompt.cpp
@@ -60,8 +60,7 @@ TEST_CASE("thinking model detection and postprocess") {
     CHECK(fmt.gen_suffix.empty()); // no Qwen3 no-think prefill
     CHECK(fmt.strip_thinking_content);
 
-    const std::string raw =
-        std::string("<think>") + " step by step\n" + "</think>" + "\n\n4";
+    const std::string raw = std::string("<think>") + " step by step\n" + "</think>" + "\n\n4";
     CHECK(fmt.postprocess_output(raw) == "4");
     // Truncated mid-thought: no answer left.
     CHECK(fmt.postprocess_output(std::string("<think>") + " still going").empty());

--- a/tests/test_routing_policy.cpp
+++ b/tests/test_routing_policy.cpp
@@ -153,6 +153,42 @@ TEST_CASE("routing: the trimmer budget fits the shipping context") {
     CHECK(kDefaultNCtx - kMaxPromptTokens >= 200);
 }
 
+TEST_CASE("resolve_n_ctx clamps and defaults") {
+    CHECK(resolve_n_ctx(0) == kDefaultNCtx);
+    CHECK(resolve_n_ctx(-1) == kDefaultNCtx);
+    CHECK(resolve_n_ctx(4096) == 4096);
+    CHECK(resolve_n_ctx(kMinSessionNCtx - 1) == kMinSessionNCtx);
+    CHECK(resolve_n_ctx(kMaxSessionNCtx + 1) == kMaxSessionNCtx);
+}
+
+TEST_CASE("max_prompt_tokens_for_n_ctx tracks session size") {
+    // Shipping default keeps the historical constant (not n-250 arithmetic).
+    CHECK(max_prompt_tokens_for_n_ctx(0) == kMaxPromptTokens);
+    CHECK(max_prompt_tokens_for_n_ctx(kDefaultNCtx) == kMaxPromptTokens);
+    // Coding catalogue n_ctx=4096 leaves ~250 for generation.
+    CHECK(max_prompt_tokens_for_n_ctx(4096) == 4096 - kReservedGenerationTokens);
+    CHECK(max_prompt_tokens_for_n_ctx(4096) > kMaxPromptTokens);
+    CHECK(max_prompt_tokens_for_n_ctx(4096) < 4096);
+}
+
+TEST_CASE("role_is_coding and denser token estimate") {
+    CHECK(role_is_coding("coding"));
+    CHECK(role_is_coding("Coding"));
+    CHECK(role_is_coding("CODING"));
+    CHECK_FALSE(role_is_coding(""));
+    CHECK_FALSE(role_is_coding("chat"));
+    CHECK_FALSE(role_is_coding("code"));
+
+    CHECK(chars_per_token_for_role("coding") == doctest::Approx(kEstimatedCharsPerTokenCoding));
+    CHECK(chars_per_token_for_role("") == doctest::Approx(kEstimatedCharsPerToken));
+
+    // Same char count → more estimated tokens for coding (trims earlier).
+    CHECK(estimate_tokens_from_chars(3500, kEstimatedCharsPerTokenCoding) == 1000);
+    CHECK(estimate_tokens_from_chars(3500) == 700);
+    CHECK(estimate_tokens_from_chars(3500, kEstimatedCharsPerTokenCoding) >
+          estimate_tokens_from_chars(3500));
+}
+
 TEST_CASE("routing: gguf disables routing") {
     RoutingSettings s;
     s.mode = RoutingMode::Auto;

--- a/tests/test_routing_policy.cpp
+++ b/tests/test_routing_policy.cpp
@@ -6,6 +6,8 @@
 #include "xllama/inference_params.h" // kDefaultNCtx (#171)
 #include "xllama/routing_policy.h"
 
+#include <algorithm>
+
 using namespace xllama;
 
 TEST_CASE("routing: cpu-only") {
@@ -169,6 +171,32 @@ TEST_CASE("max_prompt_tokens_for_n_ctx tracks session size") {
     CHECK(max_prompt_tokens_for_n_ctx(4096) == 4096 - kReservedGenerationTokens);
     CHECK(max_prompt_tokens_for_n_ctx(4096) > kMaxPromptTokens);
     CHECK(max_prompt_tokens_for_n_ctx(4096) < 4096);
+}
+
+TEST_CASE("max_prompt_tokens_for_n_ctx reserves the requested generation length") {
+    // The generation loop clamps n_predict to n_ctx - prompt (session.cpp,
+    // #173): a ceiling that reserves less than the requested n_predict cuts the
+    // reply silently instead of dropping one more turn. The UI default (512)
+    // is above the 250 floor, so it must move the ceiling on BOTH the shipping
+    // context and a catalogue coding one.
+    CHECK(max_prompt_tokens_for_n_ctx(kDefaultNCtx, 512) == kDefaultNCtx - 512);
+    CHECK(max_prompt_tokens_for_n_ctx(kDefaultNCtx, 512) < kMaxPromptTokens);
+    CHECK(max_prompt_tokens_for_n_ctx(4096, 512) == 4096 - 512);
+    // For every slider position (16..2048), a prompt sitting exactly on the
+    // ceiling still leaves room for the whole requested reply — unless the
+    // 256-token prompt floor kicks in first.
+    for (const int n_predict : {16, 256, 512, 1024, 2048}) {
+        for (const int n_ctx : {kDefaultNCtx, 4096}) {
+            const int ceiling = max_prompt_tokens_for_n_ctx(n_ctx, n_predict);
+            CHECK(ceiling >= 256);
+            CHECK(n_ctx - ceiling >= std::min(n_predict, n_ctx - 256));
+        }
+    }
+    // Below the floor the reserve does not shrink (250 stays the minimum).
+    CHECK(max_prompt_tokens_for_n_ctx(4096, 16) == max_prompt_tokens_for_n_ctx(4096));
+    CHECK(max_prompt_tokens_for_n_ctx(kDefaultNCtx, 0) == kMaxPromptTokens);
+    // A reserve as large as the context still leaves a usable prompt window.
+    CHECK(max_prompt_tokens_for_n_ctx(kDefaultNCtx, kDefaultNCtx) == 256);
 }
 
 TEST_CASE("role_is_coding and denser token estimate") {

--- a/tests/test_session.cpp
+++ b/tests/test_session.cpp
@@ -217,6 +217,98 @@ TEST_CASE("Session: KV prefix reuse collapses a repeated prefill (opt-in: XLLAMA
     }
 }
 
+// A prompt longer than the logical batch must be prefilled in chunks. This is
+// not a "nicer error" test: llama_decode ASSERTS n_tokens <= n_batch (GGML_ABORT,
+// Release included), so before the chunking this test process died. n_batch
+// defaults to min(n_ctx, 2048), so the regime only exists above the shipping
+// context — which is exactly what the coding catalogue opens (n_ctx 4096, ceiling
+// 3846 prompt tokens). Opt-in — needs a real GGUF:
+//   XLLAMA_TEST_MODEL=/path/to/model.gguf ./xllama-tests
+TEST_CASE("Session: a prompt past n_batch prefills in chunks (opt-in: XLLAMA_TEST_MODEL)") {
+    const char* model_env = std::getenv("XLLAMA_TEST_MODEL");
+    if (!model_env)
+        return;
+
+    // Same regime as a 4096-token coding session with the default 2048 batch,
+    // at 1/30th of the tokens: what matters is prompt > n_batch, and n_batch is
+    // a knob. A 2100-token prefill in a Debug build takes minutes; this runs in
+    // seconds and fails identically (an abort, not a failed assertion) without
+    // the chunking.
+    xllama::SessionParams sp;
+    sp.model_path = model_env;
+    sp.n_ctx = 512;
+    sp.n_batch = 64;
+    std::string err;
+    auto sess = xllama::Session::create(sp, &err);
+    REQUIRE_MESSAGE(sess, err);
+
+    // Grow past n_batch with the model's own tokenizer, so the test does not
+    // depend on one vocabulary's density.
+    std::string prompt = "Summarize the following log.\n";
+    int n_prompt = 0;
+    for (int i = 0; i < 200 && n_prompt <= 96; ++i) {
+        prompt += "line " + std::to_string(i) + ": nothing happened\n";
+        if ((i % 4) == 3)
+            n_prompt = sess->count_tokens(prompt);
+    }
+    n_prompt = sess->count_tokens(prompt);
+    REQUIRE(n_prompt > sp.n_batch); // past the logical batch: the regime under test
+    REQUIRE(n_prompt < 400);        // still inside n_ctx with room to generate
+
+    xllama::GenerateParams gp;
+    gp.prompt = prompt;
+    gp.n_predict = 8;
+    gp.temperature = 0.0f; // greedy: the two sessions below must agree
+    const auto r = sess->generate(gp);
+    REQUIRE_MESSAGE(r.success, r.error_msg); // before the chunking: SIGABRT here
+    CHECK(r.n_p_eval == n_prompt);           // every token was prefilled, not just the first chunk
+
+    // And chunking must not change what the model reads: the same prompt in ONE
+    // batch (default n_batch, well above this prompt) sees the same context.
+    // Only the leading token is compared — a different batch shape moves the
+    // last K/V bits, so greedy can flip at a near-tie downstream (same caveat as
+    // the #170a prefix-reuse case above).
+    sp.n_batch = 0;
+    auto whole = xllama::Session::create(sp, &err);
+    REQUIRE_MESSAGE(whole, err);
+    const auto r_whole = whole->generate(gp);
+    REQUIRE(r_whole.success);
+    CHECK(r_whole.n_p_eval == n_prompt);
+    CHECK(r.n_eval == r_whole.n_eval);
+    if (!r.output_text.empty() && !r_whole.output_text.empty())
+        CHECK(r.output_text.substr(0, 1) == r_whole.output_text.substr(0, 1));
+}
+
+// A full prompt that cannot fit the context has nothing to evict — the trimmer
+// upstream owns that — so it must fail fast rather than reach the decode, where
+// an over-context batch is an abort. Opt-in:
+//   XLLAMA_TEST_MODEL=/path/to/model.gguf ./xllama-tests
+TEST_CASE("Session: a prompt past n_ctx fails fast (opt-in: XLLAMA_TEST_MODEL)") {
+    const char* model_env = std::getenv("XLLAMA_TEST_MODEL");
+    if (!model_env)
+        return;
+
+    xllama::SessionParams sp;
+    sp.model_path = model_env;
+    sp.n_ctx = 512;
+    std::string err;
+    auto sess = xllama::Session::create(sp, &err);
+    REQUIRE_MESSAGE(sess, err);
+
+    std::string prompt;
+    for (int i = 0; i < 400; ++i)
+        prompt += "token " + std::to_string(i) + " ";
+    REQUIRE(sess->count_tokens(prompt) > 512);
+
+    xllama::GenerateParams gp;
+    gp.prompt = prompt;
+    gp.n_predict = 8;
+    const auto r = sess->generate(gp);
+    CHECK_FALSE(r.success);
+    CHECK(r.error_msg.find("prompt too long") != std::string::npos);
+    CHECK(r.n_eval == 0);
+}
+
 // #170b: the resident KV round-trips through a file, so a conversation the
 // session no longer holds resumes without re-reading its history. Opt-in —
 // needs a real GGUF:

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -667,7 +667,20 @@ std::string MainPageController::BuildPrompt(const std::string& user_text, int* o
     // budget live in routing_policy.h next to token_threshold: the trimmer runs
     // before routing, so its ceiling silently bounds what routing can ever see
     // (#133). Collect turns (skip system which always stays).
-    constexpr int kMaxEstimatedTokens = ::xllama::kMaxPromptTokens;
+    //
+    // Catalogue coding models open a larger n_ctx and use a denser
+    // chars-per-token estimate so long source/diff pastes trim earlier rather
+    // than overflowing generate().
+    int max_estimated_tokens = ::xllama::kMaxPromptTokens;
+    double chars_per_token = ::xllama::kEstimatedCharsPerToken;
+    {
+        const auto& manifest = CachedManifest();
+        if (const auto* e = ::xllama::FindManifestEntry(manifest, m_model_filename)) {
+            max_estimated_tokens = ::xllama::max_prompt_tokens_for_n_ctx(e->n_ctx);
+            chars_per_token =
+                ::xllama::chars_per_token_for_role(::xllama::wstring_to_utf8(e->role));
+        }
+    }
     std::vector<size_t> turn_starts; // index of first User message in each turn
     for (size_t i = 0; i < m_current.messages.size(); ++i) {
         if (m_current.messages[i].role == xllama::ui::MessageRole::User)
@@ -693,7 +706,8 @@ std::string MainPageController::BuildPrompt(const std::string& user_text, int* o
 
     size_t first_turn = 0;
     while (first_turn < turn_starts.size() &&
-           ::xllama::estimate_tokens_from_chars(static_cast<size_t>(chars)) > kMaxEstimatedTokens)
+           ::xllama::estimate_tokens_from_chars(static_cast<size_t>(chars), chars_per_token) >
+               max_estimated_tokens)
         chars -= turn_chars[first_turn++];
     if (first_turn > 0)
         log_output("[xllama] context trimmed: dropped " + std::to_string(first_turn) +
@@ -1540,7 +1554,11 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
     if (result != winrt::Windows::UI::Xaml::Controls::ContentDialogResult::Primary)
         co_return;
 
-    // Read back values
+    // Read back values. System prompt is whatever the user left in the box —
+    // no silent rewrite when the model role changes (that was string-equality
+    // magic and fought the Settings field). API empty-system fill still uses
+    // role → kCodingSystemPrompt (routing_policy / chat_prompt).
+    self->m_system_prompt = ::xllama::wstring_to_utf8(std::wstring(sysPromptBox.Text().c_str()));
     int mi = modelBox.SelectedIndex();
     if (mi >= 0 && mi < (int)model_keys.size()) {
         std::wstring new_model = model_keys[mi];
@@ -1559,7 +1577,6 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
             self->EnsureModelNamedAsync(new_model, true);
         }
     }
-    self->m_system_prompt = ::xllama::wstring_to_utf8(std::wstring(sysPromptBox.Text().c_str()));
     self->m_temperature = static_cast<float>(tempSlider.Value());
     self->m_top_p = static_cast<float>(topPSlider.Value());
     self->m_top_k = static_cast<int>(topKSlider.Value());
@@ -2534,24 +2551,28 @@ bool MainPageController::EnsureSession(const std::string& model, std::string* er
     // this field is ignored (only one path is compiled). The model name is bare
     // (no extension), so Backend::Auto's suffix sniffing cannot classify it.
     // Optional catalogue `lora` (relative to model dir) enables runtime LoRA.
+    // Optional catalogue `n_ctx` (coding models use 4096) overrides the default.
     {
         // Direct load, not CachedManifest: this runs on the worker thread and
         // the cache is UI-thread-only (no lock). Cold path anyway — a disk
         // parse is noise next to the model load that follows.
         auto manifest = ::xllama::LoadModelManifest();
         const auto* entry = ::xllama::FindManifestEntry(manifest, ::xllama::utf8_to_wstring(model));
-        if (entry && entry->kind == L"gguf") {
-            sp.backend = xllama::Backend::LlamaCpp;
-            if (!entry->lora.empty()) {
-                // Resolve against LocalState\models\<name>\lora-file (or InstalledPath
-                // after provision). resolve_model_path on a bare name yields the dir.
-                const std::string model_dir = xllama::resolve_model_path(model);
-                sp.lora_path = model_dir;
-                if (!sp.lora_path.empty() && sp.lora_path.back() != '\\' &&
-                    sp.lora_path.back() != '/')
-                    sp.lora_path.push_back('\\');
-                sp.lora_path += xllama::wstring_to_utf8(entry->lora);
-                sp.lora_scale = static_cast<float>(entry->lora_scale);
+        if (entry) {
+            sp.n_ctx = ::xllama::resolve_n_ctx(entry->n_ctx);
+            if (entry->kind == L"gguf") {
+                sp.backend = xllama::Backend::LlamaCpp;
+                if (!entry->lora.empty()) {
+                    // Resolve against LocalState\models\<name>\lora-file (or InstalledPath
+                    // after provision). resolve_model_path on a bare name yields the dir.
+                    const std::string model_dir = xllama::resolve_model_path(model);
+                    sp.lora_path = model_dir;
+                    if (!sp.lora_path.empty() && sp.lora_path.back() != '\\' &&
+                        sp.lora_path.back() != '/')
+                        sp.lora_path.push_back('\\');
+                    sp.lora_path += xllama::wstring_to_utf8(entry->lora);
+                    sp.lora_scale = static_cast<float>(entry->lora_scale);
+                }
             }
         }
     }

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -2923,20 +2923,25 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
             }
 
             std::string output_text = fmt.postprocess_output(res.output_text);
-            // A thinking model whose reasoning ran out of tokens leaves NOTHING
-            // after postprocess (strip_thinking_blocks drops an unclosed
+            bool was_aborted = self->m_abort.load();
+            // A thinking model that spent its whole budget reasoning leaves
+            // NOTHING after postprocess (strip_thinking_blocks drops an unclosed
             // <think> to EOF). Without a stand-in the turn vanished: no message
             // saved, no FinalizeStreamedTurn, the streamed chain of thought left
             // orphaned on screen and a status of "Done". Say what happened
             // instead — the fix for the cut-off reply is the Max-new-tokens box.
-            const bool thinking_only = output_text.empty() && !res.output_text.empty();
+            //
+            // Only for a turn that COMPLETED: a cancel or a failure mid-thought
+            // empties the output too, and blaming the token budget there would
+            // be a lie (and would persist a reply the user stopped).
+            const bool thinking_only =
+                res.success && !was_aborted && output_text.empty() && !res.output_text.empty();
             if (thinking_only) {
                 output_text = "(reasoning only — the answer did not fit; raise \"Max new "
                               "tokens\" in Settings)";
                 ::xllama::log_output(
                     "[xllama] postprocess left no answer (truncated reasoning block)\n");
             }
-            bool was_aborted = self->m_abort.load();
             dispatcher.RunAsync(
                 CoreDispatcherPriority::Normal,
                 [self, metrics, res, output_text, was_aborted, ep_kv_ok, thinking_only]() {

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -671,12 +671,18 @@ std::string MainPageController::BuildPrompt(const std::string& user_text, int* o
     // Catalogue coding models open a larger n_ctx and use a denser
     // chars-per-token estimate so long source/diff pastes trim earlier rather
     // than overflowing generate().
-    int max_estimated_tokens = ::xllama::kMaxPromptTokens;
+    //
+    // The ceiling reserves the requested generation length, not a flat 250: the
+    // generation loop clamps n_predict to n_ctx - prompt (#173), so a prompt
+    // filling the old ceiling cut the reply at ~248 tokens instead of dropping
+    // one more turn of history — silently, with no error and no log.
+    int max_estimated_tokens =
+        ::xllama::max_prompt_tokens_for_n_ctx(::xllama::kDefaultNCtx, m_n_predict);
     double chars_per_token = ::xllama::kEstimatedCharsPerToken;
     {
         const auto& manifest = CachedManifest();
         if (const auto* e = ::xllama::FindManifestEntry(manifest, m_model_filename)) {
-            max_estimated_tokens = ::xllama::max_prompt_tokens_for_n_ctx(e->n_ctx);
+            max_estimated_tokens = ::xllama::max_prompt_tokens_for_n_ctx(e->n_ctx, m_n_predict);
             chars_per_token =
                 ::xllama::chars_per_token_for_role(::xllama::wstring_to_utf8(e->role));
         }
@@ -776,6 +782,13 @@ void MainPageController::SaveCurrentConversation(bool partial) {
 // matches the rendered prompt collapses to a normal prefill.
 void MainPageController::SaveKvSnapshotAsync() {
     if (!m_kv_reuse || !m_kv_valid || m_current.messages.empty())
+        return;
+    // Thinking models: the saved history holds the STRIPPED answer while the KV
+    // holds the full <think> stream, so the #170a prefix diff always diverges
+    // inside the first assistant turn on return — and on LFM's hybrid cache a
+    // tail rewind is refused, collapsing to a full re-prefill. The snapshot
+    // would cost tens of MB of writes to buy nothing.
+    if (chat_format().strip_thinking_content)
         return;
     const std::string routed =
         ::xllama::wstring_to_utf8(m_active_model.empty() ? m_model_filename : m_active_model);
@@ -2910,37 +2923,62 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
             }
 
             std::string output_text = fmt.postprocess_output(res.output_text);
+            // A thinking model whose reasoning ran out of tokens leaves NOTHING
+            // after postprocess (strip_thinking_blocks drops an unclosed
+            // <think> to EOF). Without a stand-in the turn vanished: no message
+            // saved, no FinalizeStreamedTurn, the streamed chain of thought left
+            // orphaned on screen and a status of "Done". Say what happened
+            // instead — the fix for the cut-off reply is the Max-new-tokens box.
+            const bool thinking_only = output_text.empty() && !res.output_text.empty();
+            if (thinking_only) {
+                output_text = "(reasoning only — the answer did not fit; raise \"Max new "
+                              "tokens\" in Settings)";
+                ::xllama::log_output(
+                    "[xllama] postprocess left no answer (truncated reasoning block)\n");
+            }
             bool was_aborted = self->m_abort.load();
-            dispatcher.RunAsync(CoreDispatcherPriority::Normal, [self, metrics, res, output_text,
-                                                                 was_aborted, ep_kv_ok]() {
-                self->m_metricsText.Text(metrics);
-                self->SetStatus(was_aborted ? L"Cancelled" : (res.success ? L"Done" : L"Error"),
-                                was_aborted
-                                    ? StatusKind::Info
-                                    : (res.success ? StatusKind::Success : StatusKind::Error));
-                self->SetRunning(false); // also stops timer + flushes remaining tokens
-                // KV-reuse bookkeeping: the persistent generator now holds this
-                // turn only if it completed cleanly. On failure or abort, force a
-                // fresh generator (full re-prefill) next turn.
-                if (self->m_kv_reuse && res.success && !was_aborted && ep_kv_ok) {
-                    self->m_kv_valid = true;
-                    self->m_kv_last_ended_with_stop = res.ended_with_stop;
-                } else {
-                    self->m_kv_valid = false;
-                }
-                // Save assistant response (partial-flagged if user aborted)
-                if (!output_text.empty()) {
-                    xllama::ui::ChatMessage amsg;
-                    amsg.role = xllama::ui::MessageRole::Assistant;
-                    amsg.content = output_text;
-                    amsg.ts_unix = static_cast<int64_t>(std::time(nullptr));
-                    amsg.partial = was_aborted;
-                    self->m_current.messages.push_back(std::move(amsg));
-                }
-                self->SaveCurrentConversation(was_aborted);
-                if (!was_aborted && !output_text.empty())
-                    self->FinalizeStreamedTurn(output_text);
-            });
+            dispatcher.RunAsync(
+                CoreDispatcherPriority::Normal,
+                [self, metrics, res, output_text, was_aborted, ep_kv_ok, thinking_only]() {
+                    self->m_metricsText.Text(metrics);
+                    const wchar_t* status_text = L"Error";
+                    StatusKind status_kind = StatusKind::Error;
+                    if (was_aborted) {
+                        status_text = L"Cancelled";
+                        status_kind = StatusKind::Info;
+                    } else if (res.success && thinking_only) {
+                        // Not a failure and not a normal answer: the model spent the
+                        // whole budget reasoning.
+                        status_text = L"Reasoning cut off — raise Max new tokens";
+                        status_kind = StatusKind::Info;
+                    } else if (res.success) {
+                        status_text = L"Done";
+                        status_kind = StatusKind::Success;
+                    }
+                    self->SetStatus(status_text, status_kind);
+                    self->SetRunning(false); // also stops timer + flushes remaining tokens
+                    // KV-reuse bookkeeping: the persistent generator now holds this
+                    // turn only if it completed cleanly. On failure or abort, force a
+                    // fresh generator (full re-prefill) next turn.
+                    if (self->m_kv_reuse && res.success && !was_aborted && ep_kv_ok) {
+                        self->m_kv_valid = true;
+                        self->m_kv_last_ended_with_stop = res.ended_with_stop;
+                    } else {
+                        self->m_kv_valid = false;
+                    }
+                    // Save assistant response (partial-flagged if user aborted)
+                    if (!output_text.empty()) {
+                        xllama::ui::ChatMessage amsg;
+                        amsg.role = xllama::ui::MessageRole::Assistant;
+                        amsg.content = output_text;
+                        amsg.ts_unix = static_cast<int64_t>(std::time(nullptr));
+                        amsg.partial = was_aborted;
+                        self->m_current.messages.push_back(std::move(amsg));
+                    }
+                    self->SaveCurrentConversation(was_aborted);
+                    if (!was_aborted && !output_text.empty())
+                        self->FinalizeStreamedTurn(output_text);
+                });
         } catch (const std::exception& ex) {
             ::xllama::log_output(std::string("[xllama] thread terminated: ") + ex.what() + "\n");
             dispatcher.RunAsync(CoreDispatcherPriority::Normal, [self]() {

--- a/uwp/MainPage.h
+++ b/uwp/MainPage.h
@@ -233,7 +233,7 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     // Multi-turn chat state
     xllama::ui::ChatHistory m_history;
     xllama::ui::Conversation m_current;
-    std::string m_system_prompt{"You are a helpful AI assistant."};
+    std::string m_system_prompt{::xllama::kDefaultSystemPrompt};
 
     // Autoscroll state: true while the user has not scrolled up during streaming
     bool m_at_bottom{true};

--- a/uwp/api-server.cpp
+++ b/uwp/api-server.cpp
@@ -18,12 +18,14 @@
 // clang-format on
 
     #include "inference-bridge.h"
+    #include "model-downloader.h"
     #include "xllama/chat_prompt.h"
     #include "xllama/model_provision.h"
     #include "xllama/path_utils.h"
     #include "xllama/personalize.h"
     #include "xllama/platform.h"
     #include "xllama/preference_capture.h"
+    #include "xllama/routing_policy.h"
     #include "xllama/session.h"
     #include "xllama/session_hub.h"
     #include "xllama/utf8_utils.h"
@@ -307,27 +309,38 @@ std::string handle_chat_locked(const std::string& body, const char*& status) {
         status = "400 Bad Request";
         return error_json("no user message to complete");
     }
-    // Small instruct models degrade badly with an empty system turn (they
-    // hallucinate the next role instead of answering); the chat UI always seeds
-    // one. Match it when the client sends no system message.
-    if (system.empty())
-        system = "You are a helpful AI assistant.";
-
     // Lazily (re)create the resident Session when the requested model differs
     // (hub.mtx is held by the caller; the swap invalidates the GUI's KV-reuse
-    // state via hub.generation, which its next turn detects).
+    // state via hub.generation, which its next turn detects). Catalogue n_ctx
+    // / role (coding) apply the same policy as the chat UI.
     ::xllama::Session* session = nullptr;
+    bool model_is_coding = false;
     {
         std::string err;
         ::xllama::SessionParams sp;
         sp.model_path = model;
         sp.n_ctx = ::xllama::kDefaultNCtx;
+        auto manifest = ::xllama::LoadModelManifest();
+        if (const auto* entry =
+                ::xllama::FindManifestEntry(manifest, ::xllama::utf8_to_wstring(model))) {
+            sp.n_ctx = ::xllama::resolve_n_ctx(entry->n_ctx);
+            model_is_coding = ::xllama::role_is_coding(::xllama::wstring_to_utf8(entry->role));
+            if (entry->kind == L"gguf")
+                sp.backend = ::xllama::Backend::LlamaCpp;
+        }
         session = ::xllama::session_hub().ensure_locked(model, sp, &err);
         if (!session) {
             status = "500 Internal Server Error";
             return error_json("session create failed: " + err);
         }
     }
+
+    // Small instruct models degrade badly with an empty system turn (they
+    // hallucinate the next role instead of answering); the chat UI always seeds
+    // one. Match it when the client sends no system message — coding models get
+    // the coding default so a bare LAN client does not look like general chat.
+    if (system.empty())
+        system = model_is_coding ? ::xllama::kCodingSystemPrompt : ::xllama::kDefaultSystemPrompt;
 
     const ::xllama::ChatFormat fmt = ::xllama::chat_format_for(model);
     ::xllama::GenerateParams gp;

--- a/uwp/api-server.cpp
+++ b/uwp/api-server.cpp
@@ -252,6 +252,37 @@ std::string error_json(const std::string& msg) {
 // OpenAI /v1/chat/completions
 // ---------------------------------------------------------------------------
 
+// Catalogue session policy for one model, cached: parsing the manifest (bundled
+// file + LocalState override) on EVERY chat request, under hub.mtx and in front
+// of the model load, is pure latency. Only called from handle_chat_locked, which
+// holds hub.mtx — that lock is what serialises the statics below.
+//
+// A miss re-reads the file, so a model published (or uploaded) while the server
+// runs is picked up on its first request; models genuinely absent from the
+// catalogue re-read once per request, exactly as every request did before.
+struct CatalogueSessionPolicy {
+    int n_ctx = ::xllama::kDefaultNCtx;
+    bool coding = false;
+    bool gguf = false;
+};
+
+CatalogueSessionPolicy catalogue_session_policy(const std::string& model) {
+    static std::vector<::xllama::ManifestEntry> cache;
+    const std::wstring wname = ::xllama::utf8_to_wstring(model);
+    const ::xllama::ManifestEntry* entry = ::xllama::FindManifestEntry(cache, wname);
+    if (!entry) {
+        cache = ::xllama::LoadModelManifest();
+        entry = ::xllama::FindManifestEntry(cache, wname);
+    }
+    CatalogueSessionPolicy p;
+    if (entry) {
+        p.n_ctx = ::xllama::resolve_n_ctx(entry->n_ctx);
+        p.coding = ::xllama::role_is_coding(::xllama::wstring_to_utf8(entry->role));
+        p.gguf = entry->kind == L"gguf";
+    }
+    return p;
+}
+
 // Turn the OpenAI messages[] into (system, history, final_user) for render_prompt.
 void split_messages(JsonArray const& messages, std::string& system,
                     std::vector<::xllama::ChatTurn>& history, std::string& final_user) {
@@ -317,17 +348,13 @@ std::string handle_chat_locked(const std::string& body, const char*& status) {
     bool model_is_coding = false;
     {
         std::string err;
+        const CatalogueSessionPolicy policy = catalogue_session_policy(model);
+        model_is_coding = policy.coding;
         ::xllama::SessionParams sp;
         sp.model_path = model;
-        sp.n_ctx = ::xllama::kDefaultNCtx;
-        auto manifest = ::xllama::LoadModelManifest();
-        if (const auto* entry =
-                ::xllama::FindManifestEntry(manifest, ::xllama::utf8_to_wstring(model))) {
-            sp.n_ctx = ::xllama::resolve_n_ctx(entry->n_ctx);
-            model_is_coding = ::xllama::role_is_coding(::xllama::wstring_to_utf8(entry->role));
-            if (entry->kind == L"gguf")
-                sp.backend = ::xllama::Backend::LlamaCpp;
-        }
+        sp.n_ctx = policy.n_ctx;
+        if (policy.gguf)
+            sp.backend = ::xllama::Backend::LlamaCpp;
         session = ::xllama::session_hub().ensure_locked(model, sp, &err);
         if (!session) {
             status = "500 Internal Server Error";

--- a/uwp/model-downloader.cpp
+++ b/uwp/model-downloader.cpp
@@ -359,6 +359,9 @@ std::vector<ManifestEntry> parse_manifest(winrt::hstring const& text) {
         e.hf_base_url = obj.GetNamedString(L"hf_base_url", L"");
         e.lora = obj.GetNamedString(L"lora", L"");
         e.lora_scale = obj.GetNamedNumber(L"lora_scale", 1.0);
+        // 0 / absent → shipping default at session open (resolve_n_ctx).
+        e.n_ctx = static_cast<int>(obj.GetNamedNumber(L"n_ctx", 0));
+        e.role = obj.GetNamedString(L"role", L"");
         if (obj.HasKey(L"files")) {
             for (auto const& f : obj.GetNamedArray(L"files")) {
                 auto fo = f.GetObject();

--- a/uwp/model-downloader.h
+++ b/uwp/model-downloader.h
@@ -60,6 +60,12 @@ struct ManifestEntry {
     // Catalogue publish contract for fine-tuned adapters (training pillar Lane C).
     std::wstring lora;
     double lora_scale = 1.0;
+    // Optional session context size (0 = kDefaultNCtx). Coding models use 4096.
+    // Clamped by resolve_n_ctx() at session open (routing_policy.h).
+    int n_ctx = 0;
+    // Optional workload role: "" (general chat) or "coding". Drives denser
+    // token estimates and the coding system-prompt default on the LAN API.
+    std::wstring role;
 };
 
 // Load the model catalogue: InstalledPath\models\manifest.json (bundled) is

--- a/uwp/models/manifest.json
+++ b/uwp/models/manifest.json
@@ -182,7 +182,7 @@
       ]
     },
     {
-      "_comment": "Qwen2.5-Coder-0.5B-Instruct Q4_K_M — coding fast tier (role:coding, n_ctx 4096). ChatML; no Qwen3 <think>. Apache-2.0 unsloth GGUF. Host Release 2026-07-27: prefill 81 / decode 30.9 tok/s peak 513 MB (phase14-host-validation.csv). Console campaign pending. H3 draft candidate.",
+      "_comment": "Qwen2.5-Coder-0.5B-Instruct Q4_K_M — coding fast tier (role:coding, n_ctx 4096). ChatML; no Qwen3 <think>. Apache-2.0 unsloth GGUF. Console phase14: 148.2 prefill / 62.4 decode / 533 MB peak (phase14-console.csv); host Release quality PASS. H3 draft candidate.",
       "name": "qwen25-coder-0.5b",
       "display": "Qwen2.5 Coder 0.5B (GGUF · CPU · coding · fast)",
       "kind": "gguf",
@@ -197,7 +197,7 @@
       ]
     },
     {
-      "_comment": "Qwen2.5-Coder-1.5B-Instruct Q4_K_M — coding balanced tier. Host Release: prefill 40.3 / decode 17.2 tok/s peak 1703 MB. Console pending.",
+      "_comment": "Qwen2.5-Coder-1.5B-Instruct Q4_K_M — coding balanced tier. Console phase14: 96.6 prefill / 26.1 decode / 1179 MB peak; host Release quality PASS.",
       "name": "qwen25-coder-1.5b",
       "display": "Qwen2.5 Coder 1.5B (GGUF · CPU · coding)",
       "kind": "gguf",
@@ -212,7 +212,7 @@
       ]
     },
     {
-      "_comment": "Qwen2.5-Coder-3B-Instruct Q4_K_M — coding quality tier (Q3_K_M host quality FAIL; Q4_K_M PASS). Host Release: prefill 17.7 / decode 9.7 tok/s peak 3301 MB (borderline Series S RAM). Advanced optional.",
+      "_comment": "Qwen2.5-Coder-3B-Instruct Q4_K_M — coding quality tier (Q3_K_M host quality FAIL; Q4_K_M PASS). Console phase14: 46.2 prefill / 14.0 decode / 2116 MB peak (host peak was 3301 MB — console is the product figure). Advanced optional.",
       "name": "qwen25-coder-3b",
       "display": "Qwen2.5 Coder 3B (GGUF · CPU · coding · advanced)",
       "kind": "gguf",
@@ -227,7 +227,7 @@
       ]
     },
     {
-      "_comment": "Qwen3-1.7B Q4_K_M — chat upgrade over qwen35-0.8b. ChatML + model_is_qwen3 no-think prefill. Host Release: prefill 39 / decode 17.2 tok/s peak 1976 MB. Apache-2.0 unsloth. Console pending. imrope: no context shift.",
+      "_comment": "Qwen3-1.7B Q4_K_M — chat upgrade over qwen35-0.8b. ChatML + model_is_qwen3 no-think prefill. Console phase14: 89.5 prefill / 21.8 decode / 1398 MB peak; host Release quality PASS. Apache-2.0 unsloth. Context shift NOT measured on this model — can_shift is a runtime property, the longchat gate has only run on qwen35-0.8b (imrope, no shift) and lfm25-350m.",
       "name": "qwen3-1.7b",
       "display": "Qwen3 1.7B (GGUF · CPU)",
       "kind": "gguf",
@@ -240,7 +240,7 @@
       ]
     },
     {
-      "_comment": "LFM2.5-1.2B-Thinking Q4_K_M — hybrid CoT. ChatML; model_is_thinking strips <think>…</think> for display/persist (postprocess_output). No Qwen3 no-think prefill. Console phase14: 130.4 prefill / 36.7 decode / 811 MB peak. LFM Open License + LICENSE file. UI n_predict default 512 is enough for think+answer.",
+      "_comment": "LFM2.5-1.2B-Thinking Q4_K_M — hybrid CoT. ChatML; model_is_thinking strips <think>…</think> for display/persist (postprocess_output). No Qwen3 no-think prefill. Console phase14: 130.4 prefill / 36.7 decode / 811 MB peak. LFM Open License + LICENSE file. UI n_predict default 512 covers think+answer on a short prompt (console: 153-215 generated); when the context leaves less room the reply postprocesses to nothing and the UI shows a 'reasoning only' turn. No KV snapshot (#170b) — stripped history diverges from the resident CoT tokens.",
       "name": "lfm25-1.2b-thinking",
       "display": "LFM2.5 1.2B Thinking (GGUF · CPU · reasoning)",
       "kind": "gguf",

--- a/uwp/models/manifest.json
+++ b/uwp/models/manifest.json
@@ -182,6 +182,81 @@
       ]
     },
     {
+      "_comment": "Qwen2.5-Coder-0.5B-Instruct Q4_K_M — coding fast tier (role:coding, n_ctx 4096). ChatML; no Qwen3 <think>. Apache-2.0 unsloth GGUF. Host Release 2026-07-27: prefill 81 / decode 30.9 tok/s peak 513 MB (phase14-host-validation.csv). Console campaign pending. H3 draft candidate.",
+      "name": "qwen25-coder-0.5b",
+      "display": "Qwen2.5 Coder 0.5B (GGUF · CPU · coding · fast)",
+      "kind": "gguf",
+      "role": "coding",
+      "n_ctx": 4096,
+      "hf_base_url": "https://huggingface.co/unsloth/Qwen2.5-Coder-0.5B-Instruct-GGUF/resolve/main",
+      "files": [
+        {
+          "filename": "Qwen2.5-Coder-0.5B-Instruct-Q4_K_M.gguf",
+          "approx_bytes": 397807456
+        }
+      ]
+    },
+    {
+      "_comment": "Qwen2.5-Coder-1.5B-Instruct Q4_K_M — coding balanced tier. Host Release: prefill 40.3 / decode 17.2 tok/s peak 1703 MB. Console pending.",
+      "name": "qwen25-coder-1.5b",
+      "display": "Qwen2.5 Coder 1.5B (GGUF · CPU · coding)",
+      "kind": "gguf",
+      "role": "coding",
+      "n_ctx": 4096,
+      "hf_base_url": "https://huggingface.co/unsloth/Qwen2.5-Coder-1.5B-Instruct-GGUF/resolve/main",
+      "files": [
+        {
+          "filename": "Qwen2.5-Coder-1.5B-Instruct-Q4_K_M.gguf",
+          "approx_bytes": 986048032
+        }
+      ]
+    },
+    {
+      "_comment": "Qwen2.5-Coder-3B-Instruct Q4_K_M — coding quality tier (Q3_K_M host quality FAIL; Q4_K_M PASS). Host Release: prefill 17.7 / decode 9.7 tok/s peak 3301 MB (borderline Series S RAM). Advanced optional.",
+      "name": "qwen25-coder-3b",
+      "display": "Qwen2.5 Coder 3B (GGUF · CPU · coding · advanced)",
+      "kind": "gguf",
+      "role": "coding",
+      "n_ctx": 4096,
+      "hf_base_url": "https://huggingface.co/unsloth/Qwen2.5-Coder-3B-Instruct-GGUF/resolve/main",
+      "files": [
+        {
+          "filename": "Qwen2.5-Coder-3B-Instruct-Q4_K_M.gguf",
+          "approx_bytes": 1929902496
+        }
+      ]
+    },
+    {
+      "_comment": "Qwen3-1.7B Q4_K_M — chat upgrade over qwen35-0.8b. ChatML + model_is_qwen3 no-think prefill. Host Release: prefill 39 / decode 17.2 tok/s peak 1976 MB. Apache-2.0 unsloth. Console pending. imrope: no context shift.",
+      "name": "qwen3-1.7b",
+      "display": "Qwen3 1.7B (GGUF · CPU)",
+      "kind": "gguf",
+      "hf_base_url": "https://huggingface.co/unsloth/Qwen3-1.7B-GGUF/resolve/main",
+      "files": [
+        {
+          "filename": "Qwen3-1.7B-Q4_K_M.gguf",
+          "approx_bytes": 1107409472
+        }
+      ]
+    },
+    {
+      "_comment": "LFM2.5-1.2B-Thinking Q4_K_M — hybrid CoT. ChatML; model_is_thinking strips <think>…</think> for display/persist (postprocess_output). No Qwen3 no-think prefill. Console phase14: 130.4 prefill / 36.7 decode / 811 MB peak. LFM Open License + LICENSE file. UI n_predict default 512 is enough for think+answer.",
+      "name": "lfm25-1.2b-thinking",
+      "display": "LFM2.5 1.2B Thinking (GGUF · CPU · reasoning)",
+      "kind": "gguf",
+      "hf_base_url": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF/resolve/main",
+      "files": [
+        {
+          "filename": "LFM2.5-1.2B-Thinking-Q4_K_M.gguf",
+          "approx_bytes": 730895360
+        },
+        {
+          "filename": "LICENSE",
+          "approx_bytes": 10596
+        }
+      ]
+    },
+    {
       "name": "sd-turbo-fp16",
       "display": "SD-Turbo (image, GPU fp16)",
       "kind": "diffusion",


### PR DESCRIPTION
Review pass over the phase14 catalogue work (f60346b). The `n_ctx`/`role` policy widened three latent holes on the llama.cpp path; all three are reachable without unusual input.

## P0 — a long prompt aborted the process

Both prefills (`LlamaSession::generate`, `run_inference`) submitted the whole prompt as ONE logical batch. `llama_decode` does not return an error for an oversized batch — it trips `GGML_ASSERT(n_tokens_all <= cparams.n_batch)` (`llama.cpp/src/llama-context.cpp:1761`), which aborts in Release too. `n_batch` defaults to `min(n_ctx, 2048)`, so ~2049 real tokens were enough:

- **chat UI** — the coding tier opens `n_ctx 4096`, so `max_prompt_tokens_for_n_ctx` lets the trimmer pass 3846 tokens (~13 KB of pasted code);
- **LAN API** — `POST /v1/chat/completions` caps the body at 8 MB and the token count not at all.

The prefill is now chunked at `llama_n_batch`. The physical ubatch (512 — the #172 optimum every published prefill figure was measured on) is untouched: this is the logical batch only. A full prompt that cannot fit `n_ctx` now fails fast with an actionable message, the way a continuation already did (#173).

**Verified on host**, not deduced: without the chunking the new opt-in test dies with `SIGABRT` (exit 134, core dumped); with it, LFM2.5-350M and Qwen3.5-0.8B both prefill every token and agree with a single-batch session on the leading token.

## P1 — replies were cut at ~250 tokens on a full context

The trimmer ceiling reserved a flat 250 tokens while the UI default `n_predict` is 512 (slider to 2048), and the generation loop clamps `n_predict` to what the context has left. A prompt sitting on the ceiling therefore got a truncated answer with **no error and no log**, instead of the trimmer dropping one more turn of history. `max_prompt_tokens_for_n_ctx(n_ctx, reserved)` now takes the requested generation length (250 stays the floor, 256 the prompt floor). This also fixes the shipping default context, not just the coding tier.

## P1 — a thinking model could lose a whole turn

With the reasoning block truncated, `postprocess_output` correctly returns an empty answer — and the UI then saved no message and never called `FinalizeStreamedTurn`, leaving raw chain of thought orphaned on screen, a user turn with no reply in the saved history, and a status of "Done". It now stores an explicit "reasoning only" turn and says so in the status.

## Smaller items

- `strip_thinking_blocks` handles a closer with no opener (`reasoning…</think>answer`, when the template opens the block) — before, the whole CoT and the raw tag reached the screen and the history.
- No KV snapshot for thinking models: the stripped history always diverges from the resident CoT tokens, so the #170a prefix diff collapses (a full re-prefill on LFM's hybrid cache) and #170b bought nothing at tens of MB per conversation switch.
- The LAN chat handler caches the catalogue instead of parsing `manifest.json` + the LocalState override on every request, under `hub.mtx`, in front of the model load.
- Stale `"Console pending"` manifest comments corrected against `phase14-console.csv` (same commit that added the rows); the unmeasured *"imrope: no context shift"* claim on `qwen3-1.7b` softened to what was actually gated (`can_shift` is a runtime property and the longchat gate only ran on `qwen35-0.8b`).

## Verification

| Check | Result |
| --- | --- |
| P0 repro without the fix | `SIGABRT`, exit 134, core dumped |
| P0 repro with the fix (LFM2.5-350M, Qwen3.5-0.8B) | pass, `n_p_eval` == every prompt token |
| Host suite | 159 test cases / 1331 assertions green (148 before) |
| Opt-in #170a / #170b on a real GGUF | pass |
| `scripts/check-coherence.py` | 36 OK / 0 WARN / 0 ERR |
| `git clang-format` | clean |

**Still owed:** `validate-api.sh` (needs the LAN endpoint) and the console gates — required regardless of this PR, since the phase14 code has never run on device (`docs/model-matrix.md`: the benches are on MSIX 1.5.1.737, pre-phase14).

Markdown tables in the two touched docs were realigned by the repo's prettier hook — that is the churn in `docs/model-matrix.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new coding, chat, and reasoning model options, including Qwen Coder, Qwen3, and LFM Thinking variants.
  * Added coding-specific prompt handling, context sizing, and smarter prompt budgeting.
  * Added Linux peak memory telemetry.

* **Bug Fixes**
  * Improved handling of long prompts to prevent crashes and silent truncation.
  * Improved reasoning-content filtering and user feedback for reasoning-only responses.
  * Improved LAN response efficiency through manifest caching.

* **Documentation**
  * Expanded model catalogue, configuration guidance, architecture documentation, and benchmark reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->