### PR TITLE
feat: Xbox Store SKU foundation, buildable without a Windows VM

### DIFF
--- a/.github/actions/build-uwp-package/action.yml
+++ b/.github/actions/build-uwp-package/action.yml
@@ -1,0 +1,131 @@
+# Shared UWP package build (dev or Store SKU). Used by build-uwp.yml so the
+# Store lane can be a separate job gated on workflow_dispatch without
+# duplicating the Windows steps. No local Windows VM required.
+name: build-uwp-package
+description: Restore deps, optional patched ORT/GenAI, run build-uwp.ps1, upload MSIX
+inputs:
+  variant:
+    description: "ort | llamacpp | unified"
+    required: true
+  patched:
+    description: "Install vendor-dlls-v1 patched ORT + GenAI (true/false)"
+    required: true
+  store_sku:
+    description: "XLLAMA_STORE_SKU / AppxManifest.store.xml (true/false)"
+    required: false
+    default: "false"
+  artifact:
+    description: "actions/upload-artifact name"
+    required: true
+  build_revision:
+    description: "MSIX version Revision (usually github.run_number)"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout llama.cpp submodule + apply AppContainer guards
+      if: inputs.variant == 'llamacpp' || inputs.variant == 'unified'
+      shell: bash
+      run: |
+        git submodule update --init --depth 1 llama.cpp
+        bash scripts/apply-uwp-patches.sh
+        bash scripts/check-uwp-sources.sh
+
+    - name: Restore NuGet packages
+      shell: pwsh
+      working-directory: uwp
+      run: nuget restore packages.config -PackagesDirectory packages -NonInteractive
+
+    - name: Download pinned patched runtime DLLs (vendor-dlls-v1)
+      if: inputs.patched == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        BASE="https://github.com/gianlucamazza/xllama/releases/download/vendor-dlls-v1"
+        download_pin() {
+          local name="$1" dest_dir="$2" sums="$3"
+          mkdir -p "$dest_dir"
+          local out="$dest_dir/$name"
+          curl -fsSL -o "$out" "$BASE/$name"
+          local expected actual
+          expected=$(awk -v n="$name" '/^[[:xdigit:]]{64}[[:space:]]+/ && $2==n {print $1; exit}' "$sums")
+          if [ -z "$expected" ]; then
+            echo "No hash line for $name in $sums"
+            exit 1
+          fi
+          actual=$(sha256sum "$out" | awk '{print $1}')
+          if [ "$expected" != "$actual" ]; then
+            echo "SHA256 mismatch for $name"
+            echo "  expected: $expected"
+            echo "  actual:   $actual"
+            exit 1
+          fi
+          echo "Pinned $name OK ($actual)"
+          ls -la "$out"
+        }
+        download_pin onnxruntime.dll \
+          vendor/onnxruntime-patched/win-x64 \
+          vendor/onnxruntime-patched/SHA256SUMS
+        download_pin onnxruntime-genai.dll \
+          vendor/onnxruntime-genai-patched/win-x64 \
+          vendor/onnxruntime-genai-patched/SHA256SUMS
+
+    - name: Install patched onnxruntime-genai.dll over NuGet
+      if: inputs.patched == 'true'
+      shell: pwsh
+      run: ./scripts/vendor-genai-dml-patch.ps1
+
+    - name: Install patched onnxruntime.dll over NuGet
+      if: inputs.patched == 'true'
+      shell: pwsh
+      run: ./scripts/vendor-ort-extdata-patch.ps1
+
+    - name: Verify both patched DLLs replaced the NuGet copies
+      if: inputs.patched == 'true'
+      shell: pwsh
+      run: |
+        $pkgs = ([xml](Get-Content uwp/packages.config)).packages.package
+        $genaiVer = ($pkgs | Where-Object { $_.id -eq "Microsoft.ML.OnnxRuntimeGenAI.DirectML" }).version
+        $ortVer   = ($pkgs | Where-Object { $_.id -eq "Microsoft.ML.OnnxRuntime.DirectML" }).version
+        $checks = @(
+          @{ vendor = "vendor/onnxruntime-genai-patched/win-x64/onnxruntime-genai.dll";
+             nuget  = "uwp/packages/Microsoft.ML.OnnxRuntimeGenAI.DirectML.$genaiVer/runtimes/win-x64/native/onnxruntime-genai.dll" },
+          @{ vendor = "vendor/onnxruntime-patched/win-x64/onnxruntime.dll";
+             nuget  = "uwp/packages/Microsoft.ML.OnnxRuntime.DirectML.$ortVer/runtimes/win-x64/native/onnxruntime.dll" }
+        )
+        foreach ($c in $checks) {
+          if (-not (Test-Path $c.vendor)) { Write-Error "patched DLL missing: $($c.vendor)"; exit 1 }
+          if (-not (Test-Path $c.nuget))  { Write-Error "NuGet DLL missing: $($c.nuget)"; exit 1 }
+          if ((Get-FileHash $c.vendor).Hash -ne (Get-FileHash $c.nuget).Hash) {
+            Write-Error "NuGet DLL is not the patched build: $($c.nuget)"; exit 1
+          }
+        }
+        Write-Host "Both patched DLLs match NuGet installs."
+
+    - name: Build UWP package
+      shell: pwsh
+      run: |
+        $buildArgs = @{
+          Configuration = 'Release'
+          Platform      = 'x64'
+          Backend       = $('${{ inputs.variant }}' -eq 'unified' ? 'unified' : '${{ inputs.variant }}')
+          BuildRevision = [int]'${{ inputs.build_revision }}'
+        }
+        if ('${{ inputs.patched }}' -eq 'true') {
+          $buildArgs.PatchedGenAI = $true
+          $buildArgs.PatchedOrt   = $true
+        }
+        if ('${{ inputs.store_sku }}' -eq 'true') {
+          $buildArgs.StoreSku = $true
+        }
+        ./scripts/build-uwp.ps1 @buildArgs
+
+    - uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.artifact }}
+        path: |
+          uwp/AppPackages/**/*.msix
+          uwp/AppPackages/**/*.appx
+          uwp/xllama-test.cer
+        retention-days: 14

--- a/.github/workflows/build-uwp.yml
+++ b/.github/workflows/build-uwp.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Store SKU is opt-in: avoids +~13 min on every PR. From Linux (no Windows VM):
+  #   gh workflow run build-uwp.yml -f store_sku=true --ref <branch>
+  # Artifact: xllama-appx-store. SSOT: docs/store-readiness.md
+  workflow_dispatch:
+    inputs:
+      store_sku:
+        description: "Also build Store SKU (XLLAMA_STORE_SKU, artifact xllama-appx-store)"
+        type: boolean
+        default: false
 
 # Feature branches build once via pull_request (not also via push); superseded
 # runs on the same branch cancel — UWP builds are ~13 min, so this saves the most.
@@ -36,114 +45,29 @@ jobs:
           submodules: false
           fetch-depth: 1
 
-      - name: Checkout llama.cpp submodule + apply AppContainer guards
-        if: matrix.variant == 'llamacpp' || matrix.variant == 'unified'
-        shell: bash
-        run: |
-          git submodule update --init --depth 1 llama.cpp
-          bash scripts/apply-uwp-patches.sh
-          # Fail early if the submodule gained a top-level src/*.cpp the vcxproj
-          # doesn't list (models/*.cpp is wildcarded and can't drift).
-          bash scripts/check-uwp-sources.sh
-
-      - name: Restore NuGet packages
-        shell: pwsh
-        working-directory: uwp
-        run: nuget restore packages.config -PackagesDirectory packages -NonInteractive
-
-      # Both patched runtime DLLs are cached on vendor-dlls-v1 (hash-verified).
-      # Full source rebuilds: build-uwp-patched.yml (GenAI #2280) /
-      # build-uwp-ort-patched.yml (ORT extdata) — only for pin refresh.
-      - name: Download pinned patched runtime DLLs (vendor-dlls-v1)
-        if: matrix.patched
-        shell: bash
-        run: |
-          set -euo pipefail
-          BASE="https://github.com/gianlucamazza/xllama/releases/download/vendor-dlls-v1"
-          download_pin() {
-            local name="$1" dest_dir="$2" sums="$3"
-            mkdir -p "$dest_dir"
-            local out="$dest_dir/$name"
-            curl -fsSL -o "$out" "$BASE/$name"
-            local expected actual
-            expected=$(awk -v n="$name" '/^[[:xdigit:]]{64}[[:space:]]+/ && $2==n {print $1; exit}' "$sums")
-            if [ -z "$expected" ]; then
-              echo "No hash line for $name in $sums"
-              exit 1
-            fi
-            actual=$(sha256sum "$out" | awk '{print $1}')
-            if [ "$expected" != "$actual" ]; then
-              echo "SHA256 mismatch for $name"
-              echo "  expected: $expected"
-              echo "  actual:   $actual"
-              exit 1
-            fi
-            echo "Pinned $name OK ($actual)"
-            ls -la "$out"
-          }
-          download_pin onnxruntime.dll \
-            vendor/onnxruntime-patched/win-x64 \
-            vendor/onnxruntime-patched/SHA256SUMS
-          download_pin onnxruntime-genai.dll \
-            vendor/onnxruntime-genai-patched/win-x64 \
-            vendor/onnxruntime-genai-patched/SHA256SUMS
-
-      - name: Install patched onnxruntime-genai.dll over NuGet
-        if: matrix.patched
-        shell: pwsh
-        run: ./scripts/vendor-genai-dml-patch.ps1
-
-      - name: Install patched onnxruntime.dll over NuGet
-        if: matrix.patched
-        shell: pwsh
-        run: ./scripts/vendor-ort-extdata-patch.ps1
-
-      - name: Verify both patched DLLs replaced the NuGet copies
-        if: matrix.patched
-        shell: pwsh
-        run: |
-          $pkgs = ([xml](Get-Content uwp/packages.config)).packages.package
-          $genaiVer = ($pkgs | Where-Object { $_.id -eq "Microsoft.ML.OnnxRuntimeGenAI.DirectML" }).version
-          $ortVer   = ($pkgs | Where-Object { $_.id -eq "Microsoft.ML.OnnxRuntime.DirectML" }).version
-          $checks = @(
-            @{ vendor = "vendor/onnxruntime-genai-patched/win-x64/onnxruntime-genai.dll";
-               nuget  = "uwp/packages/Microsoft.ML.OnnxRuntimeGenAI.DirectML.$genaiVer/runtimes/win-x64/native/onnxruntime-genai.dll" },
-            @{ vendor = "vendor/onnxruntime-patched/win-x64/onnxruntime.dll";
-               nuget  = "uwp/packages/Microsoft.ML.OnnxRuntime.DirectML.$ortVer/runtimes/win-x64/native/onnxruntime.dll" }
-          )
-          foreach ($c in $checks) {
-            if (-not (Test-Path $c.vendor)) { Write-Error "patched DLL missing: $($c.vendor)"; exit 1 }
-            if (-not (Test-Path $c.nuget))  { Write-Error "NuGet DLL missing: $($c.nuget)"; exit 1 }
-            if ((Get-FileHash $c.vendor).Hash -ne (Get-FileHash $c.nuget).Hash) {
-              Write-Error "NuGet DLL is not the patched build: $($c.nuget)"; exit 1
-            }
-          }
-          Write-Host "Both patched DLLs match NuGet installs."
-
-      - name: Build UWP package
-        shell: pwsh
-        run: |
-          # Hashtable splatting — string arrays bind positionally and break -Backend.
-          $buildArgs = @{
-            Configuration = 'Release'
-            Platform      = 'x64'
-            Backend       = $('${{ matrix.variant }}' -eq 'unified' ? 'unified' : '${{ matrix.variant }}')
-            # Unique, monotonic MSIX Revision per build (Major.Minor.Build stays
-            # the committed semantic version) so console updates never collide.
-            BuildRevision = ${{ github.run_number }}
-          }
-          if ('${{ matrix.patched }}' -eq 'true') {
-            $buildArgs.PatchedGenAI = $true
-            $buildArgs.PatchedOrt   = $true
-          }
-          ./scripts/build-uwp.ps1 @buildArgs
-
-      - uses: actions/upload-artifact@v7
-        if: success()
+      - uses: ./.github/actions/build-uwp-package
         with:
-          name: ${{ matrix.artifact }}
-          path: |
-            uwp/AppPackages/**/*.msix
-            uwp/AppPackages/**/*.appx
-            uwp/xllama-test.cer
-          retention-days: 14
+          variant: ${{ matrix.variant }}
+          patched: ${{ matrix.patched }}
+          store_sku: "false"
+          artifact: ${{ matrix.artifact }}
+          build_revision: ${{ github.run_number }}
+
+  # Store SKU: separate job so the gate can use inputs.* (matrix.* is illegal
+  # in job-level if). Only on workflow_dispatch with store_sku=true.
+  store:
+    if: github.event_name == 'workflow_dispatch' && inputs.store_sku == true
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+          fetch-depth: 1
+
+      - uses: ./.github/actions/build-uwp-package
+        with:
+          variant: unified
+          patched: "true"
+          store_sku: "true"
+          artifact: xllama-appx-store
+          build_revision: ${{ github.run_number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Xbox Store SKU foundation (Phase 1 engineering).** Compile-time
+  `XLLAMA_STORE_SKU` / MSBuild `XllamaStoreSku=true` / `build-uwp.ps1 -StoreSku`:
+  strips LAN API, USB model path, and headless operator flags; packages
+  `AppxManifest.store.xml` (`internetClient` only). Dev Mode package unchanged.
+  First-run generative-AI disclaimer (`disclaimer.accepted`) on both SKUs.
+  **No Windows VM required:** `build-uwp.yml` `workflow_dispatch` with
+  `store_sku=true` → artifact `xllama-appx-store`; `install-latest-build.sh
+  --store` from Linux. Privacy draft: `docs/privacy.md`. Workstream SSOT:
+  `docs/store-readiness.md`. Not Store-submission-ready (test signing + Partner
+  Center still open).
 - **Coding + chat + thinking tier (phase14), architecture-first.** Catalogue
   `n_ctx` / `role: coding`; no Settings system-prompt rewrite. Catalogue:
   `qwen25-coder-0.5b` / `1.5b` / `3b`, `qwen3-1.7b`, **`lfm25-1.2b-thinking`**.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -331,6 +331,21 @@ reverted 2026-07-14 with zero measured benefit (`uwp-constraints.md` §1);
 the negative measurement stands even though its original attribution was
 retired after #155.
 
+## Xbox Store retail (public release path)
+
+SSOT: [`docs/store-readiness.md`](docs/store-readiness.md). Dev Mode remains
+the supported install path until a submission is accepted.
+
+- [~] Phase 0 — discovery: SSOT + licence matrix in `store-readiness.md`;
+      Partner Center decision + App vs Game spike + go/no-go still open.
+- [~] Phase 1 — Store SKU foundation + **no-VM CI path** (`workflow_dispatch`
+      `store_sku=true` → `xllama-appx-store`, `install-latest-build.sh --store`);
+      console smoke + Partner Center identity still open.
+- [~] Phase 2 — privacy draft in `docs/privacy.md`; age rating + listing assets
+      + published HTTPS privacy URL still open.
+- [ ] Phase 3 — Partner Center submission + certification.
+- [ ] Phase 4 — post-launch dual path (Store + Dev Mode) in README.
+
 ## Upstream and vendor lifecycle
 
 Operational details live in `docs/vendor-lifecycle-plan.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,8 @@ Technical notes and design decisions for xllama.
 | App gamepad UI (chat, settings, personalize, images)                                   | [using-the-app.md](./using-the-app.md)                                                                                       |
 | Version / current product state                                                        | [`../CHANGELOG.md`](../CHANGELOG.md) + [`../ROADMAP.md`](../ROADMAP.md)                                                      |
 | Package identity / install & migration path                                            | [install-release.md](./install-release.md) (user) + `AGENTS.md` Versioning (dev)                                             |
+| Xbox Store retail readiness (dual SKU, licence matrix, App vs Game gate)               | [store-readiness.md](./store-readiness.md)                                                                                   |
+| Privacy policy (Store / end-user draft)                                                | [privacy.md](./privacy.md)                                                                                                   |
 | Agent / contributor quick map                                                          | [`../AGENTS.md`](../AGENTS.md)                                                                                               |
 
 The benchmark flow is intentionally one-way:
@@ -70,6 +72,7 @@ path checklist for discovery — descriptions are not repeated.
 **Ops / install:** [install-release.md](./install-release.md) ·
 [device-portal.md](./device-portal.md) · [windows-dev-vm.md](./windows-dev-vm.md) ·
 [console-validation-runbook.md](./console-validation-runbook.md) ·
+[store-readiness.md](./store-readiness.md) · [privacy.md](./privacy.md) ·
 [../training/README.md](../training/README.md) ·
 [../bench/README.md](../bench/README.md)
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,81 @@
+# Privacy policy — xllama
+
+**Last updated:** 2026-07-29  
+**Applies to:** the xllama UWP application (Dev Mode sideload and any future
+Microsoft Store listing of the Store SKU).  
+**Operator:** Gianluca Mazza (see the GitHub repository
+[gianlucamazza/xllama](https://github.com/gianlucamazza/xllama)).
+
+This document is written for Partner Center / Store submission and for end
+users. It is not legal advice.
+
+## Summary
+
+xllama is a **local** LLM chat and optional image-generation app for Xbox
+Series S|X. Inference runs **on the device**. There is **no account system**,
+**no analytics**, and **no crash-reporting service** built into the app today.
+
+## What stays on the device
+
+Unless you choose otherwise, the following remain in the app sandbox
+(`LocalState` and related AppContainer storage):
+
+- Downloaded model weights and configs  
+- Chat history and conversation settings  
+- Preference / feedback samples used for optional on-device personalization  
+- Optional on-device training outputs (merged GGUF under the personalize flow)  
+- App logs (`xllama.log`) written for debugging  
+
+The maintainer does not receive these files automatically.
+
+## What leaves the device
+
+Outbound network use is limited to:
+
+1. **Model catalogue downloads** you start (or that first launch starts for the
+   default chat model). Sources are listed in the in-app catalogue
+   (`uwp/models/manifest.json`): typically GitHub Releases (`models-v1`) and/or
+   Hugging Face model repositories.  
+2. **Nothing else by default.** The optional LAN HTTP API (Dev Mode / research
+   SKU only) speaks only on your local network when you turn it on; it is
+   **not** included in the Store SKU and is unauthenticated — use only on a
+   trusted LAN.
+
+The app does **not** upload chats, prompts, images, or feedback to the
+maintainer or to a cloud inference backend.
+
+## Third parties
+
+When models download from GitHub or Hugging Face, those services process the
+download request under **their** privacy policies (IP address, user agent, etc.).
+xllama does not control that processing.
+
+Runtime components (e.g. ONNX Runtime, DirectML, llama.cpp) run locally and do
+not phone home through xllama.
+
+## Children
+
+xllama can generate open-ended text and images. It is **not** directed at
+children. A future Store listing will carry an age rating reflecting generative
+content; parents should not treat the app as a supervised kids product.
+
+## Your choices
+
+- Do not download models you do not want stored on the console.  
+- Clear app data / uninstall to remove LocalState (including history and models).  
+- Do not enable the LAN API (Dev Mode) on untrusted networks.  
+- Prefer the Store SKU (when published) if you want research surfaces (LAN API,
+  USB paths, headless flags) omitted.
+
+## Changes
+
+Material changes to this policy will be reflected in this file and in the app
+version notes (`CHANGELOG.md`). The “Last updated” date will change.
+
+## Contact
+
+- GitHub Issues: [gianlucamazza/xllama](https://github.com/gianlucamazza/xllama/issues)  
+- Repository owner profile on GitHub for contact details  
+
+For a Store listing, a stable HTTPS URL to this document (or a GitHub Pages
+mirror) should be used as the privacy policy link in Partner Center.

--- a/docs/store-readiness.md
+++ b/docs/store-readiness.md
@@ -1,0 +1,329 @@
+# Store readiness — Xbox Store retail path
+
+> **SSOT for the public Xbox Store workstream.** Product code and Dev Mode
+> install docs stay on the research path until a submission is accepted.
+> Numbers and platform constraints still live in `uwp-constraints.md` /
+> `benchmarks.md`; this page owns **go-to-market gates**, dual-SKU policy, and
+> the licence matrix for a retail listing.
+
+**Status (2026-07-29):** Phase 0 discovery + Phase 1 **engineering foundation**
+landed. **Not Store-ready** for retail: no Partner Center product, no
+Store-signed package, no privacy URL, no age rating. Dev Mode remains the only
+supported install path.
+
+**Audience for a eventual listing:** hobbyist local-LLM / homebrew Xbox users
+who should not need Dev Mode. Contributors keep the Dev Mode sideload path.
+
+**Related:** plan in session / product intent; `docs/launch-copy.md` (claims
+that must not be made); `docs/api-endpoint.md` (LAN: not for the Store);
+`docs/install-release.md` (Dev Mode only today).
+
+---
+
+## 1. Baseline (what ships today)
+
+| Area | Current | Store needs |
+| --- | --- | --- |
+| Distribution | Device Portal sideload + CI / GitHub Release | Partner Center submission |
+| Signing | `Publisher="CN=xllama-dev"`, self-signed test PFX | Partner Center publisher identity |
+| Package identity | `GianlucaMazza.xllama` | Reserved Store identity (may differ) |
+| LAN API | Opt-in, unauthenticated | **Absent** from Store SKU |
+| USB models | `removableStorage` + `E:\xllama\models` | Prefer **absent** from Store SKU |
+| Content / AI | No age gate, no generative-AI disclaimer | Age rating + first-run disclosure |
+| Privacy | No public policy | HTTPS privacy URL + support contact |
+| Docs product claim | “Dev Mode only — no retail path” | Dual path only **after** Store live |
+
+Manifest capabilities today (`uwp/AppxManifest.xml`): `internetClient`,
+`privateNetworkClientServer`, `removableStorage`. Store SKU target:
+**`internetClient` only** (unless review forces another justified capability).
+
+---
+
+## 2. Product decisions (D1–D5)
+
+### D1 — Game vs App designation
+
+Benchmark and GPU-budget figures assume **Game** OS resources
+(`uwp-constraints.md` §5 / App vs Game lever): **3801 MB** GPU budget, full
+Game scheduling. In Dev Mode the designation is set in Dev Home (tile → View
+details → App type) and can reset on reinstall.
+
+| Designation | Implication |
+| --- | --- |
+| **Game** (current measured path) | Required for published perf claims; listing metadata must match |
+| **App** (shared resources) | Likely starves large models / diffusion; **must measure before go** |
+
+**Gate (Phase 0 spike):** on a Series S, with the shipping default chat model
+(`lfm25-350m`), run the same short decode bench under **App** and **Game**.
+Record tok/s + peak working set. Procedure: §6 below.
+
+- If App mode is unusable → Store listing **must** obtain Game metadata, or do
+  not ship.
+- If App mode is “good enough” for hobbyist default chat → document the delta
+  and avoid advertising Game-only numbers on the listing.
+
+### D2 — Dual-track SKU
+
+| SKU | Channel | Surfaces |
+| --- | --- | --- |
+| **dev** (default today) | Dev Mode sideload | LAN API, bench flags, USB path, full catalogue |
+| **store** | Xbox Store retail | No LAN, no bench/USB research paths; curated catalogue; disclaimers |
+
+Compile-time flag (planned Phase 1): `XLLAMA_STORE_SKU`. Dev package identity
+(`GianlucaMazza.xllama` / `CN=xllama-dev`) must **not** be broken for existing
+Dev Mode installs when the Store identity is reserved.
+
+### D3 — Store SKU surface cuts
+
+| Feature | Store SKU action |
+| --- | --- |
+| LAN OpenAI endpoint | Remove (code + capability + Settings) |
+| Headless `bench.flag` / operator flags | Remove or strip |
+| USB model path + `removableStorage` | Remove |
+| On-device training (Lane B) | Allowed behind advanced UI if privacy-local; optional v1 cut |
+| In-app model download | Keep (`internetClient` + licence matrix) |
+| Stable Diffusion | Riskiest for review — text-only v1 Store is an accepted fallback |
+| Patched ORT/GenAI in-package | Keep; pin lifecycle stays in `vendor-lifecycle-plan.md` |
+
+### D4 — Generative AI policy bar (minimum)
+
+1. Honest **IARC / age rating** (open chat + image gen ≠ Everyone).
+2. **First-run disclosure:** local AI; may be wrong or inappropriate; not
+   affiliated with Microsoft.
+3. **Diffuse opt-in** + short NSFW risk note (or ship text-only first).
+4. No false claims (`docs/launch-copy.md`: not “first LLM on Xbox”).
+5. **Privacy policy** URL (what stays on device; outbound = model downloads only
+   unless opt-in telemetry is added later — default off).
+6. **Support:** GitHub Issues and/or email.
+
+### D5 — Microsoft program path
+
+1. Partner Center **individual** developer account (one-time fee).
+2. Create product, reserve package identity / publisher.
+3. UWP package targeting `Windows.Xbox` (Desktop optional later).
+4. **ID@Xbox not required** for day-1 (no Xbox Live multiplayer/achievements).
+5. Submit → certification loop → Available.
+
+Out of scope day-1: paid IAP, XCloud, Microsoft marketing, LAN-API Store rewrite.
+
+---
+
+## 3. Phases (summary)
+
+| Phase | Goal | Exit |
+| --- | --- | --- |
+| **0 Discovery** (now) | Go/no-go, this doc, App vs Game spike, licence matrix | Written go or stop |
+| **1 Store SKU code** | `XLLAMA_STORE_SKU`, capabilities, CI variant | Installable store MSIX smoke on console |
+| **2 Compliance pack** | Privacy URL, age rating, listing assets, NOTICE | Partner Center listing complete |
+| **3 Submission** | Upload, cert iteration, Game metadata if needed | Live on Store |
+| **4 Post-launch** | README dual path, stable vs research cadence | Hobbyist retail install works |
+
+Calendar order-of-magnitude: **~2–4 months**, dominated by review and policy,
+not pure coding.
+
+---
+
+## 4. Model licence matrix (catalogue)
+
+Authoritative download layout: `uwp/models/manifest.json`. Narrative redistribution
+notes: `model-selection.md` (LFM / Qwen / Gemma). This table is the **Store
+allowlist draft** — not legal advice; re-verify before submission.
+
+| Catalogue id | Family | Typical licence (upstream) | Hosting today | Store SKU draft |
+| --- | --- | --- | --- | --- |
+| `lfm25-350m` | Liquid LFM2.5 | LFM Open License v1.0 (LICENSE next to weights; commercial use limited by entity revenue — see upstream §5) | `models-v1` + LICENSE | **Allow** default chat if non-commercial listing OK under LFM terms |
+| `lfm25-1.2b-instruct` | Liquid LFM2.5 | LFM Open License | HF LiquidAI + LICENSE | **Allow** if same |
+| `lfm2-2.6b` | Liquid LFM2 | LFM Open License | HF LiquidAI + LICENSE | **Allow** if same |
+| `lfm25-1.2b-thinking` | Liquid LFM2.5 | LFM Open License | HF LiquidAI + LICENSE | **Allow** (advanced) |
+| `qwen35-0.8b` | Qwen | Apache-2.0 (unsloth GGUF) | `models-v1` | **Allow** |
+| `qwen3-1.7b` | Qwen | Apache-2.0 | HF unsloth | **Allow** |
+| `qwen25-coder-0.5b` / `1.5b` / `3b` | Qwen2.5-Coder | Apache-2.0 | HF unsloth | **Allow** |
+| `smollm2-360m-cpu-int4` | SmolLM2 | Apache-2.0 (HuggingFaceTB lineage — confirm pin) | `models-v1` | **Allow** |
+| `smollm2-360m-dml-fp16-v2` | SmolLM2 | same | `models-v1` | **Allow** (GPU text) |
+| `smollm2-1.7b-cpu-int4` | SmolLM2 | same | `models-v1` | **Allow** / size check |
+| `gemma3-270m` | Gemma | Gemma Terms of Use (not Apache) | HF only (no models-v1 mirror) | **Review** before Store; may exclude v1 |
+| `gemma4-e2b` | Gemma | Gemma Terms | HF only | **Review** / likely advanced-only or exclude |
+| `llama32-3b` | Llama 3.2 | Meta Llama Community License | HF only (do not mirror without review) | **Review** / likely exclude v1 Store |
+| `sd-turbo-fp16` | Stable Diffusion Turbo | Stability / model card terms + OpenRAIL-class constraints | `models-v1` | **Highest risk** — text-only Store v1 if review hostile |
+
+**Rules of thumb for Store v1 catalogue**
+
+1. Prefer **Apache-2.0 + LFM-with-LICENSE-file** defaults.
+2. Do **not** re-host Gemma/Llama on `models-v1` without explicit licence OK.
+3. Ship **LFM 350M + SmolLM2 + Qwen** as the safe core; treat Gemma/Llama/SD as
+   optional advanced or Dev-only until counsel/policy pass.
+4. In-app download must remain **allowlisted** (manifest), fail-closed.
+
+---
+
+## 5. Gap checklist (Phase 0 → 3)
+
+### Account / process
+
+- [ ] Partner Center individual account created (or explicit no-go)
+- [ ] Product reserved; Store publisher CN known
+- [ ] IARC age rating questionnaire drafted
+- [ ] Privacy policy URL live
+- [ ] Support contact published
+
+### Engineering
+
+- [x] `XLLAMA_STORE_SKU` / `XllamaStoreSku=true` strips LAN / USB / headless flags
+- [x] `uwp/AppxManifest.store.xml` (`internetClient` only); identity still test CN
+- [x] `build-uwp.ps1 -StoreSku` (+ `/p:XllamaStoreSku=true`)
+- [x] CI store lane via `workflow_dispatch` `store_sku=true` → artifact
+      `xllama-appx-store` (no VM; not on every PR)
+- [x] `install-latest-build.sh --store` (Linux → Device Portal)
+- [x] First-run generative-AI disclaimer (`LocalState\disclaimer.accepted`)
+- [x] Privacy draft [`privacy.md`](./privacy.md)
+- [ ] NOTICE / runtime attributions (ORT, llama.cpp, DirectML, models)
+- [ ] App vs Game spike results filed under `bench/results/`
+- [ ] Console smoke of store SKU (chat + model download)
+
+### Listing
+
+- [ ] EN title / description / screenshots / trailer (current numbers)
+- [ ] “Not affiliated with Microsoft”
+- [ ] Hardware: Series S\|X
+- [ ] Category / Game metadata decision from D1
+
+### Go/no-go
+
+- [ ] **Go** only if: Partner Center ready, App-vs-Game acceptable, core
+      catalogue licences OK, generative-AI bar accepted (or text-only fallback).
+- [ ] **Stop / pivot** to “public Dev Mode only” if Game metadata is refused and
+      App mode is unusable, or model/AI policy blocks listing.
+
+---
+
+## 6. Spike procedure — App vs Game resources
+
+**Goal:** quantify whether a retail **App** designation can run the default
+hobbyist path.
+
+**Prerequisites:** Series S (or X) in Dev Mode, current shipping MSIX, default
+chat model already provisioned (`lfm25-350m`), Device Portal access.
+
+1. Install / upgrade to current unified package (`install-release.md`).
+2. Dev Home → xllama tile → **View details** → set **App type = App**.
+3. Cold-start app, load `lfm25-350m`, run a fixed prompt (same as a known bench
+   row, e.g. short decode from `bench/README.md` methodology).
+4. Capture: decode tok/s, prefill tok/s if available, `peak_working_set_mb` (log
+   or headless bench if still available on dev SKU), GPU budget if logged.
+5. Switch **App type = Game**, reboot/relaunch if needed, repeat **identical**
+   prompt.
+6. Write CSV under `bench/results/store-app-vs-game-<date>.csv` with columns:
+   `designation,model,prefill_tps,decode_tps,peak_ws_mb,notes`.
+7. Paste a one-line verdict into this section when done.
+
+**Verdict (fill after measurement):** _TBD — not yet run._
+
+Historical note: GPU budget **3801 MB** and published benchmarks are **Game**
+numbers (`uwp-constraints.md` §5). Do not quote them as App-mode until measured.
+
+---
+
+## 7. Risks (short)
+
+| Risk | Mitigation |
+| --- | --- |
+| Certification rejects open image gen | Store v1 text-only; SD stays Dev / later update |
+| App mode too slow / OOM | Require Game listing metadata or no-go |
+| LFM / Gemma / Llama licence friction | Curated catalogue; default LFM+Qwen+Smol |
+| Dual identity confuses users | Clear README: Store vs Dev Mode packages |
+| Research pace vs Store freeze | Store SKU thin; `main` stays Dev Mode |
+
+---
+
+## 8. Explicit non-goals (day-1)
+
+- Full ID@Xbox Live services
+- Authenticated LAN API on Store SKU
+- Desktop Store as primary (optional later if `Windows.Desktop` stays)
+- Monetisation
+- Claiming Microsoft affiliation or “first LLM on Xbox”
+
+---
+
+## 9. No Windows VM — CI is the only UWP builder
+
+Local packaging still needs Windows (see `windows-dev-vm.md`), but the **supported
+Store path does not**: use GitHub Actions `windows-2022` from Linux.
+
+### Build Store SKU (from Linux) — verified
+
+```bash
+# On any branch that contains the Store SKU code:
+gh workflow run build-uwp.yml -f store_sku=true --ref "$(git branch --show-current)"
+gh run watch   # wait for success
+
+# Artifact name: xllama-appx-store
+gh run list --workflow build-uwp --limit 5
+gh run download <run-id> -n xllama-appx-store
+```
+
+PR/push builds keep **only** the usual `xllama-appx` + `xllama-appx-llamacpp`
+lanes (no extra cost). The **`store` job** runs only when `workflow_dispatch`
+sets `store_sku=true` (composite action `.github/actions/build-uwp-package`).
+
+**Smoke (2026-07-29, branch `research/h2-ram-ceiling`):** run
+[30446583341](https://github.com/gianlucamazza/xllama/actions/runs/30446583341)
+— `store` + unified + llamacpp all green; artifact `xllama-appx-store`
+downloaded on Linux as `xllama_1.5.1.771_x64.msix` (~19 MB) + `xllama-test.cer`.
+
+### Install on Xbox Dev Mode (from Linux)
+
+Same identity as dev today → **replaces** the Dev Mode package on the console.
+
+```bash
+source ~/.config/xllama/xbox-env
+./scripts/install-latest-build.sh --store          # this branch
+./scripts/install-latest-build.sh main --store     # explicit branch
+# --bench is rejected on --store (headless flags compiled out)
+```
+
+### Optional local Windows (not required)
+
+```powershell
+.\scripts\build-uwp.ps1 -Configuration Release -Platform x64 `
+  -Backend unified -PatchedGenAI -PatchedOrt -StoreSku
+```
+
+MSBuild: `/p:XllamaStoreSku=true` → `XLLAMA_STORE_SKU=1` + `AppxManifest.store.xml`.
+
+What changes under Store SKU:
+
+| Surface | Dev SKU | Store SKU |
+| --- | --- | --- |
+| LAN API + Settings | yes | compiled out |
+| Headless flags (`bench.flag`, …) | yes | compiled out |
+| USB model path + `removableStorage` | yes | compiled out |
+| First-run AI disclaimer | yes (both) | yes |
+| Publisher CN | `xllama-dev` test | still test until Partner Center |
+| CI artifact | `xllama-appx` | `xllama-appx-store` (dispatch only) |
+
+### Privacy policy draft
+
+In-repo: [`privacy.md`](./privacy.md). For Partner Center, host a stable HTTPS
+URL (GitHub Pages or equivalent) pointing at this content.
+
+### Listing draft (EN, not submitted)
+
+| Field | Draft |
+| --- | --- |
+| Title | xllama |
+| Short description | Local LLM chat on Xbox Series S\|X — models run on the console. |
+| Long description | xllama turns an Xbox Series S\|X into a local inference box: gamepad chat UI, on-demand model catalogue, optional image generation. Nothing is sent to a cloud LLM API. Research-grade hobby project; not affiliated with Microsoft. Requires enough free storage for model downloads. |
+| Category | (TBD — Game metadata preferred if resource measurements require it; see §2 D1) |
+| Age rating | (TBD — IARC; generative text + optional image gen) |
+| Screenshots | Pending console capture |
+| Support | GitHub Issues on gianlucamazza/xllama |
+| Privacy | Link to published `privacy.md` |
+
+## 10. Next steps (no VM)
+
+1. Push branch → `gh workflow run build-uwp.yml -f store_sku=true` → download
+   `xllama-appx-store` (validates packaging without a VM).
+2. **Human:** Partner Center account (browser); App vs Game spike on console (§6).
+3. Publish privacy URL; finish listing + age rating.
+4. NOTICE / attributions pack; then submission after smoke on console.

--- a/scripts/build-uwp.ps1
+++ b/scripts/build-uwp.ps1
@@ -41,7 +41,11 @@ param(
     # increasing version — in-place console updates never hit the same-identity
     # block. 0 (the local default) leaves the committed X.Y.Z.0 unchanged, so a
     # local build never pollutes the working tree.
-    [int]$BuildRevision     = $(if ($env:GITHUB_RUN_NUMBER) { [int]$env:GITHUB_RUN_NUMBER } else { 0 })
+    [int]$BuildRevision     = $(if ($env:GITHUB_RUN_NUMBER) { [int]$env:GITHUB_RUN_NUMBER } else { 0 }),
+    # Store SKU: XLLAMA_STORE_SKU — no LAN API, no USB models, no headless flags;
+    # AppxManifest.store.xml (internetClient only). Dev Mode remains the default.
+    # See docs/store-readiness.md. Still test-signed (Partner Center identity later).
+    [switch]$StoreSku       = $false
 )
 
 $ErrorActionPreference = "Stop"
@@ -190,8 +194,9 @@ if ($PatchedOrt -and $Backend -ne "llamacpp") {
 # The negative-lookbehind avoids the TargetDeviceFamily Min/MaxVersion attributes;
 # only the first (Identity) Version is rewritten.
 # ---------------------------------------------------------------------------
+$ManifestName = if ($StoreSku) { "AppxManifest.store.xml" } else { "AppxManifest.xml" }
 if ($BuildRevision -gt 0) {
-    $ManifestPath = Join-Path $UwpDir "AppxManifest.xml"
+    $ManifestPath = Join-Path $UwpDir $ManifestName
     $manifestText = Get-Content -Raw $ManifestPath
     $rx = [regex]'(?<!\w)Version="(\d+)\.(\d+)\.(\d+)\.\d+"'
     $newText = $rx.Replace($manifestText, {
@@ -200,10 +205,13 @@ if ($BuildRevision -gt 0) {
     }, 1)
     Set-Content -Path $ManifestPath -Value $newText -NoNewline
     $stamped = ([regex]::Match($newText, '(?<!\w)Version="(\d+\.\d+\.\d+\.\d+)"')).Groups[1].Value
-    Write-Host "Version stamped: $stamped (revision = build $BuildRevision)"
+    Write-Host "Version stamped ($ManifestName): $stamped (revision = build $BuildRevision)"
 }
 
 Write-Host "Building $Configuration|$Platform ..."
+if ($StoreSku) {
+    Write-Host "Store SKU: XLLAMA_STORE_SKU=1, manifest=$ManifestName"
+}
 
 # ---------------------------------------------------------------------------
 # Build + sign
@@ -219,6 +227,9 @@ $MsBuildArgs = @(
     "/m",
     "/nologo"
 )
+if ($StoreSku) {
+    $MsBuildArgs += "/p:XllamaStoreSku=true"
+}
 if ($Backend -ne "ort") {
     Write-Host "Backend: $Backend (links the static ggml/llama lib)"
     $MsBuildArgs += "/p:XllamaBackend=$Backend"

--- a/scripts/install-latest-build.sh
+++ b/scripts/install-latest-build.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   source ~/.config/xllama/xbox-env
-#   ./scripts/install-latest-build.sh [branch] [--bench]
+#   ./scripts/install-latest-build.sh [branch] [--bench] [--store]
 #
 # Defaults to the current git branch if no branch argument is given.
 # Requires: gh CLI (authenticated), jq, curl.
@@ -12,6 +12,12 @@
 # bench.flag so the next launch runs headless bench mode (delete
 # LocalState\bench.flag via WDP before UI or validate-console.sh otherwise).
 # MSIX uninstall wipes LocalState — re-provision models after a fresh install.
+#
+# --store downloads the Store SKU artifact (xllama-appx-store) from a
+# workflow_dispatch run that set store_sku=true. That SKU has no headless
+# flags — --bench is rejected. Same package identity as dev for now, so this
+# replaces the Dev Mode install on the console (docs/store-readiness.md).
+# No local Windows VM: packages come from GitHub Actions windows-2022 only.
 
 set -euo pipefail
 
@@ -19,15 +25,25 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 UPLOAD_BENCH=false
+STORE_SKU=false
 BRANCH=""
 for arg in "$@"; do
 	case "$arg" in
 	--bench) UPLOAD_BENCH=true ;;
+	--store) STORE_SKU=true ;;
 	*) [[ -z "$BRANCH" ]] && BRANCH="$arg" ;;
 	esac
 done
 BRANCH="${BRANCH:-$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)}"
 ARTIFACT_NAME="xllama-appx"
+if [[ "$STORE_SKU" == true ]]; then
+	ARTIFACT_NAME="xllama-appx-store"
+fi
+if [[ "$STORE_SKU" == true && "$UPLOAD_BENCH" == true ]]; then
+	echo "ERROR: --bench is not supported on the Store SKU (headless flags compiled out)." >&2
+	echo "Omit --bench, or install the dev artifact without --store." >&2
+	exit 1
+fi
 WORK_DIR="/tmp/xllama-install-$$"
 
 : "${XBOX_IP:?XBOX_IP not set — run: source ~/.config/xllama/xbox-env}"
@@ -37,20 +53,46 @@ WORK_DIR="/tmp/xllama-install-$$"
 cleanup() { rm -rf "$WORK_DIR"; }
 trap cleanup EXIT
 
-echo "==> Looking for latest successful build-uwp run on branch: ${BRANCH}"
+echo "==> Looking for latest successful build-uwp run on branch: ${BRANCH} (artifact: ${ARTIFACT_NAME})"
 
-RUN_ID=$(gh run list \
-	--repo gianlucamazza/xllama \
-	--branch "$BRANCH" \
-	--workflow build-uwp \
-	--status success \
-	--limit 1 \
-	--json databaseId \
-	--jq '.[0].databaseId' 2>/dev/null || echo "")
+RUN_ID=""
+if [[ "$STORE_SKU" == true ]]; then
+	# Store SKU is only produced by workflow_dispatch -f store_sku=true; walk
+	# recent successful runs and pick the first that lists the artifact (API,
+	# no download probe).
+	while IFS= read -r candidate; do
+		[[ -z "$candidate" || "$candidate" == "null" ]] && continue
+		if gh api "repos/gianlucamazza/xllama/actions/runs/${candidate}/artifacts" \
+			--jq '.artifacts[].name' 2>/dev/null | grep -qx "$ARTIFACT_NAME"; then
+			RUN_ID="$candidate"
+			break
+		fi
+	done < <(gh run list \
+		--repo gianlucamazza/xllama \
+		--branch "$BRANCH" \
+		--workflow build-uwp \
+		--status success \
+		--limit 20 \
+		--json databaseId \
+		--jq '.[].databaseId' 2>/dev/null || true)
+else
+	RUN_ID=$(gh run list \
+		--repo gianlucamazza/xllama \
+		--branch "$BRANCH" \
+		--workflow build-uwp \
+		--status success \
+		--limit 1 \
+		--json databaseId \
+		--jq '.[0].databaseId' 2>/dev/null || echo "")
+fi
 
 if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
-	echo "No successful build-uwp run found on branch '${BRANCH}'." >&2
-	echo "Check: gh run list --branch $BRANCH" >&2
+	echo "No successful build-uwp run with artifact '${ARTIFACT_NAME}' on branch '${BRANCH}'." >&2
+	if [[ "$STORE_SKU" == true ]]; then
+		echo "Trigger a Store SKU build (no Windows VM):" >&2
+		echo "  gh workflow run build-uwp.yml -f store_sku=true --ref ${BRANCH}" >&2
+	fi
+	echo "Check: gh run list --branch $BRANCH --workflow build-uwp" >&2
 	exit 1
 fi
 

--- a/src/bridge/path_utils.cpp
+++ b/src/bridge/path_utils.cpp
@@ -177,10 +177,12 @@ std::string resolve_model_path(const std::string& filename) {
         log_output("[xllama] InstalledPath copy failed\n");
     }
 
+    #ifndef XLLAMA_STORE_SKU
     // Fallback 3: USB root cached by EnsureModelAsync (async KnownFolders probe).
     // EnsureModelAsync writes LocalState\usb_model_root.txt with the drive root
     // after finding the model via KnownFolders.RemovableDevices; read it here
-    // for the synchronous inference path.
+    // for the synchronous inference path. Omitted from Store SKU (no
+    // removableStorage capability — docs/store-readiness.md).
     {
         std::string cache_utf8 = local_folder_path("usb_model_root.txt", nullptr);
         int csz = MultiByteToWideChar(CP_UTF8, 0, cache_utf8.c_str(), -1, nullptr, 0);
@@ -225,6 +227,7 @@ std::string resolve_model_path(const std::string& filename) {
             }
         }
     }
+    #endif // !XLLAMA_STORE_SKU
 
     return primary; // return primary even if not found (ORT will emit a clear error)
 }

--- a/uwp/App.cpp
+++ b/uwp/App.cpp
@@ -8,16 +8,20 @@
 #include "pch.h"
 #include "App.h"
 #include "MainPage.h"
-#include "api-server.h"
 #include "inference-bridge.h"
 #include "xllama/platform.h"
+#ifndef XLLAMA_STORE_SKU
+#include "api-server.h"
+#endif
 // clang-format on
 
     #include <thread>
 
+    #ifndef XLLAMA_STORE_SKU
 // Defined in the headless section below; also used by the in-process
 // diffusion experiment in App::OnLaunched.
 static std::wstring flag_path_if_present(const wchar_t* name);
+    #endif
 
 using namespace winrt;
 using namespace winrt::Windows::ApplicationModel::Activation;
@@ -111,12 +115,14 @@ void App::OnLaunched(LaunchActivatedEventArgs const&) {
         Window::Current().Activate();
         log_write("[xllama] Window activated\n");
 
+    #ifndef XLLAMA_STORE_SKU
         // §7 experiment: the 887A0036 device conflict was measured with ORT
         // GenAI's Agility-factory device; diffuse.cpp uses plain ORT DML, whose
         // device may coexist with the compositor device the line above just
         // created. diffuse-inproc.flag runs the diffusion pipeline on a
         // background MTA thread INSIDE the XAML process to test exactly that.
         // Consumed before the run, same semantics as the headless flags.
+        // Store SKU: research flags omitted (docs/store-readiness.md).
         std::wstring inproc = flag_path_if_present(L"diffuse-inproc.flag");
         if (!inproc.empty()) {
             _wremove(inproc.c_str());
@@ -150,6 +156,10 @@ void App::OnLaunched(LaunchActivatedEventArgs const&) {
         } else if (m_controller) {
             m_controller->StartAutopilotIfRequested();
         }
+    #else
+        if (m_controller)
+            m_controller->StartAutopilotIfRequested();
+    #endif
     } catch (winrt::hresult_error const& e) {
         char buf[512];
         snprintf(buf, sizeof(buf), "[xllama] OnLaunched hresult 0x%08X: %ls\n",
@@ -169,6 +179,7 @@ void App::OnLaunched(LaunchActivatedEventArgs const&) {
 
 } // namespace winrt::xllama::implementation
 
+    #ifndef XLLAMA_STORE_SKU
 // ---------------------------------------------------------------------------
 // Headless bench mode — no XAML, no compositor D3D12 device
 //
@@ -179,6 +190,8 @@ void App::OnLaunched(LaunchActivatedEventArgs const&) {
 // collides with the compositor's in-box-runtime device and throws 887A0036
 // DXGI_ERROR_ALREADY_EXISTS. Running the bench without XAML leaves the process
 // D3D12-clean so the DML EP can initialise.
+//
+// Entire headless path is Dev Mode / research only (not compiled into Store SKU).
 // ---------------------------------------------------------------------------
 
 // Returns the wide path of LocalFolder\<name> if it exists, empty otherwise.
@@ -235,6 +248,7 @@ struct HeadlessView
             winrt::Windows::UI::Core::CoreProcessEventsOption::ProcessUntilQuit);
     }
 };
+    #endif // !XLLAMA_STORE_SKU
 
 // ---------------------------------------------------------------------------
 // Entry point — Application::Start replaces CoreApplication::Run
@@ -242,6 +256,9 @@ struct HeadlessView
 int __stdcall wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
     try {
         winrt::init_apartment(); // MTA: needed for ApplicationData in the detection
+    #ifndef XLLAMA_STORE_SKU
+        // Headless operator modes (Device Portal flags). Omitted from the Store
+        // SKU — retail builds always take the interactive XAML path.
         // Consume the flag BEFORE the run:
         // a later start without the flag goes back to interactive.
         std::wstring diffuse_flag = flag_path_if_present(L"diffuse.flag");
@@ -293,6 +310,7 @@ int __stdcall wWinMain(HINSTANCE, HINSTANCE, PWSTR, int) {
                 winrt::make<HeadlessView>(&::xllama::bridge::run_train, "train"));
             return 0; // not reached: CoreApplication::Exit terminates the process
         }
+    #endif                         // !XLLAMA_STORE_SKU
         winrt::uninit_apartment(); // restore pre-existing thread state for XAML
         winrt::Windows::UI::Xaml::Application::Start(
             [](auto&&) { winrt::make<winrt::xllama::implementation::App>(); });

--- a/uwp/AppxManifest.store.xml
+++ b/uwp/AppxManifest.store.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+  xmlns:xbox="http://schemas.microsoft.com/appx/manifest/xbox/windows10"
+  IgnorableNamespaces="mp uap uap3 xbox">
+
+  <!-- Store SKU manifest (XllamaStoreSku=true / XLLAMA_STORE_SKU).
+       Research surfaces stay on AppxManifest.xml (dev / Dev Mode):
+         - privateNetworkClientServer (LAN API)
+         - removableStorage (USB models)
+       Identity remains the local test identity until Partner Center reserves
+       a Store publisher; do not point shipping Dev Mode users at this file.
+       SSOT: docs/store-readiness.md -->
+  <!-- Version: Major.Minor.Build is the semantic version (bump manually per
+       release, alongside CHANGELOG). The Revision (the trailing .0) is stamped
+       automatically in CI to the workflow run number (build-uwp.ps1
+       -BuildRevision) so every build is uniquely, monotonically versioned and
+       the console always accepts an in-place update. Local builds keep .0. -->
+  <Identity
+    Name="GianlucaMazza.xllama"
+    Publisher="CN=xllama-dev"
+    Version="1.5.1.0"
+    ProcessorArchitecture="x64" />
+
+  <mp:PhoneIdentity
+    PhoneProductId="00000000-0000-0000-0000-000000000000"
+    PhonePublisherId="00000000-0000-0000-0000-000000000000" />
+
+  <Properties>
+    <DisplayName>xllama</DisplayName>
+    <PublisherDisplayName>Gianluca Mazza</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Xbox"    MinVersion="10.0.19041.0" MaxVersionTested="10.0.22621.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.22621.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="en-US" />
+  </Resources>
+
+  <Applications>
+    <Application Id="xllama" Executable="xllama.exe" EntryPoint="xllama.App">
+      <uap:VisualElements
+        DisplayName="xllama"
+        Description="Local LLM inference for Xbox Series S|X"
+        BackgroundColor="#0E1116"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" ShortName="xllama" />
+        <uap:SplashScreen Image="Assets\SplashScreen.png" BackgroundColor="#0E1116" />
+        <uap:InitialRotationPreference>
+          <uap:Rotation Preference="landscape" />
+        </uap:InitialRotationPreference>
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <!-- internetClient: catalogue / Hugging Face model download on first use. -->
+    <Capability Name="internetClient" />
+  </Capabilities>
+
+</Package>

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -8,7 +8,9 @@
 #include "MainPage.h"
 // clang-format on
 
-    #include "api-server.h"
+    #ifndef XLLAMA_STORE_SKU
+        #include "api-server.h"
+    #endif
     #include "chat-history.h"
     #include "inference-bridge.h"
     #include "xllama/chat_prompt.h"
@@ -382,6 +384,7 @@ void MainPageController::Init() {
     LoadSettings();
 
     EnsureModelAsync();
+    ShowDisclaimerIfNeeded();
 }
 
 // ---------------------------------------------------------------------------
@@ -1301,6 +1304,7 @@ void MainPageController::SaveSettings() {
     m_kv_valid = false;
 }
 
+    #ifndef XLLAMA_STORE_SKU
 void MainPageController::ApplyApiSettings(bool enabled, int port) {
     if (enabled) {
         write_local_bytes(L"api-port.txt", std::to_string(port));
@@ -1337,6 +1341,32 @@ void MainPageController::ApplyApiSettings(bool enabled, int port) {
             }
         });
     }).detach();
+}
+    #endif // !XLLAMA_STORE_SKU
+
+winrt::fire_and_forget MainPageController::ShowDisclaimerIfNeeded() {
+    auto self = shared_from_this();
+    if (std::filesystem::exists(local_wpath(L"disclaimer.accepted")))
+        co_return;
+
+    // Yield once so XamlRoot is attached after Window.Content/Activate.
+    co_await winrt::resume_foreground(m_root.Dispatcher());
+
+    winrt::Windows::UI::Xaml::Controls::TextBlock body;
+    body.TextWrapping(winrt::Windows::UI::Xaml::TextWrapping::Wrap);
+    body.Text(L"xllama runs language and image models entirely on this device. "
+              L"Generated text and images can be inaccurate, biased, or inappropriate. "
+              L"Nothing leaves the console except model downloads you start. "
+              L"This project is not affiliated with Microsoft.");
+    body.MaxWidth(520);
+
+    winrt::Windows::UI::Xaml::Controls::ContentDialog dlg;
+    dlg.Title(winrt::box_value(L"Before you start"));
+    dlg.Content(body);
+    dlg.PrimaryButtonText(L"I understand");
+    dlg.XamlRoot(m_root.XamlRoot());
+    co_await dlg.ShowAsync();
+    write_local_bytes(L"disclaimer.accepted", "1\n");
 }
 
 winrt::fire_and_forget MainPageController::ShowSettings() {
@@ -1435,6 +1465,7 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
     routingBox.Items().Append(winrt::box_value(L"Auto (long prompts → GPU)"));
     routingBox.SelectedIndex(m_routing >= 0 && m_routing <= 2 ? m_routing : 0);
 
+    #ifndef XLLAMA_STORE_SKU
     const bool api_enabled = std::filesystem::exists(local_wpath(L"api.flag"));
     int api_port = 11434;
     try {
@@ -1484,6 +1515,7 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
         apiStatus.Text(L"Status: stopped. Trusted LAN only; no authentication.");
         break;
     }
+    #endif // !XLLAMA_STORE_SKU
 
     // GGUF models run stateless on CPU-only llama.cpp: KV-reuse and EP routing do
     // not apply, so grey them out whenever a GGUF entry is selected (and restore
@@ -1540,9 +1572,11 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
     panel.Children().Append(nPredSlider);
     panel.Children().Append(kvToggle);
     panel.Children().Append(routingBox);
+    #ifndef XLLAMA_STORE_SKU
     panel.Children().Append(apiToggle);
     panel.Children().Append(apiPortBox);
     panel.Children().Append(apiStatus);
+    #endif
 
     winrt::Windows::UI::Xaml::Controls::ScrollViewer sv;
     sv.Content(panel);
@@ -1596,6 +1630,7 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
     self->m_repetition_penalty = static_cast<float>(repSlider.Value());
     self->m_n_predict = static_cast<int>(nPredSlider.Value());
     self->m_kv_reuse = kvToggle.IsOn();
+    #ifndef XLLAMA_STORE_SKU
     int selected_api_port = api_port;
     if (apiToggle.IsOn()) {
         try {
@@ -1610,12 +1645,15 @@ winrt::fire_and_forget MainPageController::ShowSettings() {
             co_return;
         }
     }
+    #endif
     int ri = routingBox.SelectedIndex();
     self->m_routing = (ri >= 0 && ri <= 2) ? ri : 0;
     // Routing is per-conversation: a change applies from the next new/loaded chat
     // (m_active_model stays fixed for the conversation in progress).
     self->SaveSettings();
+    #ifndef XLLAMA_STORE_SKU
     self->ApplyApiSettings(apiToggle.IsOn(), selected_api_port);
+    #endif
 }
 
 // ---------------------------------------------------------------------------
@@ -2245,9 +2283,11 @@ fire_and_forget MainPageController::EnsureModelNamedAsync(std::wstring model_nam
         }
     }
 
+    #ifndef XLLAMA_STORE_SKU
     // Check 3: USB removable storage via KnownFolders.RemovableDevices
     // (requires <uap:Capability Name="removableStorage" /> in manifest).
     // Enumerates all removable drives; looks for xllama/models/<name>/genai_config.json.
+    // Store SKU: no removableStorage capability — download / LocalState only.
     co_await resume_foreground(dispatcher);
     {
         bool usb_found = false;
@@ -2374,15 +2414,23 @@ fire_and_forget MainPageController::EnsureModelNamedAsync(std::wstring model_nam
             co_return;
         }
     }
+    #endif // !XLLAMA_STORE_SKU
     // Neither found: consult the model catalogue (loaded above) — any entry with
     // an hf_base_url can be auto-downloaded; anything else must be provided via
-    // USB or Device Portal upload.
+    // USB or Device Portal upload (dev SKU only for USB).
     if (!entry || entry->hf_base_url.empty() || entry->files.empty()) {
         log_output(("[xllama] EnsureModel: '" + ::xllama::wstring_to_utf8(model_name) +
                     "' not in catalogue (no hf_base_url)\n")
                        .c_str());
         co_await resume_foreground(dispatcher);
         if (set_app_ready) {
+    #ifdef XLLAMA_STORE_SKU
+            self->SetStatus(L"Model '" + model_name +
+                                L"' not found.\n"
+                                L"Choose a catalogue model that can download, "
+                                L"or reinstall and try again.",
+                            StatusKind::Error);
+    #else
             self->SetStatus(L"Model '" + model_name +
                                 L"' not found.\n"
                                 L"Upload to LocalState\\models\\" +
@@ -2390,6 +2438,7 @@ fire_and_forget MainPageController::EnsureModelNamedAsync(std::wstring model_nam
                                 L" via Device Portal or USB "
                                 L"(see docs/model-selection.md).",
                             StatusKind::Error);
+    #endif
             self->m_runButton.IsEnabled(false);
         }
         co_return;
@@ -3222,6 +3271,10 @@ void MainPageController::ApRun(std::vector<ApAction> actions, std::chrono::secon
                 m_active_model.clear();
             });
         } else if (a.op == "set_api") {
+    #ifdef XLLAMA_STORE_SKU
+            throw std::runtime_error("action " + std::to_string(i) +
+                                     " set_api: LAN API not available in Store SKU");
+    #else
             if (a.enabled && !::xllama::api::port_bindable(a.port))
                 throw std::runtime_error("action " + std::to_string(i) + " set_api: invalid port");
             ApDispatchSync(
@@ -3242,6 +3295,7 @@ void MainPageController::ApRun(std::vector<ApAction> actions, std::chrono::secon
                 (!a.enabled && state != ::xllama::api::ServerState::Stopped))
                 throw std::runtime_error("action " + std::to_string(i) +
                                          " set_api: lifecycle timeout");
+    #endif
         } else if (a.op == "set_routing") {
             // Same semantics as the Settings panel: per-conversation, applies from
             // the next new/loaded chat (m_active_model stays sticky meanwhile).

--- a/uwp/MainPage.h
+++ b/uwp/MainPage.h
@@ -45,6 +45,8 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     void StartAutopilotIfRequested(); // called from App::OnLaunched
 
   private:
+    // First-run generative-AI disclosure (LocalState\disclaimer.accepted).
+    winrt::fire_and_forget ShowDisclaimerIfNeeded();
     // One parsed autopilot action (see ApParseScript in MainPage.cpp).
     struct ApAction {
         std::string op;   // load_chat|send|new_chat|set_model|set_api|set_routing|set_sampling|
@@ -119,7 +121,9 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     void LoadSettings();
     void SaveSettings();
     winrt::fire_and_forget ShowSettings();
+    #ifndef XLLAMA_STORE_SKU
     void ApplyApiSettings(bool enabled, int port);
+    #endif
     // Phase 11 (#116): in-app personalization — train on samples.jsonl, publish
     // merged.gguf as catalogue entry "personalized".
     void StartPersonalizeTrain();

--- a/uwp/xllama.vcxproj
+++ b/uwp/xllama.vcxproj
@@ -48,6 +48,10 @@
     <XllamaLlamaDefine Condition="'$(XllamaBackend)' == 'llamacpp' or '$(XllamaBackend)' == 'unified'">XLLAMA_USE_LLAMA=1;</XllamaLlamaDefine>
     <!-- Lane B in-process training rides on the llama.cpp backend (ggml-opt). -->
     <XllamaDeviceTrainDefine Condition="'$(XllamaBackend)' == 'llamacpp' or '$(XllamaBackend)' == 'unified'">XLLAMA_DEVICE_TRAIN=1;</XllamaDeviceTrainDefine>
+    <!-- Store SKU: strip research surfaces (LAN API, USB models, headless flags).
+         Default false keeps the Dev Mode package. See docs/store-readiness.md. -->
+    <XllamaStoreSku Condition="'$(XllamaStoreSku)' == ''">false</XllamaStoreSku>
+    <XllamaStoreSkuDefine Condition="'$(XllamaStoreSku)' == 'true'">XLLAMA_STORE_SKU=1;</XllamaStoreSkuDefine>
   </PropertyGroup>
 
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -124,6 +128,7 @@
         $(XllamaOrtDefine)
         $(XllamaLlamaDefine)
         $(XllamaDeviceTrainDefine)
+        $(XllamaStoreSkuDefine)
         %(PreprocessorDefinitions)
       </PreprocessorDefinitions>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -202,7 +207,12 @@
        Manifest
        ===================================================================== -->
   <ItemGroup>
-    <AppxManifest Include="AppxManifest.xml">
+    <!-- Dev Mode / research package (LAN API + USB model path). -->
+    <AppxManifest Include="AppxManifest.xml" Condition="'$(XllamaStoreSku)' != 'true'">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+    <!-- Store SKU: internetClient only (docs/store-readiness.md). -->
+    <AppxManifest Include="AppxManifest.store.xml" Condition="'$(XllamaStoreSku)' == 'true'">
       <SubType>Designer</SubType>
     </AppxManifest>
   </ItemGroup>
@@ -315,7 +325,8 @@
   <!-- xllama UWP app -->
   <ItemGroup>
     <ClCompile Include="App.cpp" />
-    <ClCompile Include="api-server.cpp" />
+    <!-- LAN API is Dev Mode only; omit from Store SKU link (docs/store-readiness.md). -->
+    <ClCompile Include="api-server.cpp" Condition="'$(XllamaStoreSku)' != 'true'" />
     <ClCompile Include="chat-history.cpp" />
     <ClCompile Include="MainPage.cpp" />
     <ClCompile Include="model-downloader.cpp" />


### PR DESCRIPTION
## What

Compile-time `XLLAMA_STORE_SKU` / MSBuild `XllamaStoreSku=true` / `build-uwp.ps1 -StoreSku` strips the research surfaces a retail package cannot carry — LAN API, USB model path, headless operator flags — and packages `AppxManifest.store.xml` with `internetClient` only. The Dev Mode package is unchanged. Both SKUs show the first-run generative-AI disclaimer.

CI builds it **without a Windows VM**: `workflow_dispatch` with `store_sku=true` produces `xllama-appx-store`, and `install-latest-build.sh --store` deploys it from Linux.

- Privacy draft: `docs/privacy.md`
- Workstream SSOT: `docs/store-readiness.md`

**Not Store-submission-ready**: test signing and Partner Center identity remain open.

## Why this PR exists separately

This work was swept into PR #195 by an over-broad `git add` while that branch was measuring the console heap ceiling — two unrelated filoni under commit messages about MoE admissibility. This PR carries the Store SKU work on its own, from `main`.

Content is unchanged apart from `clang-format` on the files the CI formatting gate rejected (`MainPage.cpp`, `MainPage.h`, `path_utils.cpp`, `App.cpp`).

## Verification

- Host suite 159/159
- No trace of the probe/MoE filone: `git diff main --name-only` carries none of its files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Xbox Store SKU build option with a dedicated package manifest and streamlined Store-compatible app behavior.
  * Added optional Store SKU builds to the build workflow and installation script.
  * Added a first-run disclosure dialog for generative AI functionality.
  * Added a privacy policy and Xbox Store readiness documentation.

* **Bug Fixes**
  * Store builds now exclude unsupported USB model paths, LAN API controls, and headless execution options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->