### PR TITLE
release: v1.5.2.0 — Phase 14, the exact context budget, and the Store SKU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,39 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [Unreleased]
+## [1.5.2.0] - 2026-07-29
+
+Phase 14 shipped — a coding, chat and thinking tier the catalogue can actually
+hold — together with the exact context budget that made it safe to offer a
+4096-token session, and the Xbox Store SKU foundation.
+
+**Upgrading from 1.5.x is a normal in-place update** (same package identity
+`GianlucaMazza.xllama`). Coming from ≤1.4.x still requires the identity migration
+described in `docs/install-release.md`.
 
 ### Added
 
+- **The console heap ceiling is measured, and the probe that measures it ships.**
+  `--ramceil` on the CLI and `ramceil.flag` headless on device commit heap in
+  128 MB steps, fault every page in, and record the platform counters after each
+  one — stopping at the first failed allocation or when `avail_phys` falls under
+  256 MB, deliberately short of OOM, because the PLM resolves OOM by killing the
+  process and a killed probe reports nothing. Rows stream as they are produced, so
+  a kill still leaves the answer on disk. **Measured on Series S: 4864 MB of heap
+  committed, 4893 MB peak working set** over 38 steps, process overhead a flat
+  29 MB throughout (`bench/results/phase15-ramceil.csv`, driver
+  `scripts/bench-ramceil.sh`). This decides which model quants are admissible at
+  all: GGUF weights are read into the heap, since the sandbox has no mmap, and the
+  only figure the repo had before was one incidental `avail_phys` log line.
+  Two bounds ship with it — it is a **lower** bound, having stopped on its own
+  floor rather than on a failed allocation, and it is **headless**, so an in-app
+  load pays more.
+- **Catalogue entry `lfm25-8b-a1b`** (LFM2.5-8B-A1B MoE, `UD-IQ3_S`, 3.57 GB): the
+  H2 candidate, 32 experts with 4 active per token. Provisionable and
+  **not yet measured on console** — `docs/model-matrix.md` §A3 is the state, and
+  nothing in it may be quoted as a performance figure. Its estimated ~4.0 GB peak
+  clears H2's 4 GB gate and breaks the 3.5 GB product gate; that tension is open
+  on purpose.
 - **Xbox Store SKU foundation (Phase 1 engineering).** Compile-time
   `XLLAMA_STORE_SKU` / MSBuild `XllamaStoreSku=true` / `build-uwp.ps1 -StoreSku`:
   strips LAN API, USB model path, and headless operator flags; packages
@@ -16,7 +45,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   First-run generative-AI disclaimer (`disclaimer.accepted`) on both SKUs.
   **No Windows VM required:** `build-uwp.yml` `workflow_dispatch` with
   `store_sku=true` → artifact `xllama-appx-store`; `install-latest-build.sh
-  --store` from Linux. Privacy draft: `docs/privacy.md`. Workstream SSOT:
+--store` from Linux. Privacy draft: `docs/privacy.md`. Workstream SSOT:
   `docs/store-readiness.md`. Not Store-submission-ready (test signing + Partner
   Center still open).
 - **Coding + chat + thinking tier (phase14), architecture-first.** Catalogue
@@ -33,6 +62,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **A thinking model whose name does not say so was treated as a plain model.**
+  `model_is_thinking` matched the substring `thinking`, and LFM2.5-8B-A1B reasons
+  on **every** turn — its template emits `<think>` unconditionally, with
+  `preserve_thinking` deciding only whether past turns' chain of thought is
+  replayed. So cataloguing it would have leaked raw CoT into the UI and left KV
+  snapshots enabled on a model whose stripped saved history can never prefix-match
+  a cache holding the full reasoning, making every return a silent full
+  re-prefill. The predicate now also matches `a1b`. Found while adding the entry,
+  not by a user.
 - **A long prompt aborted the process instead of failing (llama.cpp backend).**
   Both prefills (`LlamaSession::generate` and `run_inference`) submitted the whole
   prompt as ONE logical batch, and `llama_decode` does not return an error for an
@@ -52,7 +90,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   prose ran 4.6 real chars/token against the 5.0 constant and dense C++ 2.5 against
   3.5, and since the generation loop clamps `n_predict` to what the context has
   left (#173), every token of undershoot came off the reply. The estimate keeps one
-  job, routing, where it must run *before* a tokenizer exists and where being wrong
+  job, routing, where it must run _before_ a tokenizer exists and where being wrong
   costs a routing decision instead of an answer.
 - **`can_shift` is logged per load, and the docs were wrong about Qwen3.** The
   capability matrix said imrope/no-shift for both Qwen3 and Qwen3.5, inherited from

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,12 +5,15 @@ performance belongs in `docs/benchmarks.md`.
 
 ## Current product state
 
-- Current manifest: **1.5.1.0** under the **`GianlucaMazza.xllama`** identity
-  (in-place update from 1.5.0.0; still breaking vs ≤1.4.x, see
-  `docs/install-release.md`). Released as **v1.5.1.0** (2026-07-27): the
+- Current manifest: **1.5.2.0** under the **`GianlucaMazza.xllama`** identity
+  (in-place update from 1.5.x; still breaking vs ≤1.4.x, see
+  `docs/install-release.md`). Released as **v1.5.2.0** (2026-07-29): Phase 14 —
+  the coding/chat/thinking tier — plus the exact token budget that made a
+  4096-token session safe to offer (#193/#194) and the Xbox Store SKU
+  foundation. The previous release, **v1.5.1.0** (2026-07-27), carried the
   Phase 13 CPU-prefill + KV-reuse campaign (#168, #169, #170a/b, #171,
-  #173-#175). The previous release, **v1.5.0.0** (2026-07-26), carried the
-  perf campaign + rebrand (PR #155-#165) on console-validated MSIX 1.5.0.698.
+  #173-#175); **v1.5.0.0** (2026-07-26) the perf campaign + rebrand
+  (PR #155-#165) on console-validated MSIX 1.5.0.698.
 - Shipping artifact: unified ORT GenAI + llama.cpp, with pinned patched runtime
   DLLs while upstream fixes have not reached NuGet. The UWP ggml build now
   enables `GGML_USE_CPU_REPACK` (PR #155): **GGUF prefill +62%** on Q4_K.
@@ -28,8 +31,9 @@ performance belongs in `docs/benchmarks.md`.
 - Phases 1–11 are complete for product code: Phase 10 Lane B is `available`
   (host + console marker gates PASS; pin-blocked filter-widening remains);
   Phase 11 closed the headless↔UI gap (in-app personalize + LAN API parity,
-  #116/#118). Remaining open work: the Phase 13 CPU-prefill/KV-reuse campaign
-  (#168–#175), the #130 root-cause profile, and upstream vendor pin drops.
+  #116/#118). Phases 13 and 14 are complete and shipped. Remaining open work:
+  Phase 15 (make the 3B–4B class usable), the #130 root-cause profile, and
+  upstream vendor pin drops.
 
 ## Phase 7 — Peer-class model research
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,7 +120,7 @@ Spot-checked against code + evidence:
 | GPU allowlist `-v2` only                            | `dml_text_model_ok`                                       | OK                                                        |
 | NuGet 0.14.1 / 1.24.4 / DML 1.15.4                  | `packages.config`                                         | OK                                                        |
 | Decode table (94.9 / 37.9 / 18.4 / 74.8 / 44.4 / …) | `generate-benchmark-summary.py --check`                   | OK (2026-07-26: LFM post-#168 median, ORT CPU shipped-t6) |
-| Package identity `GianlucaMazza.xllama` (1.5.1.0)   | `uwp/AppxManifest.xml`; migration in `install-release.md` | OK (in-place from 1.5.0.0; breaking vs ≤1.4.x)            |
+| Package identity `GianlucaMazza.xllama` (1.5.2.0)   | `uwp/AppxManifest.xml`; migration in `install-release.md` | OK (in-place from 1.5.x; breaking vs ≤1.4.x)            |
 | One resident Session (GUI+API)                      | `include/xllama/session_hub.h`                            | OK (PR #161/#164)                                         |
 | H9 6/8 · 7/8 · 4/8 · 5/8                            | `phase7-h9.jsonl`                                         | OK                                                        |
 | Lane B peak_ws 1195 MB, wall 446 s                  | `phase10-console-devtrain-result.json`                    | OK                                                        |

--- a/docs/install-release.md
+++ b/docs/install-release.md
@@ -49,7 +49,7 @@ Notes:
 - **Upgrades within the same identity**: a higher version installs over the
   old one and **preserves** LocalState (models, settings, history). WDP
   refuses a same-version install with different contents.
-- **1.5.0.0 → 1.5.1.0 is a normal in-place update**: same identity, LocalState
+- **Any 1.5.x → 1.5.y is a normal in-place update**: same identity, LocalState
   (models, settings, history, KV snapshots) is preserved.
 - ⚠️ **Upgrading from ≤1.4.x to 1.5.x is NOT an in-place update.** 1.5.0.0
   changed the package identity (`VenereLabs.xllama` → `GianlucaMazza.xllama`):

--- a/docs/launch-copy.md
+++ b/docs/launch-copy.md
@@ -171,9 +171,10 @@ the answer. This is the part of the plan that cannot be delegated or rushed.
   conversation switch 551 → 19 prompt tokens (#170b); turn-2 KV reuse 15–16×.
 - **Build fixes**: repack 241.9 → 393.2 tok/s (#155); `n_threads_batch`
   390.7 → 438.1 at P=298 (#168).
-- **Scale**: ~17.5k lines of own C++ across 80 files, 155 host test cases, 6
-  console validation gates (`scripts/validate-console.sh`), 14 product releases
-  since 2026-05-19, current 1.5.1.0.
+- **Scale**: ~17.5k lines of own C++ across 80 files, 176 host test cases, 9
+  console validation gates (`scripts/validate-console.sh` — routing, settings,
+  gguf, longchat, kvsnap, coderpaste, thinkcut, genroom, taesd), 15 product releases
+  since 2026-05-19, current 1.5.2.0.
 - **Hardware limits**: ~6 usable cores (livelock at 7–8), GPU budget 3801 MB, no
   `mmap` / `dlopen`, 2 GB per-file ONNX ceiling (which does not apply to GGUF).
 - **Do not cite** the v1.2.0 demo video as current: it predates the performance

--- a/uwp/AppxManifest.store.xml
+++ b/uwp/AppxManifest.store.xml
@@ -22,7 +22,7 @@
   <Identity
     Name="GianlucaMazza.xllama"
     Publisher="CN=xllama-dev"
-    Version="1.5.1.0"
+    Version="1.5.2.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -15,7 +15,7 @@
   <Identity
     Name="GianlucaMazza.xllama"
     Publisher="CN=xllama-dev"
-    Version="1.5.1.0"
+    Version="1.5.2.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity


### PR DESCRIPTION
## What

Manifest **1.5.1.0 → 1.5.2.0** on both the dev and Store SKUs; `[Unreleased]` closed as `[1.5.2.0]`.

Content of the release, all already on `main`:
- **Phase 14** — the coding / chat / thinking tier (`qwen25-coder-0.5b|1.5b|3b`, `qwen3-1.7b`, `lfm25-1.2b-thinking`), catalogue `n_ctx` / `role`, and the thinking product path.
- **The exact context budget** (#193/#194) — enforced in tokens, once, where the tokenizer is. This is what made a 4096-token session safe to offer, and it fixed two user-visible defects: auto GPU routing was unreachable on a default install, and the LAN endpoint had no context budget at all.
- **Xbox Store SKU foundation** — compile-time opt-in; the Dev Mode package is unchanged.
- **The heap-ceiling probe** and the `lfm25-8b-a1b` H2 candidate.

## Two gaps this closes

Both from my own PR #198, neither recorded anywhere:

1. The heap-ceiling probe and the MoE catalogue entry were **absent from the changelog**. The entry carries a behaviour change with no record: `model_is_thinking` now also matches `a1b`, because that model reasons on every turn without saying so in its name. Without the predicate it would have leaked raw chain of thought into the UI and left KV snapshots enabled on a model whose stripped saved history can never prefix-match its own CoT-bearing cache.
2. `docs/launch-copy.md` claimed **6 console gates against the real 9** (`coderpaste`, `thinkcut`, `genroom` arrived with #193/#194) and **155 host test cases against 176**. The gates are now enumerated rather than counted, since a stats block nobody re-derives is one that lies.

## Verification

- Host suite **176/176** (1395 assertions)
- `check-coherence.py`: **39 OK, 0 WARN, 0 ERR**
- **Console validation of the built MSIX is the next gate and is not claimed here.** The tag and the GitHub release follow it, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)