### PR TITLE
fix: the bench guessed its quant label, its model, and its prompt

### DIFF
--- a/scripts/bench-xbox-ort.sh
+++ b/scripts/bench-xbox-ort.sh
@@ -430,6 +430,22 @@ for ((run = 1; run <= N_RUNS; run++)); do
 			echo "The installed MSIX is older than the CSV schema — redeploy before benchmarking." >&2
 			exit 1
 		fi
+		# Before anything else: did the device measure the model we ASKED for?
+		# model.txt reaches the console over WDP, and a WDP POST can report
+		# success while writing nothing (the missing-X-CSRF-Token failure mode
+		# documented in uwp-constraints). A build older than 1.5.2 answered a
+		# missing model.txt by silently benching smollm2-360m-cpu-int4, so a lost
+		# upload produced a genuine row for the wrong model, appended to the
+		# results file of the run that was requested. Current builds refuse and
+		# write no CSV; this check also covers the older ones, and any future way
+		# the two can drift apart.
+		got_model=$(awk -F, '{print $1}' <<<"$data_row")
+		if [[ "$got_model" != "$MODEL_NAME" ]]; then
+			echo "Error: the console benched '${got_model}', not the requested '${MODEL_NAME}'." >&2
+			echo "  model.txt likely never reached the device (WDP writes can fail silently)." >&2
+			echo "  Nothing was appended — re-run rather than trusting this row." >&2
+			exit 1
+		fi
 		# The CSV schema does NOT change with --max-length, so the arity check
 		# above cannot catch an MSIX that ignores bench_maxlen.txt — it would
 		# record DERIVED max_lengths under a "saturated" label and the whole

--- a/src/bridge/bench.cpp
+++ b/src/bridge/bench.cpp
@@ -29,14 +29,12 @@ const char* quant_token_in(const std::string& haystack_lower) {
     // "iq3_xs"). Getting that wrong silently truncates the label rather than
     // failing, which is how "UD-IQ3_S" would have been recorded as "IQ3_S".
     static constexpr const char* kTokens[] = {
-        "ud-iq1_m", "ud-iq1_s",  "ud-iq2_m", "ud-iq2_s", "ud-iq3_m", "ud-iq3_s",
-        "ud-iq4_xs", "ud-q2_k_xl", "ud-q3_k_m", "ud-q4_k_m",
-        "q3_k_xl",  "q3_k_l",    "q3_k_m",   "q3_k_s",   "q4_k_m",   "q4_k_s",
-        "q5_k_m",   "q5_k_s",    "q6_k",     "q8_0",
-        "iq1_m",    "iq1_s",     "iq2_xxs",  "iq2_xs",   "iq2_m",    "iq2_s",
-        "iq3_xxs",  "iq3_xs",    "iq3_m",    "iq3_s",
-        "iq4_xs",   "iq4_nl",    "q4_0",     "q5_0",     "q2_k",     "fp16",
-        "int4",
+        "ud-iq1_m",   "ud-iq1_s",  "ud-iq2_m",  "ud-iq2_s", "ud-iq3_m", "ud-iq3_s", "ud-iq4_xs",
+        "ud-q2_k_xl", "ud-q3_k_m", "ud-q4_k_m", "q3_k_xl",  "q3_k_l",   "q3_k_m",   "q3_k_s",
+        "q4_k_m",     "q4_k_s",    "q5_k_m",    "q5_k_s",   "q6_k",     "q8_0",     "iq1_m",
+        "iq1_s",      "iq2_xxs",   "iq2_xs",    "iq2_m",    "iq2_s",    "iq3_xxs",  "iq3_xs",
+        "iq3_m",      "iq3_s",     "iq4_xs",    "iq4_nl",   "q4_0",     "q5_0",     "q2_k",
+        "fp16",       "int4",
     };
     for (const char* tok : kTokens) {
         if (haystack_lower.find(tok) != std::string::npos)

--- a/src/bridge/bench.cpp
+++ b/src/bridge/bench.cpp
@@ -24,10 +24,19 @@ std::string to_lower_copy(std::string s) {
 // Extract a quant / EP label from a model path or GGUF filename.
 // Longer tokens first so Q3_K_XL wins over Q3_K_L / Q3, etc.
 const char* quant_token_in(const std::string& haystack_lower) {
+    // Order matters: the first match wins, so a longer label must precede the
+    // shorter one it contains ("ud-iq3_s" before "iq3_s", "iq3_xxs" before
+    // "iq3_xs"). Getting that wrong silently truncates the label rather than
+    // failing, which is how "UD-IQ3_S" would have been recorded as "IQ3_S".
     static constexpr const char* kTokens[] = {
-        "ud-iq2_m", "q3_k_xl", "q3_k_l", "q3_k_m", "q3_k_s", "q4_k_m", "q4_k_s",
-        "q5_k_m",   "q5_k_s",  "q6_k",   "q8_0",   "iq2_m",  "iq3_m",  "iq3_xs",
-        "iq4_xs",   "iq4_nl",  "q4_0",   "q5_0",   "q2_k",   "fp16",   "int4",
+        "ud-iq1_m", "ud-iq1_s",  "ud-iq2_m", "ud-iq2_s", "ud-iq3_m", "ud-iq3_s",
+        "ud-iq4_xs", "ud-q2_k_xl", "ud-q3_k_m", "ud-q4_k_m",
+        "q3_k_xl",  "q3_k_l",    "q3_k_m",   "q3_k_s",   "q4_k_m",   "q4_k_s",
+        "q5_k_m",   "q5_k_s",    "q6_k",     "q8_0",
+        "iq1_m",    "iq1_s",     "iq2_xxs",  "iq2_xs",   "iq2_m",    "iq2_s",
+        "iq3_xxs",  "iq3_xs",    "iq3_m",    "iq3_s",
+        "iq4_xs",   "iq4_nl",    "q4_0",     "q5_0",     "q2_k",     "fp16",
+        "int4",
     };
     for (const char* tok : kTokens) {
         if (haystack_lower.find(tok) != std::string::npos)
@@ -69,8 +78,14 @@ std::string detect_quant_label(const std::string& model_path, bool is_llama) {
     if (const char* t = quant_token_in(lower_path))
         return format_quant_label(t);
 
+    // No recognisable token. Say so, rather than guessing a plausible label: an
+    // invented "Q4_K_M" reads as measured fact in the CSV and cannot be told from
+    // a real one, while an explicit "unknown" is visible to both a reader and to
+    // benchmark-summary.json (which can override it with `quant_label`). This
+    // fallback silently mislabelled the first LFM2.5-8B-A1B run as Q4_K_M — a
+    // quant whose 5156 MB would not even fit the measured heap ceiling.
     if (is_llama)
-        return "Q4_K_M"; // legacy GGUF default
+        return "unknown";
     // ORT: dir-name convention smollm2-*-{cpu|dml}-{int4|fp16}
     if (lower_path.find("fp16") != std::string::npos)
         return "fp16";

--- a/tests/test_bench.cpp
+++ b/tests/test_bench.cpp
@@ -69,7 +69,9 @@ TEST_CASE("Bench CSV writer: basic output") {
     const std::vector<std::string> f = split_csv(row);
     REQUIRE(f.size() == split_csv(kExpectedHeader).size());
     CHECK(f[0] == "test-model");
-    CHECK(f[1] == "Q4_K_M");
+    // "test-model.gguf" carries no quant token, and an unrecognised quant is
+    // reported as such rather than guessed — see the quant test below.
+    CHECK(f[1] == "unknown");
     CHECK(f[2] == "cpu");
     CHECK(f[3] == "2048");
     CHECK(f[4] == "4");
@@ -126,7 +128,24 @@ TEST_CASE("Bench CSV writer: quant from GGUF filename") {
     CHECK(write_and_read_quant("Phi-3.5-mini-instruct-Q3_K_S.gguf") == "Q3_K_S");
     CHECK(write_and_read_quant("Llama-3.2-3B-Instruct-Q3_K_S.gguf") == "Q3_K_S");
     CHECK(write_and_read_quant("models/foo-Q4_K_M.gguf") == "Q4_K_M");
-    CHECK(write_and_read_quant("unknown-model.gguf") == "Q4_K_M"); // fallback
+
+    // i-quants, and the UD (unsloth dynamic) variants the catalogue actually
+    // uses. IQ3_S was missing, so LFM2.5-8B-A1B's first console run recorded
+    // "Q4_K_M" — a quant whose 5156 MB does not fit the measured heap ceiling,
+    // i.e. a label no reader could have believed but also could not have caught.
+    CHECK(write_and_read_quant("LFM2.5-8B-A1B-UD-IQ3_S.gguf") == "UD-IQ3_S");
+    CHECK(write_and_read_quant("foo-IQ3_S.gguf") == "IQ3_S");
+    CHECK(write_and_read_quant("foo-IQ2_XXS.gguf") == "IQ2_XXS");
+    CHECK(write_and_read_quant("foo-UD-Q2_K_XL.gguf") == "UD-Q2_K_XL");
+
+    // Longest-match-first: a shorter token that is a substring of the real one
+    // must not win, or the label is silently truncated.
+    CHECK(write_and_read_quant("foo-IQ3_XXS.gguf") == "IQ3_XXS");
+
+    // An unrecognised quant must NOT be guessed. A plausible invented label is
+    // indistinguishable from a measured one; "unknown" is visible to a reader
+    // and overridable via benchmark-summary.json's `quant_label`.
+    CHECK(write_and_read_quant("unknown-model.gguf") == "unknown");
 }
 
 TEST_CASE("Bench CSV writer: gpu memory columns") {

--- a/uwp/inference-bridge.cpp
+++ b/uwp/inference-bridge.cpp
@@ -135,23 +135,29 @@ void main_loop() {
     // ORT enable_profiling prefix) land in a writable, WDP-fetchable location.
     set_cwd_to_local_folder();
 
-    // Read prompt from LocalFolder/prompt.txt, fallback to default.
-    // SmolLM2-360M-Instruct uses ChatML format; bare text triggers EOS immediately.
+    // model.txt and prompt.txt are REQUIRED, and their absence aborts the run.
+    //
+    // Both used to fall back to a hardcoded default — smollm2-360m-cpu-int4 and a
+    // 58-character prompt. That turns a lost upload into a silent measurement of
+    // the wrong thing, and WDP POSTs are documented to fail silently in this
+    // project (a POST without X-CSRF-Token returns success and writes nothing).
+    // The result would be a real, plausible CSV row describing a run nobody asked
+    // for, appended to the results file of the run that was asked for. Same defect
+    // class as the invented quant label: a benchmark that guesses its own inputs
+    // produces evidence indistinguishable from the genuine kind.
+    //
     // read_local_file reads to EOF; the hand-rolled reader this replaced used a
     // fixed char buf[8192] and truncated silently at ~2k tokens — exactly the
-    // range a prompt-length sweep needs. The bench would then report a shorter
-    // prompt's throughput under the long prompt's label with nothing in the log.
-    std::string user_prompt = "Hello from Xbox Series S. Tell me about your architecture.";
-    {
-        std::string from_file = read_local_file("prompt.txt");
-        if (!from_file.empty()) {
-            user_prompt = std::move(from_file);
-            log_output("[xllama] bench: prompt.txt " + std::to_string(user_prompt.size()) +
-                       " bytes\n");
-        }
+    // range a prompt-length sweep needs.
+    std::string user_prompt = read_local_file("prompt.txt");
+    if (user_prompt.empty()) {
+        log_output("[xllama] bench: prompt.txt missing or empty — refusing to bench a prompt "
+                   "nobody asked for. Upload it and retry.\n");
+        return;
     }
-    // Read model directory/filename from LocalFolder/model.txt, fallback to default.
-    std::string model_name = "smollm2-360m-cpu-int4";
+    log_output("[xllama] bench: prompt.txt " + std::to_string(user_prompt.size()) + " bytes\n");
+
+    std::string model_name;
     {
         std::string model_cfg = resolve_local_path("model.txt");
         FILE* mf = _wfopen(utf8_to_wstring(model_cfg).c_str(), L"r");
@@ -167,6 +173,11 @@ void main_loop() {
                     model_name.pop_back();
             }
         }
+    }
+    if (model_name.empty()) {
+        log_output("[xllama] bench: model.txt missing or empty — refusing to pick a model. "
+                   "Upload it and retry.\n");
+        return;
     }
 
     // Optional numeric knobs from LocalState, written by the bench scripts.


### PR DESCRIPTION
Three defects of one class: **the benchmark supplied its own inputs and its own labels when it did not have them**, producing evidence indistinguishable from the genuine kind. `bench/results/*.csv` is this project's immutable evidence; evidence that guesses is worse than evidence that admits a gap.

## 1. The quant label was invented

`detect_quant_label` fell back to `"Q4_K_M"` for any unrecognised GGUF, and the token list had no `IQ3_S`. The first LFM2.5-8B-A1B console run therefore recorded its **UD-IQ3_S** measurement as **Q4_K_M** — a quant whose 5156 MB does not fit the measured 4864 MB heap ceiling. Not merely wrong: *impossible*, and invisible from the CSV.

- Unrecognised quants now report **`"unknown"`** — visible to a reader, overridable by `benchmark-summary.json`'s existing `quant_label`.
- The token list gains the i-quants and UD (unsloth dynamic) variants the catalogue uses, **ordered longest-first**: the lookup returns the first match, so `"iq3_s"` before `"ud-iq3_s"` would silently truncate the label rather than fail. Tests cover the ordering, not just the presence.
- A test was **codifying the defect** (`"unknown-model.gguf" == "Q4_K_M" // fallback`). Updated.

## 2. The model was guessed

A missing `model.txt` meant "bench `smollm2-360m-cpu-int4`". Both `model.txt` and `prompt.txt` reach the console over WDP, and a WDP POST is documented in this project to **report success while writing nothing** (the missing-`X-CSRF-Token` failure mode). A lost upload therefore produced a genuine, plausible row for a run nobody requested, appended to the results file of the run that was.

## 3. The prompt was guessed

A missing `prompt.txt` meant a hardcoded 58-character string — a throughput number under the wrong prompt's label.

Both are required now; their absence aborts with a log line naming the file.

## The check on the way back

`bench-xbox-ort.sh` now compares column 1 against the requested model before appending. The script already does exactly this for `--max-length` and `--ubatch`, with the same reasoning spelled out in its comments — the model was simply missing from that list, and it is the one field whose mismatch invalidates every other number in the row. This also covers MSIX builds older than this fix, which still substitute a default.

## Prior art in the same codebase

The LAN endpoint already got this right: `api-server.cpp:326` reads `model.txt` as a hint and returns `missing 'model' (and no LocalState\model.txt fallback)` when absent. The bench was the outlier, not the norm.

## Why the mislabelled CSV is not hand-corrected

The LFM2.5-8B-A1B row will be **re-measured on a build carrying this fix**. Editing evidence by hand to match what the code should have written is the debt this PR removes.

## Verification

Host suite **176/176** (1415 assertions). `check-coherence.py` 39 OK / 0 ERR. `shellcheck` clean. The UWP path is covered by the Windows CI build. No parser reads column 2 positionally (`bench-xbox-ort.sh` uses `$1`, `$3`, `$14`, `$15`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark validation to detect when the requested model was not received by the console.
  * Corrected quantization labels for model files, including more specific formats and unknown variants.
  * Prevented benchmark runs from proceeding when required prompt or model information is missing.
* **Tests**
  * Expanded coverage for quantization label detection and benchmark output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->