### PR TITLE
refactor: write the prefill and decode loops once

### DIFF
--- a/src/bridge/decode_loop.h
+++ b/src/bridge/decode_loop.h
@@ -1,0 +1,143 @@
+// Copyright (c) 2024 Gianluca Mazza
+// SPDX-License-Identifier: MIT
+// Internal: the llama.cpp prefill and generation loops, written in exactly one
+// place. Needs llama.h, so it stays out of the public include/ tree.
+#pragma once
+
+#include "llama.h"
+#include "xllama/chat_prompt.h" // apply_stop_sequences
+#include "xllama/platform.h"    // log_output
+
+#include <atomic>
+#include <cstdio>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace xllama {
+
+// Why this is shared rather than copied: run_inference (CLI, bench) and
+// LlamaSession (chat UI, LAN API) ran two hand-maintained copies of the same
+// prefill and generation loops, and the copies had already drifted.
+//
+//   * #193 — a prompt past the logical batch aborted the process, because
+//     llama_decode ASSERTS on an oversized batch instead of returning an error.
+//     The fix had to be written twice; inference.cpp still carried the comment
+//     "same fix as LlamaSession::generate" as evidence.
+//   * The stop-sequence token count diverged silently: run_inference counted the
+//     token that triggered the stop, LlamaSession did not, so n_eval — and the
+//     published decode_tok_s derived from it — differed by one between the two
+//     paths for the same generation.
+//
+// The project had already drawn this conclusion for sampling (#125/#141,
+// sampler_chain.h) and stop sequences (chat_prompt.h). This is the piece that
+// was left out.
+
+// Feed |n_tokens| tokens through the context, chunked at the model's logical
+// batch. Returns false if a chunk fails to decode; the caller owns what that
+// means for its cache, since the two callers answer that differently.
+//
+// The chunking is NOT optional: llama_decode does not return an error for a
+// batch larger than n_batch, it trips GGML_ASSERT(n_tokens_all <= n_batch) and
+// aborts — in Release too. n_batch defaults to min(n_ctx, 2048) while a 4096-token
+// coding session's trimmer ceiling is 3846, so a long paste used to kill the
+// process. This is the LOGICAL batch only; the physical ubatch stays at the #172
+// optimum of 512, which is what every published prefill rate was measured on.
+inline bool prefill_chunked(llama_context* ctx, const llama_token* tokens, int n_tokens) {
+    const int n_batch = std::max(1, static_cast<int>(llama_n_batch(ctx)));
+    for (int off = 0; off < n_tokens; off += n_batch) {
+        llama_batch batch = llama_batch_get_one(const_cast<llama_token*>(tokens) + off,
+                                                std::min(n_batch, n_tokens - off));
+        if (llama_decode(ctx, batch) != 0)
+            return false;
+    }
+    return true;
+}
+
+// The message for a prompt that cannot fit the context at all. Chunking makes an
+// oversized BATCH safe, not an oversized CONTEXT — without this the run would
+// fail somewhere inside the loop with a bare "decode failed".
+inline std::string prompt_too_long_message(int n_tokens, int n_ctx) {
+    return "prompt too long: " + std::to_string(n_tokens) +
+           " tokens exceed n_ctx=" + std::to_string(n_ctx);
+}
+
+struct DecodeLoopParams {
+    llama_context* ctx = nullptr;
+    llama_sampler* sampler = nullptr;
+    const llama_vocab* vocab = nullptr;
+    int n_predict = 0;
+    const std::vector<std::string>* stop_sequences = nullptr;
+    const std::atomic<bool>* abort_flag = nullptr;
+    // Streamed piece-by-piece to the caller (chat UI token stream, CLI echo).
+    std::function<void(std::string_view)> on_token;
+    // CLI only: mirror the stream to stdout as it decodes.
+    bool echo_stdout = false;
+    // Called after a token has been accepted into the cache. LlamaSession uses it
+    // to keep m_kv_tokens in step with the KV cells, which is what the #170a
+    // prefix diff and the #170b snapshot fingerprint both read.
+    std::function<void(llama_token)> on_accepted;
+};
+
+struct DecodeLoopResult {
+    int n_generated = 0;
+    bool ended_with_stop = false; // a textual stop sequence matched
+};
+
+// Generate up to |n_predict| tokens, appending decoded text to |output_text|.
+//
+// n_generated counts every token the model produced, INCLUDING the one that
+// triggered a stop sequence. That token was sampled and rendered — the cost is
+// real and t_eval contains it — so leaving it out understates decode_tok_s.
+// run_inference already counted it and LlamaSession did not; this unifies on the
+// counting version, which is why LlamaSession's figure moves by one token on a
+// stop-sequence finish.
+inline DecodeLoopResult decode_loop(const DecodeLoopParams& p, std::string& output_text) {
+    DecodeLoopResult out;
+    while (out.n_generated < p.n_predict) {
+        if (p.abort_flag && p.abort_flag->load())
+            break;
+
+        llama_token token = llama_sampler_sample(p.sampler, p.ctx, -1);
+        if (llama_vocab_is_eog(p.vocab, token)) {
+            log_output("[xllama] EOG after " + std::to_string(out.n_generated) + " tokens\n");
+            break;
+        }
+
+        char buf[256] = {};
+        const int len = llama_token_to_piece(p.vocab, token, buf, sizeof(buf) - 1, 0, false);
+        if (len > 0) {
+            buf[len] = '\0';
+            output_text += buf;
+            if (p.on_token)
+                p.on_token(std::string_view(buf, static_cast<size_t>(len)));
+            if (p.echo_stdout) {
+                std::fputs(buf, stdout);
+                std::fflush(stdout);
+            }
+        }
+
+        // Stop strings (e.g. Gemma's <end_of_turn>, not an EOG token in every
+        // GGUF): the shared suffix matcher trims the trailing match in place.
+        if (p.stop_sequences && apply_stop_sequences(output_text, *p.stop_sequences)) {
+            out.ended_with_stop = true;
+            ++out.n_generated;
+            log_output("[xllama] stop sequence after " + std::to_string(out.n_generated) +
+                       " tokens\n");
+            break;
+        }
+
+        llama_batch next = llama_batch_get_one(&token, 1);
+        if (llama_decode(p.ctx, next) != 0) {
+            log_output("[xllama] decode failed at token, stopping generation\n");
+            break;
+        }
+        if (p.on_accepted)
+            p.on_accepted(token);
+        ++out.n_generated;
+    }
+    return out;
+}
+
+} // namespace xllama

--- a/src/bridge/inference.cpp
+++ b/src/bridge/inference.cpp
@@ -403,6 +403,7 @@ InferenceResult run_inference_ort(const InferenceParams& params) {
 
     #include "llama.h"
 
+    #include "decode_loop.h"
     #include "sampler_chain.h" // shared sampler chain (#125); needs llama.h
     #include "xllama/llama_raii.h"
 
@@ -544,30 +545,19 @@ InferenceResult run_inference_llama(const InferenceParams& params) {
 
     log_output(("[xllama] prompt tokens: " + std::to_string(tokens.size()) + "\n").c_str());
     const auto t_prompt0 = std::chrono::steady_clock::now();
-    // Chunked at n_batch: an oversized logical batch is a GGML_ASSERT abort in
-    // llama_decode, not an error code (same fix as LlamaSession::generate).
-    // n_ubatch — the chunk the prefill rate was measured on (#172) — is untouched.
-    const int n_prompt_batch = std::max(1, static_cast<int>(llama_n_batch(ctx.get())));
+    // Prefill chunking and the context guard live in decode_loop.h — see there
+    // for why an oversized logical batch aborts rather than erroring.
     const int n_prompt_tokens = static_cast<int>(tokens.size());
-    // Chunking makes an oversized batch safe, not an oversized CONTEXT: a prompt
-    // past n_ctx would fail somewhere inside the loop with a bare "decode
-    // failed". Say what is actually wrong, before touching the cache — same
-    // message as LlamaSession::generate.
     const int n_ctx_active = static_cast<int>(llama_n_ctx(ctx.get()));
     if (n_prompt_tokens + 1 > n_ctx_active) {
-        res.error_msg = "prompt too long: " + std::to_string(n_prompt_tokens) +
-                        " tokens exceed n_ctx=" + std::to_string(n_ctx_active);
+        res.error_msg = prompt_too_long_message(n_prompt_tokens, n_ctx_active);
         log_output(("[xllama] " + res.error_msg + "\n").c_str());
         return res;
     }
-    for (int off = 0; off < n_prompt_tokens; off += n_prompt_batch) {
-        llama_batch batch = llama_batch_get_one(tokens.data() + off,
-                                                std::min(n_prompt_batch, n_prompt_tokens - off));
-        if (llama_decode(ctx.get(), batch) != 0) {
-            res.error_msg = "prompt decode failed";
-            log_output("[xllama] prompt decode failed\n");
-            return res;
-        }
+    if (!prefill_chunked(ctx.get(), tokens.data(), n_prompt_tokens)) {
+        res.error_msg = "prompt decode failed";
+        log_output("[xllama] prompt decode failed\n");
+        return res;
     }
     const double prompt_ms =
         std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_prompt0)
@@ -607,49 +597,19 @@ InferenceResult run_inference_llama(const InferenceParams& params) {
     // inside the builder.
     add_sampler_stages(sampler.get(), params.sampling());
 
-    int n_generated = 0;
     const auto t_gen0 = std::chrono::steady_clock::now();
-    while (n_generated < params.n_predict) {
-        if (params.abort_flag && params.abort_flag->load())
-            break;
-
-        llama_token token = llama_sampler_sample(sampler.get(), ctx.get(), -1);
-        if (llama_vocab_is_eog(vocab, token)) {
-            log_output(("[xllama] EOG after " + std::to_string(n_generated) + " tokens\n").c_str());
-            break;
-        }
-
-        char buf[256] = {};
-        int len = llama_token_to_piece(vocab, token, buf, sizeof(buf) - 1, 0, false);
-        if (len > 0) {
-            buf[len] = '\0';
-            res.output_text += buf;
-            if (params.on_token)
-                params.on_token(std::string_view(buf, static_cast<size_t>(len)));
-            if (params.echo_stdout) {
-                std::fputs(buf, stdout);
-                std::fflush(stdout);
-            }
-        }
-
-        // Stop strings (e.g. Gemma's <end_of_turn>, not an EOG token in every
-        // GGUF): shared suffix-match helper, trims the trailing match.
-        if (apply_stop_sequences(res.output_text, params.stop_sequences)) {
-            res.ended_with_stop = true;
-            log_output(
-                ("[xllama] stop sequence after " + std::to_string(n_generated + 1) + " tokens\n")
-                    .c_str());
-            ++n_generated;
-            break;
-        }
-
-        llama_batch next = llama_batch_get_one(&token, 1);
-        if (llama_decode(ctx.get(), next) != 0) {
-            log_output("[xllama] decode failed at token, stopping generation\n");
-            break;
-        }
-        ++n_generated;
-    }
+    DecodeLoopParams dlp;
+    dlp.ctx = ctx.get();
+    dlp.sampler = sampler.get();
+    dlp.vocab = vocab;
+    dlp.n_predict = params.n_predict;
+    dlp.stop_sequences = &params.stop_sequences;
+    dlp.abort_flag = params.abort_flag;
+    dlp.on_token = params.on_token;
+    dlp.echo_stdout = params.echo_stdout;
+    const DecodeLoopResult dlr = decode_loop(dlp, res.output_text);
+    const int n_generated = dlr.n_generated;
+    res.ended_with_stop = dlr.ended_with_stop;
 
     if (params.echo_stdout)
         std::fputc('\n', stdout);

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -458,6 +458,7 @@ std::unique_ptr<Session> create_ort(const SessionParams& sp, std::string* err) {
 
     #include "llama.h"
 
+    #include "decode_loop.h"   // shared prefill + generation loops; needs llama.h
     #include "sampler_chain.h" // shared sampler chain (#125); needs llama.h
     #include "xllama/llama_raii.h"
 
@@ -755,20 +756,16 @@ class LlamaSession final : public Session {
         // LOGICAL batch only — the physical ubatch stays 512 (#172 optimum),
         // which is what the prefill rate was measured on.
         const auto t_prefill0 = std::chrono::steady_clock::now();
-        const int n_batch = std::max(1, static_cast<int>(llama_n_batch(ctx)));
-        for (int off = 0; off < n_pf; off += n_batch) {
-            llama_batch batch = llama_batch_get_one(pf + off, std::min(n_batch, n_pf - off));
-            if (llama_decode(ctx, batch) != 0) {
-                res.error_msg = "prompt decode failed";
-                log_output("[xllama] session generate: prompt decode failed\n");
-                // The cache now holds a partial batch — nothing about it is
-                // trustworthy, so drop the record AND the cells. Clearing both
-                // keeps a continuation turn (which reads the cache length, not
-                // m_kv_tokens) from decoding on top of half a prefill.
-                m_kv_tokens.clear();
-                llama_memory_clear(mem, true);
-                return res;
-            }
+        if (!prefill_chunked(ctx, pf, n_pf)) {
+            res.error_msg = "prompt decode failed";
+            log_output("[xllama] session generate: prompt decode failed\n");
+            // The cache now holds a partial batch — nothing about it is
+            // trustworthy, so drop the record AND the cells. Clearing both keeps
+            // a continuation turn (which reads the cache length, not
+            // m_kv_tokens) from decoding on top of half a prefill.
+            m_kv_tokens.clear();
+            llama_memory_clear(mem, true);
+            return res;
         }
         res.t_p_eval_ms =
             std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_prefill0)
@@ -795,8 +792,6 @@ class LlamaSession final : public Session {
         }
         llama_sampler* sampler_chain = m_sampler.get();
 
-        int n_generated = 0;
-        bool stopped_by_seq = false;
         const auto t_decode0 = std::chrono::steady_clock::now();
 
         // Clean stop at the context end (#173): each generated token needs a KV
@@ -804,37 +799,22 @@ class LlamaSession final : public Session {
         // at 0 — an oversized full prompt yields a clean zero-token result.
         const int n_predict_eff = std::max(0, std::min(gp.n_predict, m_n_ctx - kv_len - n_pf));
 
-        while (n_generated < n_predict_eff) {
-            if (gp.abort_flag && gp.abort_flag->load())
-                break;
-
-            llama_token token = llama_sampler_sample(sampler_chain, ctx, -1);
-            if (llama_vocab_is_eog(vocab, token))
-                break;
-
-            char buf[256] = {};
-            int len = llama_token_to_piece(vocab, token, buf, sizeof(buf) - 1, 0, false);
-            if (len > 0) {
-                buf[len] = '\0';
-                res.output_text += buf;
-                if (gp.on_token)
-                    gp.on_token(std::string_view(buf, static_cast<size_t>(len)));
-            }
-
-            // Stop sequences (shared suffix-match helper).
-            if (apply_stop_sequences(res.output_text, gp.stop_sequences)) {
-                stopped_by_seq = true;
-                break;
-            }
-
-            llama_batch next = llama_batch_get_one(&token, 1);
-            if (llama_decode(ctx, next) != 0) {
-                log_output("[xllama] session generate: decode failed, stopping\n");
-                break;
-            }
-            m_kv_tokens.push_back(token); // resident as of this decode (#170a)
-            ++n_generated;
-        }
+        // The loop itself lives in decode_loop.h, shared with run_inference —
+        // see there for why. What stays here is what is genuinely this session's:
+        // keeping m_kv_tokens in step with the KV cells, which the #170a prefix
+        // diff and the #170b snapshot fingerprint both read.
+        DecodeLoopParams dlp;
+        dlp.ctx = ctx;
+        dlp.sampler = sampler_chain;
+        dlp.vocab = vocab;
+        dlp.n_predict = n_predict_eff;
+        dlp.stop_sequences = &gp.stop_sequences;
+        dlp.abort_flag = gp.abort_flag;
+        dlp.on_token = gp.on_token;
+        dlp.on_accepted = [this](llama_token t) { m_kv_tokens.push_back(t); };
+        const DecodeLoopResult dlr = decode_loop(dlp, res.output_text);
+        const int n_generated = dlr.n_generated;
+        const bool stopped_by_seq = dlr.ended_with_stop;
 
         res.t_eval_ms =
             std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_decode0)


### PR DESCRIPTION
## The duplication had already cost, twice

`run_inference_llama` and `LlamaSession::generate` each carried a hand-maintained copy of the same two loops — chunking at `n_batch`, the prompt-too-long guard, the sample/render/stop/decode cycle.

1. **#193 had to be fixed twice.** A prompt past the logical batch aborted the process (`llama_decode` asserts rather than erroring). `inference.cpp` still carried *"same fix as LlamaSession::generate"* and *"same message as LlamaSession::generate"* as comments — the duplication documenting its own cost.
2. **The stop-sequence token count had diverged silently.** `run_inference` counted the token that triggered the stop; `LlamaSession` did not. So `n_eval` — and the published `decode_tok_s` derived from it — **differed by one between the two paths for the same generation**. Not findable by reading either file alone.

## The change

`src/bridge/decode_loop.h` holds `prefill_chunked()`, `prompt_too_long_message()` and `decode_loop()`. Callers keep what is genuinely theirs: `LlamaSession` the #170a prefix diff, the #169 context shift and `m_kv_tokens` (via an `on_accepted` callback, so the record stays in step with the KV cells that #170a and the #170b fingerprint read); `run_inference` its context lifetime and stdout echo.

**Not a new pattern** — the project already reached this conclusion for sampling (#125/#141, `sampler_chain.h`) and stop sequences (`chat_prompt.h`). The prefill and decode loops were the piece left out.

## One deliberate behaviour change

The divergence had to be resolved, not preserved. `n_generated` now counts the stop-triggering token in **both** paths: it was sampled and rendered, `t_eval` contains its cost, so omitting it understates `decode_tok_s`. `LlamaSession`'s figure moves by one token on a stop-sequence finish. Called out here because a refactor should not change behaviour silently.

## Verification, in the order that matters

- **Host suite 176/176 with no test changes.** A refactor that needs a test edited is a behaviour change wearing a costume.
- **The opt-in CLI-vs-Session parity test passes** against a real GGUF (`test_sampling.cpp`) — the test that actually exercises both rewritten paths and asserts they agree.
- **Logit parity is numerically identical across the change**: same GGUF, same prompt, `max_abs_diff=0.719607 nmse=0.00164253` **both before and after**, bit-for-bit. Measured by stashing the change, rebuilding and re-running. (Those figures fail the 1e-6 gate because the local GGUF is a different quantization from the one that produced the committed golden — the point is that the two runs agree *with each other*, which isolates the refactor from the model mismatch.)

**−107 lines, +47.**

## Why now

Phase 15 W2 adds prompt-lookup speculative decoding into exactly this loop. Doing it before this refactor meant either implementing it twice or leaving the CLI without it — and the CLI is the path the project measures and A/Bs on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of long prompts to prevent oversized-batch failures.
  * Added clearer feedback when prompts exceed the available context.
  * Improved recovery after prompt decoding failures by clearing stale session state.
  * Standardized token generation and stop-sequence handling for more consistent output across inference modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->