### PR TITLE
docs: bring Phase 15 and the architecture doc up to what was measured

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,6 +34,10 @@ performance belongs in `docs/benchmarks.md`.
   #116/#118). Phases 13 and 14 are complete and shipped. Remaining open work:
   Phase 15 (make the 3B–4B class usable), the #130 root-cause profile, and
   upstream vendor pin drops.
+- **Unreleased since v1.5.2.0** (`CHANGELOG.md` `[Unreleased]`): the shared
+  prefill/decode loop and the bench input/label fixes. Both are console-validated
+  on MSIX **1.5.2.802** (8/8 gates) but carry no user-visible feature, so they
+  ride the next release rather than justifying one.
 
 ## Phase 7 — Peer-class model research
 
@@ -389,15 +393,24 @@ and Coder-3B lands at 14.0 tok/s. Three levers touch that denominator; a
 rewritten framework or a bespoke model architecture touch neither, and both are
 rejected on that ground (`docs/phase7-hypotheses.md`, "Do not reopen").
 
-- [~] **W1 — H2: a MoE whose active weights are a fraction of its total.**
-  Desk survey done 2026-07-29 against pin `b10093-1-g6d5a910c5`
-  (`src/models/*.cpp` already compiles `lfm2moe.cpp` and ~20 more MoE archs).
-  Candidate **LFM2.5-8B-A1B**, 32 experts / 4 active. Admissibility hung on a
-  never-measured number, so the **console heap ceiling was measured**:
-  **4864 MB committed / 4893 MB peak WS** (`ramceil.flag`,
-  `scripts/bench-ramceil.sh`, `bench/results/phase15-ramceil.csv`) — a lower
-  bound, and headless. That admits `UD-IQ3_S` inside the 4 GB H2 gate, so the
-  experiment tests the architecture rather than the quantization.
+**Where it stands (2026-07-30).** W1 is **closed FAIL on measure** — the MoE
+reads only its active experts, exactly as predicted, and is still no faster than
+a dense 3B because the cost moves off bandwidth. W2's pre-gate **split the
+hypothesis**: the draft-model variant is rejected (0.81× on open chat), prompt
+lookup proceeds; its groundwork (one shared decode loop) is done. W3 is
+untouched. Two of the three levers are therefore measured before any of them
+was built on — which was the point of ordering them this way.
+
+- [x] **W1 — H2: a MoE whose active weights are a fraction of its total. CLOSED
+      FAIL 2026-07-30.**
+      Desk survey done 2026-07-29 against pin `b10093-1-g6d5a910c5`
+      (`src/models/*.cpp` already compiles `lfm2moe.cpp` and ~20 more MoE archs).
+      Candidate **LFM2.5-8B-A1B**, 32 experts / 4 active. Admissibility hung on a
+      never-measured number, so the **console heap ceiling was measured**:
+      **4864 MB committed / 4893 MB peak WS** (`ramceil.flag`,
+      `scripts/bench-ramceil.sh`, `bench/results/phase15-ramceil.csv`) — a lower
+      bound, and headless. That admits `UD-IQ3_S` inside the 4 GB H2 gate, so the
+      experiment tests the architecture rather than the quantization.
 
   **Measured 2026-07-30 on MSIX 1.5.2.798 → H2 FAIL**
   (`bench/results/phase15-moe-console.csv`, 3 recorded runs): decode
@@ -452,6 +465,16 @@ rejected on that ground (`docs/phase7-hypotheses.md`, "Do not reopen").
       DXGI and D3D12 both work in AppContainer and DXIL compiles AOT, so the JIT
       ban does not bite. **Kill criterion, predeclared: under 100 GB/s STREAM
       read the hypothesis dies and goes to "Do not reopen".**
+- [x] **Groundwork W2 needs: the prefill and decode loops written once**
+      (2026-07-30, `src/bridge/decode_loop.h`). `run_inference_llama` and
+      `LlamaSession::generate` kept hand-maintained copies that had already
+      drifted twice — #193 fixed in both, and a stop-sequence token count that
+      made `n_eval` (and the published `decode_tok_s`) differ by one between the
+      paths. W2 adds prompt lookup inside exactly that loop, so doing it first is
+      what makes W2 a change in one place instead of two, and what gives the CLI
+      the same behaviour as the chat UI — the CLI being the surface this project
+      measures and A/Bs on. −107 lines; host suite unchanged, all 8 console gates
+      PASS on MSIX 1.5.2.802.
 
 ## Xbox Store retail (public release path)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,7 +49,9 @@ Header modules (`include/xllama/`), all WinRT-free so they are host-testable:
 
 Bridge sources of note under `src/bridge/`: `session.cpp`, `inference.cpp`,
 `training.cpp`, `device_train.cpp`, `personalize.cpp`, `preference_capture.cpp`,
-`sampler_chain.h` / `ort_sampling.h` (one sampler chain per backend).
+`sampler_chain.h` / `ort_sampling.h` (one sampler chain per backend),
+`decode_loop.h` (one prefill and one generation loop, shared by
+`run_inference_llama` and `LlamaSession::generate`).
 
 ## Inference backends and runtime dispatch
 
@@ -178,6 +180,22 @@ the ORT params stayed hand-duplicated across `run_inference_ort` and
 builder too. Now neither backend's two surfaces (CLI/bench vs GUI/API) can diverge
 by construction.
 
+The **prefill and generation loops** followed the same route, later and for the
+same reason (`src/bridge/decode_loop.h`: `prefill_chunked`,
+`prompt_too_long_message`, `decode_loop`). `run_inference_llama` and
+`LlamaSession::generate` kept hand-maintained copies until 2026-07-30, and the
+copies had drifted twice over: #193 — a prompt past the logical batch aborting the
+process — had to be fixed in both, and the stop-sequence token count differed, so
+`n_eval` and the `decode_tok_s` derived from it disagreed by one between the two
+paths for the same generation. Each caller keeps only what is genuinely its own:
+`LlamaSession` the #170a prefix diff, the #169 context shift and `m_kv_tokens`
+(fed by an `on_accepted` callback so the record stays in step with the KV cells);
+`run_inference` its context lifetime and the CLI's stdout echo.
+
+**The rule these three share**: a decision that both surfaces must make the same
+way lives in exactly one header. Copying it is not a style question — every copy
+in this codebase has eventually disagreed with the other, and always silently.
+
 ## Model catalogue, provisioning, and quant auto-upgrade
 
 The catalogue is `uwp/models/manifest.json` (bundled base) merged with an optional
@@ -225,7 +243,7 @@ So the estimate keeps exactly one job: **routing**. `decide_routing` needs a tok
 count before a model — hence a tokenizer — has been chosen, and its ceiling has to
 stay coherent with `token_threshold` (#133). `BuildPromptPlan` therefore trims by
 `max_prompt_tokens_for_n_ctx(n_ctx)` with the optimistic `kEstimatedCharsPerToken`,
-and being optimistic is the point: it drops *fewer* turns, so the exact pass can
+and being optimistic is the point: it drops _fewer_ turns, so the exact pass can
 only tighten and nothing routing saw reappears behind its back. Getting that
 estimate wrong costs a routing decision, not an answer.
 
@@ -235,7 +253,7 @@ context keeping the historical `kMaxPromptTokens` (1800) so the #171 pin cannot
 drift by arithmetic. It is a **context** bound and takes no `n_predict`: the
 reply's room belongs to `fit_prompt`, exactly and later. Charging the reply's
 reserve to this ceiling is not a shortcut, it is a feature killer — at the shipping
-`n_predict` of 512 the ceiling becomes 1536, *below* `token_threshold` (1550), so
+`n_predict` of 512 the ceiling becomes 1536, _below_ `token_threshold` (1550), so
 `decide_routing` can never see a long turn and auto GPU routing dies on every
 default install. That is #133 a third time; `tests/test_routing_policy.cpp` now
 pins the reachability in real tokens, and the `routing` console gate runs at the
@@ -246,7 +264,7 @@ turn worker, and `POST /v1/chat/completions` before it generates (a client whose
 final message alone cannot fit gets a `400`, not a `500` from the generator).
 
 **Known gap, tracked.** The routing decision itself still runs on the UI thread
-*before* a session exists, so on a cold first turn with `routing = auto` it counts
+_before_ a session exists, so on a cold first turn with `routing = auto` it counts
 with the estimate rather than a tokenizer — a heuristic deciding behaviour, which
 the rule above forbids. It affects only that mode (the shipping default is
 CPU-only) and the fix is mechanical: decide in the turn worker, after
@@ -434,8 +452,8 @@ host Release smoke (quality + peak)
 - **Do not** special-case Settings when a catalogue field already owns the
   policy (`n_ctx`, `role`).
 - **Do not** let a heuristic decide product behaviour. A chars-per-token estimate
-  may *bound work* (what the UI renders, what routing counts before a tokenizer
-  exists); only an exact measurement may *decide* what the user gets. Every #133
+  may _bound work_ (what the UI renders, what routing counts before a tokenizer
+  exists); only an exact measurement may _decide_ what the user gets. Every #133
   recurrence — three so far — was an estimate promoted from bound to decision.
 - **Do not** restate a number a generated file already owns unless a gate checks
   the copies agree. `check-coherence.py` now pins the `model-matrix.md` metrics


### PR DESCRIPTION
## ROADMAP

- **W1 was still `[~]`** after being closed FAIL on measure.
- **Phase 15 gains a "where it stands" paragraph.** A phase with three workstreams and no summary makes the reader reconstruct the state from three bullets. Two of the three levers are now measured before any of them was built on — which was the point of ordering them that way.
- **The shared decode loop is recorded as a Phase 15 item**, not an incidental cleanup. It is groundwork W2 needs, and the reason it came first belongs next to W2 rather than only in a merge commit.
- **Current product state** notes that there *is* unreleased work after v1.5.2.0 and why it does not justify a release on its own. Without that line the section reads as if `main` and the last tag were the same thing.

## architecture.md

`decode_loop.h` was missing from the bridge sources list, and the sampling section — the one that explains *why* one code path per decision — had no mention of the loops that followed the same route for the same reason.

Both now carry the rule the three of them share:

> A decision that both surfaces must make the same way lives in exactly one header. Copying it is not a style question — every copy in this codebase has eventually disagreed with the other, and always silently.

That is not editorialising: sampling drifted on the greedy guard (#125/#141), the prefill loop drifted on #193, and the decode loop drifted on the stop-sequence token count. Three for three.

## Verification

Docs only. `check-coherence.py`: 39 OK, 0 WARN, 0 ERR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)