### PR TITLE
docs: the project description said ORT only, and Phase 15 had no issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xllama
 
-> Local LLM chat + Stable-Diffusion image generation on Xbox Series S|X (UWP Dev Mode) — ONNX Runtime GenAI + DirectML.
+> Local LLM chat + Stable-Diffusion image generation on Xbox Series S|X (UWP Dev Mode) — llama.cpp (GGUF) + ONNX Runtime GenAI, CPU and DirectML.
 
 [![build-uwp](https://github.com/gianlucamazza/xllama/actions/workflows/build-uwp.yml/badge.svg)](https://github.com/gianlucamazza/xllama/actions/workflows/build-uwp.yml)
 [![build-linux](https://github.com/gianlucamazza/xllama/actions/workflows/build-linux.yml/badge.svg)](https://github.com/gianlucamazza/xllama/actions/workflows/build-linux.yml)
@@ -275,9 +275,9 @@ numbers:** [docs/benchmarks.md](./docs/benchmarks.md) only.
 | ------------------------------------ | --------------------------------------------------- |
 | Default chat (unified)               | `lfm25-350m`                                        |
 | Balanced / quality chat              | `lfm25-1.2b-instruct`, `lfm2-2.6b`                  |
-| Coding chat (GGUF · n_ctx 4096)      | `qwen25-coder-0.5b` / `1.5b` / `3b`                  |
-| Chat upgrade (Qwen3)                 | `qwen3-1.7b`                                         |
-| Reasoning (think stripped for UI)    | `lfm25-1.2b-thinking`                                |
+| Coding chat (GGUF · n_ctx 4096)      | `qwen25-coder-0.5b` / `1.5b` / `3b`                 |
+| Chat upgrade (Qwen3)                 | `qwen3-1.7b`                                        |
+| Reasoning (think stripped for UI)    | `lfm25-1.2b-thinking`                               |
 | ORT CPU / DML routing base           | `smollm2-360m-cpu-int4`, `smollm2-360m-dml-fp16-v2` |
 | Image gen                            | `sd-turbo-fp16`                                     |
 | Personalized (after on-device train) | `personalized` (LocalState override)                |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -426,7 +426,7 @@ was built on — which was the point of ordering them this way.
   with the result attached and enters no product tier; the 3.5 GB product-gate
   question a speed PASS would have opened is moot.
 
-- [~] **W2 — H3: speculative decoding.** Both halves of the pair already ship and
+- [~] **W2 — H3: speculative decoding (#210).** Both halves of the pair already ship and
   are console-PASS: draft `qwen25-coder-0.5b` (379 MB, 62.4 tok/s), target
   `qwen25-coder-3b` (1840 MB, 14.0). **Vocab precondition measured and
   PASSED 2026-07-29** (`bench/results/phase15-spec-vocab.csv`): the pin's
@@ -458,7 +458,7 @@ was built on — which was the point of ordering them this way.
   peak < 3.5 GB; `longchat` and `kvsnap` are the real regression tests, since
   the draft touches the KV.
 
-- [ ] **W3 — H6 gate: does our own compute shader beat DirectML?** Not a backend
+- [ ] **W3 — H6 gate: does our own compute shader beat DirectML? (#211)** Not a backend
       — a measurement. Every negative GPU result on record is a DirectML result,
       and DirectML provably has no fused low-bit GEMM (`DML_DEQUANTIZE` + full
       `DML_GEMM` materializes fp16 and reads _more_ bandwidth than fp16 itself).


### PR DESCRIPTION
## The description was out of date about the main code path

The README tagline and the GitHub repo description both read *"ONNX Runtime GenAI + DirectML"*. True when written; not now. **llama.cpp serves every GGUF in the catalogue** — every model in the balanced, quality, coding and thinking tiers, and the shipping default.

Someone deciding whether this project is relevant to them was being told the wrong thing about the path most of it runs on. Both now name both backends. Repo topics gained `llama-cpp`, `gguf`, `directml`, `game-console`.

## Phase 15 had no issues

Phase 13 tracked its eight items as #168-#175. Phase 15 tracked nothing, so the two remaining workstreams existed only in the ROADMAP prose. They now have one issue each, carrying the constraints **already measured** so nobody re-derives them:

**#210 (W2, prompt lookup)** — the pre-gate table, `k=2` as the setting rather than a starting point, dense-models-only because hybrid caches refuse the tail rewind the rollback needs (and refuse it *without mutating*, which is the PR #183 bug), no `common/` on the console target, and the five implementation steps. Plus one measurement the plan did not have: **that the shipping default, which cannot use the feature, is unchanged** — the most likely regression of all.

**#211 (W3, GPU gate)** — the 100 GB/s kill criterion declared before measuring, the preconditions already demonstrated (DXGI and D3D12 both work in AppContainer, AOT DXIL means the JIT ban does not bite, never the Agility factory), and the constraint that with no PIX and no debug layer the spike must be verifiable **by numeric result** — a checksum of the buffer read — not by inspection. A GPU probe that cannot prove it read what it claims is not evidence.

## Verification

Docs and repo metadata only. `check-coherence.py`: 39 OK, 0 WARN, 0 ERR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project description to mention the llama.cpp (GGUF) pathway alongside ONNX Runtime GenAI.
  * Clarified support for CPU and DirectML execution.
  * Refined model listings for coding chat, chat upgrades, and reasoning capabilities.
  * Added issue references to two in-progress roadmap items covering speculative decoding and compute shader performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->