### PR TITLE
fix: the demo link check compared versions but not the file

### DIFF
--- a/scripts/check-coherence.py
+++ b/scripts/check-coherence.py
@@ -174,7 +174,21 @@ def main() -> int:
                     "was never run"
                 )
             else:
-                good(f"README demo link matches the captured demo (v{dm_short})")
+                # ...and the link must point at the file the capture produced,
+                # not merely at a matching version. Nearly shipped: the README
+                # was updated, the version agreed, and the URL pointed at an
+                # asset that had never been uploaded — a 404 on the front page.
+                # Whether the asset EXISTS is a network fact this check cannot
+                # know by design (it runs offline); that the filename agrees is
+                # the half that can be checked here.
+                dm_file = str(dm.get("file", ""))
+                if dm_file and dm_file not in readme_text:
+                    err(
+                        f"README demo link does not reference {dm_file}, the file "
+                        "the capture produced"
+                    )
+                else:
+                    good(f"README demo link matches the captured demo (v{dm_short})")
                 cur = [int(x) for x in ver.group(1).split(".")]
                 got = [int(x) for x in dm_short.split(".")]
                 # Distance in minors, treating a major bump as far behind.


### PR DESCRIPTION
Found by nearly shipping the failure it now catches.

After #215 merged, the README's demo link pointed at `xllama-demo-v1.5.2.mp4` on the v1.5.2.0 release — an asset that had **never been uploaded**. The version matched `demo-manifest.json`, so `check-coherence.py` reported OK while the front page carried a 404. I had replaced a stale link with a broken one.

The check now also asserts the README references the filename the capture produced.

**What it still cannot know, stated where the check is:** whether the asset exists on the release is a network fact, and this script runs offline against the repo tree alone by design (its docstring: *"Safe to run without a console. Requires nothing beyond the repo tree"*). Making it fetch would trade that property for a CI dependency on github.com. So the limit is documented rather than papered over — a green run is not proof the link resolves.

Proved to fail by pointing the link at a different filename.

Separately, the asset is now uploaded and verified by **downloading it**: 593,546 bytes, byte-identical to the local file. Worth recording why that mattered — a `curl -I` HEAD check reported `bytes=0` and would have "passed" without proving anything about the content, the same shape as WDP answering 200 with an empty item list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)