### PR TITLE
deps: record why dependabot #29 (torch jit.script) does not move the pin

### DIFF
--- a/diffusion/requirements.txt
+++ b/diffusion/requirements.txt
@@ -18,7 +18,14 @@
 # torch >= 2.6 and Trainer is unused); Dependabot alert #28 / LightGlue RCE
 # (transformers < 5.5.0) — LightGlue model path is unused (SD-Turbo export only),
 # and optimum-onnx 0.1.0 still caps transformers < 4.58 so a 5.5 bump is blocked
-# until the export stack allows it. Offline, host-only toolchain fed only
+# until the export stack allows it. Dependabot alert #29 / torch `torch.jit.script`
+# memory corruption (<= 2.12.1, fixed 2.13.0) — `torch.jit.script` is called
+# nowhere in this repo, and the legacy exporter this pin exists for reaches
+# TorchScript through `torch.jit.trace` under `torch.onnx.export`, not the
+# scripting front-end; the bump is four minors past the version optimum-onnx
+# 0.1.0 special-cases, so taking it means moving the whole set to the dynamo
+# path (see the NOTE above), not editing one line.
+# Offline, host-only toolchain fed only
 # first-party checkpoints (stabilityai/sd-turbo). Not shipped in the MSIX.
 torch==2.9.1              # legacy torch.onnx tracer via optimum-onnx dynamo=False; --extra-index-url .../whl/cpu
 optimum-onnx[onnxruntime]==0.1.0


### PR DESCRIPTION
Dependabot alert **#29** — `torch.jit.script` memory corruption, `<= 2.12.1`, fixed in **2.13.0**, severity **low**. We pin `torch==2.9.1`.

## Why the pin does not move

- **`torch.jit.script` is called nowhere in this repo.** The reason the pin sits on the legacy TorchScript exporter is `torch.onnx.export`, which reaches TorchScript through `torch.jit.trace` — not the scripting front-end the advisory describes.
- **The toolchain is host-only and offline**, fed a single first-party checkpoint (`stabilityai/sd-turbo`). Nothing from it ships in the MSIX.
- **2.13.0 is four minors past the 2.9 line** that `optimum-onnx 0.1.0` special-cases and release-tests. Taking it is not a one-line edit: it means moving the whole coherent set onto the dynamo export path, which the file's existing NOTE already flags as the next bump's shape. That export produces the SD-Turbo assets the console gates measure, so doing it under a low-severity advisory that does not apply would trade a non-risk for a real one.

## What this PR does

Adds the residual to the `SECURITY NOTE` block in `diffusion/requirements.txt`, where alert #28 and three other non-applicable advisories are already recorded. **The alert is left open, not dismissed** — the next person should see the advisory and the reason side by side, and a dismissal hides one of them.

Docs only; no dependency change, no behaviour change.