### PR TITLE
docs: five of nine console gates had no written contract, and launch-copy published a stale test count

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -67,6 +67,28 @@ jobs:
       - name: Run unit tests
         run: ctest --test-dir build/linux-test --output-on-failure
 
+      # docs/launch-copy.md publishes the suite size as a citable fact, and it
+      # had drifted 16 cases behind before anyone noticed. It cannot live in
+      # check-coherence.py, which is offline and static: `grep -c TEST_CASE`
+      # returns 199 against the binary's 192 because seven cases sit behind #if,
+      # so a static count would be confidently wrong. Here the suite has just
+      # been built, so the real numbers are one command away.
+      - name: Verify the published test-suite size
+        run: |
+          out=$(./build/linux-test/tests/xllama-tests | tail -3)
+          cases=$(sed -n 's/.*test cases: *\([0-9]*\) .*/\1/p' <<<"$out")
+          asserts=$(sed -n 's/.*assertions: *\([0-9]*\) .*/\1/p' <<<"$out")
+          [ -n "$cases" ] && [ -n "$asserts" ] || {
+            echo "could not parse doctest output:"; echo "$out"; exit 1; }
+          claim="**${cases} host test cases / ${asserts} assertions**"
+          grep -qF "$claim" docs/launch-copy.md || {
+            echo "docs/launch-copy.md does not claim '${claim}'."
+            echo "The suite reports ${cases} cases / ${asserts} assertions — update the"
+            echo "Scale bullet in docs/launch-copy.md to match."
+            grep -n 'host test cases' docs/launch-copy.md || true
+            exit 1; }
+          echo "launch-copy.md matches the suite: ${cases} cases / ${asserts} assertions"
+
       - name: Smoke test
         run: ./build/linux-test/bin/xllama-cli --help
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ xllama/
 │   ├── deploy.sh                      # Device Portal: deploy, logs, bench trigger
 │   ├── build-uwp.ps1                  # Windows UWP packaging script
 │   ├── bench-xbox-ort.sh              # benchmark runner (run_index, multi-run)
-│   ├── validate-console.sh            # autopilot: routing / settings / GGUF / TAESD
+│   ├── validate-console.sh            # autopilot: the 9 console gates (docs/console-validation-runbook.md)
 │   ├── validate-console-training.sh   # rate / serve / device-train
 │   ├── validate-api.sh                # LAN: spike|chat|prefs|train|all
 │   ├── generate-benchmark-summary.py  # raw results → docs table + dashboard
@@ -72,6 +72,9 @@ xllama/
 │   └── …
 ├── tests/                   # Unit tests (doctest; incl. test_personalize)
 ├── bench/                   # configs, raw results, summary policy
+├── demo/                    # demo-script.json — what the capture records, reviewable in a PR
+├── diffusion/               # SD-Turbo → ONNX host toolchain (not shipped in the MSIX)
+├── patches/                 # AppContainer / runtime patches applied at build time
 ├── cmake/
 └── .github/workflows/       # build-linux.yml + build-uwp.yml
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,54 @@ prompt, label}` it finds, and `name` precedes `label`, so `show_pane` sharing
 
 ### Fixed
 
+- **Five of the nine console gates had no written contract.**
+  `docs/console-validation-runbook.md` is the SSOT for the release gates and
+  described four of them: `longchat`, `kvsnap`, `coderpaste`, `thinkcut` and
+  `genroom` appeared nowhere, while every release note cites "9/9 PASS". A gate
+  that fails without a stated assertion sends the operator to read shell. The
+  five entries are derived from the assertions in `validate-console.sh`, not
+  re-invented, and `check-coherence.py` now compares the documented set against
+  the `run_gate` arms **in both directions** — an undocumented gate and a
+  documented gate that no longer runs are both errors. Both directions were
+  proved by breaking them. Same shape as the autopilot-op check, one axis over.
+- **`docs/launch-copy.md` published a test count 16 cases stale.** That file is
+  the list of facts that may be cited outside the repo, and it claimed "176 host
+  test cases" against an actual 192, plus a scale figure (~17.5k lines / 80
+  files) with no stated definition and no way to re-derive it. Every countable
+  figure there now carries the command that produces it, and the suite size is
+  guarded in CI: `build-linux.yml` compares the published number against what
+  doctest reports, right after `ctest`. It has to live there rather than in
+  `check-coherence.py`, which is offline — `grep -c TEST_CASE` returns **199**
+  against the binary's 192 because seven cases sit behind `#if`, so a static
+  count would be confidently wrong.
+- **The user guide never mentioned the tiers the current release shipped.**
+  `docs/using-the-app.md` owns end-user behaviour and said nothing about coding
+  or thinking models or the context budget — Phase 14, shipped in 1.5.2.0 and
+  covered by three console gates. Engineers had it (`architecture.md`,
+  `model-matrix.md`); users did not, which is exactly the split `docs/README.md`
+  principle 3 exists to serve. Added: what the tiers change (a 4096-token context
+  on coding sessions), what a thinking model looks like on screen (reasoning
+  streams, only the answer is kept, and KV reuse is skipped so returning to that
+  conversation is slower), and what happens when the context fills — old turns
+  stop being sent **while staying on screen**, so the model can appear to forget
+  something still readable.
+- **The platform trap that kills the process was only in the changelog.** A
+  second `ContentDialog` throws inside a `fire_and_forget`, whose
+  `unhandled_exception()` is `std::terminate()` — no log line, no marker, and a
+  host-side timeout for what is an instant death. `uwp-constraints.md` §10c now
+  carries it with the general rule (an uncaught throw in a XAML coroutine is a
+  process kill, not an error path), because a lookup surface is where the next
+  person will go and history is not.
+- **`demo/` existed in neither repository map**, though it holds the demo script
+  that makes the capture reviewable. Added to `README.md` and `AGENTS.md`, and
+  `check-coherence.py` now requires every tracked top-level directory to appear
+  in the `AGENTS.md` map, with the deliberate omissions (`vendor/`, `.github/`)
+  listed with their reasons and themselves checked for staleness — which is how
+  a fourth, unnecessary exemption was caught.
+- Two SSOT lines that disagreed with their own files: `phase7-hypotheses.md` §H3
+  still summarised itself as "precondition passes" while its body carried the
+  full pre-gate verdict that split the hypothesis, and `store-readiness.md` was
+  dated before the screenshots it records two sections later.
 - **The README's demo link pointed at a release asset that had never been
   uploaded.** A stale link was replaced with a broken one. The asset is now on
   `v1.5.2.0`, verified by downloading it and comparing bytes — the first check

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ xllama/
 ├── training/         # jobs, host PEFT, datasets
 ├── bench/            # raw results + summary policy
 ├── diffusion/        # SD-Turbo host toolchain
+├── demo/             # demo-script.json — the recorded demo, as data
 ├── scripts/          # deploy, bench, validate, package
 ├── tests/            # doctest (xllama-tests)
 ├── docs/             # SSOT map: docs/README.md

--- a/docs/console-validation-runbook.md
+++ b/docs/console-validation-runbook.md
@@ -41,6 +41,49 @@ hardware gates pass:
   `smollm2-360m-cpu-int4` in LocalState; `set_taesd` / `set_system_prompt` need
   an app build >= 1.4.0.632, the rest >= 1.4.0.606);
 - **GGUF chat** — the default LFM model loads through llama.cpp and generates;
+- **longchat** (#169) — a chat whose history exceeds the trimmer ceiling is
+  injected, then run with KV reuse. Trimmed rounds must stay in the reuse regime
+  (prefill = the delta, not the ~1800 tokens of the whole history), and when the
+  resident KV overflows `n_ctx` the session must front-drop-evict and carry on.
+  Three log assertions, and two of them are negative: a `context shift — evicted`
+  line must appear, and neither `retrying with full prefill` nor `context full`
+  may. A continuation that silently falls back to a full re-prefill still answers
+  correctly, which is why the gate reads the log rather than the reply;
+- **kvsnap** (#170b) — leave a conversation, come back, and the history must not
+  be re-read: the snapshot written on the way out is restored on the way back and
+  the #170a prefix diff turns it into a delta. Beyond the two log lines
+  (`KV state saved`, `KV snapshot restored`) the gate compares **prompt-token
+  counts**: the returning turn must prefill under a quarter of the cold turn. A
+  snapshot that is written, restored and then ignored passes both log checks and
+  fails this one. The injected history is deliberately kept **under** the trimmer
+  budget, so a trim cannot muddy the signal with #169's shift;
+- **coderpaste** (#193) — a long paste on a coding session (`n_ctx` 4096), in two
+  regimes and two runs, on `qwen25-coder-0.5b`. **A**: past the 2048 logical
+  batch but inside `n_ctx` → the prefill must chunk and answer normally.
+  **B**: past `n_ctx` → the app must refuse with `prompt too long` and stay
+  alive. What this pins is an abort, not an error: `llama_decode` asserts
+  `n_tokens <= n_batch` with `GGML_ABORT` in Release too, so the old failure
+  killed the process. A dead app never writes `autopilot-done.txt`, so the
+  missing marker is itself the assertion;
+- **thinkcut** (#193) — a thinking model (`lfm25-1.2b-thinking`) that spends its
+  whole budget reasoning postprocesses to an empty answer, and the turn used to
+  vanish: nothing saved, the streamed chain of thought orphaned on screen, status
+  `Done`. The gate asserts both halves — `postprocess left no answer` in the log,
+  **and** the conversation on disk still ending in an assistant turn carrying the
+  explicit `reasoning only` stand-in. If the reasoning block is never truncated
+  the gate fails on purpose: either `n_predict` is too generous or the model
+  emits no `<think>` at all, which would make the whole strip a no-op. Investigate
+  it; do not relax it;
+- **genroom** (#193) — a full context must still leave room for the whole reply.
+  The trimmer ceiling used to reserve a flat 250 tokens while the UI default
+  `n_predict` is 512, and the generation loop clamps `n_predict` to what the
+  context has left, so a prompt on the old ceiling got a reply cut at ~248 tokens
+  in silence. The gate asserts the **arithmetic** — `prefill + n_predict <=
+n_ctx` — rather than the answer's length, which keeps the verdict independent
+  of whether a small model feels talkative. Two preconditions guard against a
+  vacuous pass: the `prompt budget:` line must be present (or the exact fit never
+  ran) and something must actually have been dropped (or the payload never filled
+  the context);
 - **TAESD** — image generation completes through DirectML with the fast VAE.
   This gate swaps `vae_decoder/model.onnx` from a local cache rather than
   flipping the in-app toggle: the toggle makes the console download the asset
@@ -93,6 +136,11 @@ Run an individual gate while debugging:
 ./scripts/validate-console.sh routing
 ./scripts/validate-console.sh settings
 ./scripts/validate-console.sh gguf
+./scripts/validate-console.sh longchat
+./scripts/validate-console.sh kvsnap
+./scripts/validate-console.sh coderpaste
+./scripts/validate-console.sh thinkcut
+./scripts/validate-console.sh genroom
 ./scripts/validate-console.sh taesd
 ./scripts/validate-api.sh all          # spike + chat + prefs + train
 ./scripts/validate-console-training.sh rate   # preference UI path

--- a/docs/launch-copy.md
+++ b/docs/launch-copy.md
@@ -162,7 +162,13 @@ the answer. This is the part of the plan that cannot be delegated or rushed.
 
 ---
 
-## Reference facts (verified 2026-07-27, do not re-derive)
+## Reference facts (verified 2026-07-30)
+
+Every countable figure below carries the command that produces it. That is the
+point: the previous version of this block said "176 host test cases" for long
+enough that it drifted 16 cases behind, and a bare number nobody can re-derive
+cannot be spot-checked — only trusted or rewritten. Re-run the command instead of
+re-deriving the fact by hand.
 
 - **Generated benchmark table**: `docs/benchmarks.md`. Headline `lfm25-350m`
   438.1 prefill / 94.9 decode (94.8–95.1, n=3) / 320 MB. Only the headline GGUF
@@ -171,10 +177,29 @@ the answer. This is the part of the plan that cannot be delegated or rushed.
   conversation switch 551 → 19 prompt tokens (#170b); turn-2 KV reuse 15–16×.
 - **Build fixes**: repack 241.9 → 393.2 tok/s (#155); `n_threads_batch`
   390.7 → 438.1 at P=298 (#168).
-- **Scale**: ~17.5k lines of own C++ across 80 files, 176 host test cases, 9
-  console validation gates (`scripts/validate-console.sh` — routing, settings,
-  gguf, longchat, kvsnap, coderpaste, thinkcut, genroom, taesd), 15 product releases
-  since 2026-05-19, current 1.5.2.0.
+- **Scale**: **~19.9k lines of own C++ across 90 files**, of which 3.5k in 23
+  test files; **192 host test cases / 1491 assertions**; **9 console validation
+  gates** (`scripts/validate-console.sh` — routing, settings, gguf, longchat,
+  kvsnap, coderpaste, thinkcut, genroom, taesd); **15 product releases** since
+  2026-05-19, current **1.5.2.0**. Derivations:
+
+  ```bash
+  # lines and files — src/ + include/ + uwp/ + tests/, tracked .cpp/.h only
+  git ls-files 'src/**' 'include/**' 'uwp/*.cpp' 'uwp/*.h' 'tests/**' |
+    grep -E '\.(cpp|h)$' | xargs wc -l | tail -1
+  # test cases — from the binary, NOT from a grep: `grep -c TEST_CASE` says 199
+  # because seven cases sit behind #if, so a static count would overstate by 7
+  cmake --preset linux-test && cmake --build build/linux-test -j"$(nproc)"
+  ./build/linux-test/tests/xllama-tests | tail -2
+  # gates
+  grep -cE '^\w+\) run_gate ' scripts/validate-console.sh
+  # product releases — total tags minus the two asset-only ones
+  gh release list --limit 60 --json tagName --jq 'length'
+  ```
+
+  The test-case figure is additionally guarded in CI: `build-linux.yml` compares
+  the number in this file against what doctest reports, right after `ctest`.
+
 - **Hardware limits**: ~6 usable cores (livelock at 7–8), GPU budget 3801 MB, no
   `mmap` / `dlopen`, 2 GB per-file ONNX ceiling (which does not apply to GGUF).
 - **Demo video**: cite the **v1.5.2** capture, never the v1.2.0 one. The old
@@ -183,8 +208,10 @@ the answer. This is the part of the plan that cannot be delegated or rushed.
   the rate the Device Portal actually sustains, encoded at the rate achieved so
   **playback is real time** — a demo of a performance claim must not be sped up.
   `docs/screenshots/demo-manifest.json` records the version, frame count and
-  achieved fps, and `check-coherence.py` fails if the README cites a version
-  that manifest does not claim.
+  achieved fps, and `check-coherence.py` fails if the README link disagrees with
+  that manifest on **version or filename**. The filename half exists because the
+  version check alone once passed on a link to an asset that had never been
+  uploaded — a stale link replaced by a broken one.
 
 The earlier long-form drafts (the measurement-first version and the original
 link-post copy) are in git history at `docs/reddit-announcement.md`.

--- a/docs/phase7-hypotheses.md
+++ b/docs/phase7-hypotheses.md
@@ -212,10 +212,14 @@ Closed negative: DML int4 decode, 1B fp16 DML inference, llama≫ORT BW, AppCont
 - **Claim:** ≥1.4× perceived tok/s on target without more average bandwidth.
 - **PASS:** ≥1.4× on 1.7B+ with same quality.
 - **FAIL:** Overhead &gt; gain on 6 cores.
-- **Status:** Open — **precondition PASSES on the intended pair** (2026-07-29).
-  Not in `LlamaSession` yet. Dependency forks are available and explicitly in
-  scope if H3 or a measured kernel/repack bottleneck requires changes below
-  xllama's API layer.
+- **Status:** Open — **split by the pre-gate** (2026-07-29). The precondition
+  passes on the intended pair, and the predeclared A/B then **rejected the
+  draft-model variant** (1.43× on code but **0.81× on open chat**) and **admitted
+  the draft-free prompt lookup at k=2** (1.53× / 1.00×). What remains open is the
+  implementation, tracked as Phase 15 W2 (#210); it is not in `LlamaSession` yet.
+  Both verdicts, and the cost model they rest on, are below. Dependency forks are
+  available and explicitly in scope if H3 or a measured kernel/repack bottleneck
+  requires changes below xllama's API layer.
 
   The pin gates speculation on `common_speculative_are_compatible`
   (`common/speculative.cpp:64`) and **throws** when it fails, so vocab identity

--- a/docs/store-readiness.md
+++ b/docs/store-readiness.md
@@ -6,10 +6,10 @@
 > `benchmarks.md`; this page owns **go-to-market gates**, dual-SKU policy, and
 > the licence matrix for a retail listing.
 
-**Status (2026-07-29):** Phase 0 discovery + Phase 1 **engineering foundation**
-landed. **Not Store-ready** for retail: no Partner Center product, no
-Store-signed package, no privacy URL, no age rating. Dev Mode remains the only
-supported install path.
+**Status (2026-07-30):** Phase 0 discovery + Phase 1 **engineering foundation**
+landed, and the **five listing screenshots are captured** (§9). **Not
+Store-ready** for retail: no Partner Center product, no Store-signed package, no
+privacy URL, no age rating. Dev Mode remains the only supported install path.
 
 **Audience for a eventual listing:** hobbyist local-LLM / homebrew Xbox users
 who should not need Dev Mode. Contributors keep the Dev Mode sideload path.

--- a/docs/using-the-app.md
+++ b/docs/using-the-app.md
@@ -33,6 +33,51 @@ actions. A correction requires the preferred answer. Each response can be rated
 once; the choice is stored with the conversation and appended to
 `LocalState\training\samples.jsonl`. Cancelled/partial responses cannot be rated.
 
+## Model tiers: chat, coding, thinking
+
+The catalogue is not one model in several sizes. Three kinds behave differently
+in ways you will notice, and the picker does not explain them:
+
+- **Chat** (the default, LFM2.5-350M, and the larger LFM2.5-1.2B / LFM2-2.6B) —
+  a 2048-token context. This is what a first launch gives you.
+- **Coding** (`qwen25-coder-0.5b` / `-1.5b` / `-3b`) — the same UI, but the
+  session opens a **4096-token** context, because the point of the tier is
+  pasting real source. That is the only difference you set: there is no separate
+  mode to switch on, the model's catalogue entry carries it.
+- **Thinking** (`lfm25-1.2b-thinking`) — reasons before answering. You **see the
+  reasoning stream on screen while it generates**, and the message that is kept
+  when it finishes holds only the final answer. The chain of thought is not
+  saved to the conversation.
+
+Two consequences of the thinking tier worth knowing before you blame the app:
+
+- If the model spends its whole token budget reasoning and never reaches an
+  answer, the turn is kept and says so:
+  `(reasoning only — the answer did not fit; raise "Max new tokens" in Settings)`.
+  That is the fix — it is a budget, not a failure.
+- **KV-cache reuse is skipped for thinking models.** The saved conversation holds
+  the stripped answer while the cache holds the full reasoning, so the two can
+  never match on the way back; reusing it would be wrong rather than fast.
+  Returning to a thinking conversation therefore re-reads it, and the first turn
+  after a switch is slower than it would be on a chat model.
+
+## When the context fills up
+
+Every model has a fixed context, and a long conversation eventually exceeds it.
+What happens then is deliberate, and only one half of it is visible:
+
+- **Old turns stop being sent.** The oldest turns are dropped from what the model
+  sees so the newest ones and your reply still fit. **They stay on your screen** —
+  the conversation is not edited — so the model can appear to forget something you
+  can still read. Starting a new conversation is the way to clear it.
+- **The reply keeps its room.** The prompt is budgeted so that the answer you
+  asked for still fits alongside it, rather than being cut short in silence once
+  the context is nearly full.
+- **A single message longer than the whole context is refused**, not truncated:
+  `prompt too long: N tokens exceed n_ctx=M — shorten the message or start a new
+chat`. On a coding session that ceiling is 4096 tokens, roughly 13 KB of dense
+  source.
+
 ## Settings (`[S]`)
 
 - **Model** — ComboBox populated from the model catalogue

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -599,6 +599,36 @@ vcxproj, and a `TargetDeviceFamily` in the manifest are all compile-time or
 install-time facts, and none of the three implies the type can be activated on
 the device in front of you.
 
+### §10c — A second `ContentDialog` kills the process, silently (2026-07-30)
+
+XAML allows exactly **one** `ContentDialog` open per `XamlRoot`. Showing a second
+throws. That alone would be ordinary — the trap is where the exception lands.
+
+Every dialog in this app is opened from a `winrt::fire_and_forget` coroutine, and
+`fire_and_forget`'s promise implements `unhandled_exception()` as
+**`std::terminate()`**. So the failure is not an exception you can catch at the
+call site and not an error on screen: the process disappears. No `xllama.log`
+line, no crash dialog, and — because the autopilot marker is written by the app
+itself — **no `autopilot-done.txt`**. From the host side that is indistinguishable
+from a hung run, so an automated gate reports a timeout for what is actually an
+instant death, and the operator goes looking for a deadlock that is not there.
+
+It stayed unreachable for a long time by accident, not by design: the first-run
+disclaimer was the only programmatic dialog, and every gate script seeds it away.
+The `show_pane` autopilot op made it reachable, which is how it was found.
+
+The guard is an `std::atomic<bool>` owned by `MainPageController` (`m_pane_open`),
+set from the dialog's `Opened` / `Closed` events by `ApTrackDialog`, and checked
+before opening a pane: a collision now fails with a readable `error:` in the
+marker instead of taking the process with it. Verified by running `show_pane`
+under the unaccepted disclaimer — the only collision actually reachable today.
+
+**The rule this generalises to:** in a `fire_and_forget` that touches XAML, an
+uncaught throw is a process kill, not an error path. Anything that can throw
+there needs either a guard before it or a `try`/`catch` inside it. Prefer the
+guard, because a caught exception still leaves the UI in whatever state the
+half-finished coroutine left it.
+
 ## 11. GPU Truth — EP Attribution Without PIX
 
 PIX for Xbox is GDK tooling gated behind the managed partner program; it is **not available for Dev Mode UWP**. GPU-vs-CPU execution truth is instead established by converging three surfaces (all verified against primary sources, ORT GenAI 0.13.2 / ORT 1.24.4):

--- a/scripts/check-coherence.py
+++ b/scripts/check-coherence.py
@@ -400,6 +400,93 @@ def main() -> int:
                 f"autopilot ops ({len(ops)}) — validator table and ApRun branches agree"
             )
 
+    # --- console gates: what runs vs what the runbook describes ---
+    #
+    # Same shape as the autopilot-ops check above, one axis over. The gates are
+    # the release contract — every release note cites "9/9 PASS" — but the
+    # runbook is the only place that says what each one ASSERTS, and it had
+    # drifted to describing four of nine. A gate that fails without a written
+    # contract sends the operator to read shell.
+    #
+    # Read from the script, not repeated here, for the same reason as kOps.
+    vc = (ROOT / "scripts/validate-console.sh").read_text(encoding="utf-8")
+    gates = set(re.findall(r"^(\w+)\) run_gate ", vc, re.M))
+    runbook = (ROOT / "docs/console-validation-runbook.md").read_text(encoding="utf-8")
+    # Scope the parse to the gate list itself — from the sentence that introduces
+    # it to the next heading. The file has other bolded bullet lists (the
+    # failure-class breakdown below it, whose leads are "autopilot" / "marker" /
+    # "timeout"), and reading the whole document takes those for gate names.
+    section = re.search(r"hardware gates pass:\n(.*?)\n#", runbook, re.S)
+    if not section:
+        err(
+            "console-validation-runbook.md: the sentence introducing the gate list moved"
+        )
+    section_text = section.group(1) if section else ""
+    # `gguf` is written "GGUF chat" and `taesd` "TAESD", so match case-insensitively
+    # on the bolded lead word rather than requiring the shell identifier verbatim.
+    documented = {
+        m.lower() for m in re.findall(r"^- \*\*([A-Za-z]+)", section_text, re.M)
+    }
+    if not gates:
+        err("validate-console.sh: no `<name>) run_gate` arms found")
+    else:
+        undocumented = sorted(g for g in gates if g.lower() not in documented)
+        for g in undocumented:
+            err(
+                f"console gate '{g}' runs but docs/console-validation-runbook.md does not describe it"
+            )
+        # The other direction: a gate described in the runbook that no longer
+        # exists sends an operator to run something that will just print usage.
+        # `api` is documented on purpose and lives in validate-api.sh.
+        doc_only = sorted(
+            d
+            for d in documented
+            if d not in {g.lower() for g in gates} and d not in {"api"}
+        )
+        for d in doc_only:
+            err(
+                f"the runbook describes a '{d}' gate that validate-console.sh does not run"
+            )
+        if not undocumented and not doc_only:
+            good(
+                f"console gates ({len(gates)}) — runbook describes every gate that runs"
+            )
+
+    # --- every tracked top-level directory appears in the AGENTS.md map ---
+    #
+    # AGENTS.md calls itself the file-level map for agents and contributors, so a
+    # directory missing from it is invisible to exactly the readers it is for.
+    # `demo/` arrived with the capture pipeline and was absent from both trees.
+    #
+    # The exemptions are deliberate omissions, and they carry their reason here
+    # rather than in someone's memory (same rule as `cli.cpp` above).
+    # (`llama.cpp` needs no exemption: it is a submodule, so `git ls-files`
+    # reports it as one gitlink entry with no path separator and it never reaches
+    # this set. Adding it anyway is what the stale-exemption check below caught.)
+    tree_exempt = {
+        "vendor",  # patched-DLL overlay, owned by vendor-lifecycle-plan.md
+        ".github",  # CI, described in the workflows section instead of the tree
+    }
+    agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    r = subprocess.run(
+        ["git", "ls-files"], cwd=ROOT, capture_output=True, text=True, check=False
+    )
+    top_dirs = {
+        p.split("/", 1)[0] for p in r.stdout.splitlines() if "/" in p
+    } - tree_exempt
+    missing_dirs = sorted(d for d in top_dirs if f"{d}/" not in agents)
+    for d in missing_dirs:
+        err(f"tracked directory {d}/ does not appear in the AGENTS.md map")
+    stale_tree_exempt = sorted(
+        d
+        for d in tree_exempt
+        if d not in {p.split("/", 1)[0] for p in r.stdout.splitlines() if "/" in p}
+    )
+    for d in stale_tree_exempt:
+        err(f"tree_exempt lists {d}/, which is no longer a tracked directory")
+    if not missing_dirs and not stale_tree_exempt:
+        good(f"AGENTS.md maps every tracked top-level directory ({len(top_dirs)})")
+
     # --- benchmark summary ---
     r = subprocess.run(
         [


### PR DESCRIPTION
An audit of every doc against the current tree. **Nine findings**, one of them a real gap rather than a stale number — and none of the nine was inside what `check-coherence.py` could see, which is why three of them now are.

## The gap

`docs/console-validation-runbook.md` is the SSOT for the release gates and described **four of nine**. `longchat`, `kvsnap`, `coderpaste`, `thinkcut` and `genroom` appeared nowhere, while every release note cites "9/9 PASS". A `FAIL` on `genroom` had, in the entire repo, no sentence saying what that gate required.

The five entries are **derived from the assertions in `validate-console.sh`**, not re-invented — including the parts that are easy to get wrong. `kvsnap`'s real check is a prompt-token comparison, not its two log lines: a snapshot that is written, restored and then *ignored* passes both of those and fails only the token count.

## The public numbers

`docs/launch-copy.md` is the list of facts citable outside the repo. It claimed **176 host test cases** against an actual **192**, and a scale figure (~17.5k lines / 80 files) with no stated definition and no way to re-derive it. Every countable figure now carries the command that produces it.

The suite size is guarded in **CI**, not in `check-coherence.py`, and the reason is the interesting part: `grep -c TEST_CASE` returns **199** against the binary's **192**, because seven cases sit behind `#if`. A static check would have been confidently wrong — worse than no check.

## The user guide

`docs/using-the-app.md` owns end-user behaviour and never mentioned coding models, thinking models or the context budget — Phase 14, shipped in 1.5.2.0 and covered by three console gates. Engineers had it in `architecture.md` / `model-matrix.md`; users did not, which is the split `docs/README.md` principle 3 exists to serve. Added what is actually visible, including the part that reads as a bug: **old turns stop being sent to the model while staying on screen**.

## The trap

The second-`ContentDialog` → `std::terminate()` death lived only in the changelog and a code comment. `uwp-constraints.md` §10c now carries it with the general rule: in a `fire_and_forget` touching XAML, an uncaught throw is a process kill, not an error path.

## Guards — each proved by breaking it

| guard | proved by |
| --- | --- |
| documented gates vs `run_gate` arms, **both directions** | renaming a documented gate (2 errors), deleting a `run_gate` arm (1 error) |
| every tracked top-level dir in the `AGENTS.md` map | removing `demo/` from the tree |
| exemptions checked for staleness | adding a bogus exemption — and it immediately caught a real one: `llama.cpp` never reaches that set, being a submodule |
| CI: published test count vs doctest | writing 176/1400 into `launch-copy.md` |

## Also

`demo/` was in neither repository map; `phase7-hypotheses.md` §H3 summarised itself as "precondition passes" while its own body held the verdict that split the hypothesis; `store-readiness.md` was dated before the screenshots it records two sections later.

## Verification, with a correction

- **`check-coherence.py`: 43 OK / 0 ERR locally, 40 OK / 1 WARN / 0 ERR on CI.** An earlier version of this description gave only the local number. The two differ for a pre-existing reason unrelated to this PR: the SSOT step runs *before* the build, so `xllama-cli` does not exist yet and three train-job validations skip with `! xllama-cli not built`. Both of the new checks are green in the CI log — `✓ console gates (9)` and `✓ AGENTS.md maps every tracked top-level directory (12)`.
- **The new CI step ran and printed its verdict**: `launch-copy.md matches the suite: 192 cases / 1491 assertions`. Not just green — green for the right reason.
- Host suite rebuilt from this tree: **192 cases / 1491 assertions**, and that is where the doc's number comes from.
- `shellcheck` clean, workflow YAML parses, script compiles.

Filed separately from the CI observation above: those three train-job checks **never execute on CI**, so they are effectively developer-machine-only. Pre-existing, not introduced here, and tracked rather than fixed inside a docs PR.

**No product code** — docs, one lint script, one CI step. No console gate re-run is warranted, and saying so explicitly is part of the change.