### PR TITLE
docs: post-v1.5.3.0 tracking and SSOT refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ xllama/
 │   ├── utf8_utils.cpp
 │   └── cli.cpp
 ├── src/main.cpp             # Linux entry point (getopt_long; --train-job)
-├── training/                # Training pillar ops: jobs, datasets, host PEFT
+├── training/                # Training pillar ops: jobs/, manifest-overrides/, datasets, host PEFT
 ├── docs/                    # SSOT map in docs/README.md
 │   ├── architecture.md      # System structure SSOT
 │   ├── training-architecture.md  # Training SSOT (RE + capability matrix + §11 UI arc)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![build-linux](https://github.com/gianlucamazza/xllama/actions/workflows/build-linux.yml/badge.svg)](https://github.com/gianlucamazza/xllama/actions/workflows/build-linux.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-**Status:** shipping (unified + PatchedGenAI + PatchedOrt) · research-grade — current version in [CHANGELOG](CHANGELOG.md) / [ROADMAP](ROADMAP.md)
+**Status:** shipping **v1.5.3.0** (unified + PatchedGenAI + PatchedOrt) · research-grade — [CHANGELOG](CHANGELOG.md) · [ROADMAP](ROADMAP.md) · [latest release](https://github.com/gianlucamazza/xllama/releases/tag/v1.5.3.0)
 **Maintainer:** [Gianluca Mazza](https://github.com/gianlucamazza)
 
 ![xllama running on an Xbox Series S: a chat answer, the coding tier writing a C function, saved conversations and a Stable-Diffusion image, all on-console](docs/screenshots/xllama-demo-v1.5.2.gif)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,20 +32,30 @@ performance belongs in `docs/benchmarks.md`.
   #116/#118). Phases 13 and 14 are complete and shipped. Remaining open work:
   Phase 15 (make the 3B–4B class usable), the #130 root-cause profile, and
   upstream vendor pin drops.
-- **Shipped in v1.5.3.0** (see `CHANGELOG.md`): conversation titles, History
-  leak (#219), demo/capture pipeline (#213/#215/#217), dual-CRT packaging,
-  train-job CI validate (#222), H6 parked (#228). Linux store PE launch remains
-  open (layer 2); product packages are CI MSVC — `docs/crossbuild-console.md`.
-- **The demo pipeline is re-runnable, and #214 is closed.** `README.md` links the
-  v1.5.2 capture (576 stills at 11.76 fps, encoded at the rate actually achieved
-  so playback is real time); the version, output path and watermark come from
-  `uwp/AppxManifest.xml` and the content from `demo/demo-script.json`, so
-  recapturing is one command instead of an edit to the tool.
-  `docs/screenshots/demo-manifest.json` records what was captured, and
-  `check-coherence.py` errors when the README link drifts from it in version or
-  in filename — the failure mode that shipped a link to an asset nobody had
-  uploaded. The same pipeline produced the five Store screenshots that
-  `store-readiness.md` Phase 2 was waiting on.
+- **Shipped as v1.5.3.0** (tag + GitHub Release, MSIX **1.5.3.873**): conversation
+  titles, History leak (#219), demo/capture pipeline (#213/#215/#217), dual-CRT
+  packaging, train-job CI validate (#222), H6 parked (#228). Console
+  `validate-console.sh all` **9/9 PASS** on Series S (2026-08-08). Linux store
+  PE launch remains open (layer 2); product packages are CI MSVC —
+  `docs/crossbuild-console.md`.
+- **Demo capture remains the v1.5.2 assets** (576 stills; re-record optional —
+  `check-coherence` allows a minor-version lag). Pipeline is re-runnable
+  (`demo/demo-script.json` + `scripts/capture-demo-video.sh`); Store screenshots
+  in `docs/screenshots/store/`.
+
+### Next (after v1.5.3.0)
+
+Priority order is hygiene and open product risks, not reopening parked eng:
+
+1. **Intermittent `kvsnap` under `all` (#216)** — flake still open; 1.5.3 suite
+   was green once, not a close.
+2. **Thinking-tier evidence (#223)** — no H9-style proof a reasoning turn completes.
+3. **#130 DML prefill valley** — mitigated by warm-up; root-cause profile open.
+4. **Vendor pin drops** (#84/#85/#86) — PatchedGenAI / PatchedOrt lifecycle.
+5. **Store readiness** — Partner Center, App-vs-Game spike, listing copy
+   (`docs/store-readiness.md`).
+6. **Parked** — H6/H7 GGUF GPU eng (#228) until new density measure; Linux store
+   PE activation layer 2; prompt-lookup product default (stays OFF after W2).
 
 ## Phase 7 — Peer-class model research
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,7 +126,7 @@ Spot-checked against code + evidence:
 | GPU allowlist `-v2` only                            | `dml_text_model_ok`                                       | OK                                                        |
 | NuGet 0.14.1 / 1.24.4 / DML 1.15.4                  | `packages.config`                                         | OK                                                        |
 | Decode table (94.9 / 37.9 / 18.4 / 74.8 / 44.4 / …) | `generate-benchmark-summary.py --check`                   | OK (2026-07-26: LFM post-#168 median, ORT CPU shipped-t6) |
-| Package identity `GianlucaMazza.xllama` (1.5.2.0)   | `uwp/AppxManifest.xml`; migration in `install-release.md` | OK (in-place from 1.5.x; breaking vs ≤1.4.x)              |
+| Package identity `GianlucaMazza.xllama` (1.5.3.0)   | `uwp/AppxManifest.xml`; migration in `install-release.md` | OK (in-place from 1.5.x; breaking vs ≤1.4.x)              |
 | One resident Session (GUI+API)                      | `include/xllama/session_hub.h`                            | OK (PR #161/#164)                                         |
 | H9 6/8 · 7/8 · 4/8 · 5/8                            | `phase7-h9.jsonl`                                         | OK                                                        |
 | Lane B peak_ws 1195 MB, wall 446 s                  | `phase10-console-devtrain-result.json`                    | OK                                                        |

--- a/docs/crossbuild-console.md
+++ b/docs/crossbuild-console.md
@@ -10,7 +10,7 @@ Companion SSOTs: [uwp-constraints.md](uwp-constraints.md), campaign notes in
 
 | Goal | Path | Status on Series S |
 | --- | --- | --- |
-| Ship / measure product tok/s | CI MSVC `build-uwp` → `xllama-appx` → openappx pack/sign/deploy | **Launches** (proven through `1.5.2.864`+ post-gpubw) |
+| Ship / measure product tok/s | CI MSVC `build-uwp` → `xllama-appx` → openappx pack/sign/deploy | **Launches** (shipping **v1.5.3.0** / MSIX `1.5.3.873`, 9/9 gates) |
 | Compile + package from Linux | uwp-crossbuild ≥ **0.5.0** + store `/MD` + dual-CRT stage | **Links; audit PASS**; dual-CRT stage required; **store PE still fails activation** (`0x80040904`) — layer 2 |
 | hello-uwp / non-filesystem samples | uwp-crossbuild `/MT` or store `/MD` | Launches |
 
@@ -26,7 +26,9 @@ Companion SSOTs: [uwp-constraints.md](uwp-constraints.md), campaign notes in
 ## Launchable package today (shipping path)
 
 **CI MSVC (`build-uwp` → artifact `xllama-appx`) is the proven product path on
-Series S.** Measured 2026-08-07: CI `1.5.2.910` activates and loads GGUF.
+Series S.** Measured through **v1.5.3.0** (MSIX `1.5.3.873` activates, loads GGUF,
+and passes the full console gate suite). Earlier hybrid dual-CRT probes used
+`1.5.2.x` packages (see layer table below).
 
 ## Architecture: two integrated runtimes (SSOT)
 

--- a/docs/install-release.md
+++ b/docs/install-release.md
@@ -2,9 +2,9 @@
 
 How to install a tagged xllama release (see the
 [releases page](https://github.com/gianlucamazza/xllama/releases) for the current
-tag) on an
-Xbox Series S|X in Dev Mode, from a Linux/macOS host. For building from source
-see the [README](../README.md#build); for Dev Mode activation and Device
+tag — today **[v1.5.3.0](https://github.com/gianlucamazza/xllama/releases/tag/v1.5.3.0)**)
+on an Xbox Series S|X in Dev Mode, from a Linux/macOS host. For building from
+source see the [README](../README.md#build); for Dev Mode activation and Device
 Portal basics see [device-portal.md](./device-portal.md).
 
 ## Prerequisites
@@ -24,7 +24,9 @@ Portal basics see [device-portal.md](./device-portal.md).
 
 From the GitHub Release page (or `gh release download vX.Y.Z`):
 
-- `xllama_X.Y.Z.0_x64.msix` — the app (~19 MB, no model inside)
+- `xllama_X.Y.Z.<rev>_x64.msix` — the app (~19 MB, no model inside). The fourth
+  version component is the CI run stamp (e.g. `xllama_1.5.3.873_x64.msix` for
+  **v1.5.3.0**); local builds keep `.0`.
 - `xllama-test.cer` — the signing test certificate
 - `Microsoft.VCLibs.x64.14.00.appx` — runtime dependency
 
@@ -40,8 +42,8 @@ source ~/.config/xllama/xbox-env
 #   https://<XBOX_IP>:11443 → My games & apps → Install → Microsoft.VCLibs.x64.14.00.appx
 # (or add it as a dependency in the same WDP install dialog as the MSIX)
 
-# App
-./scripts/deploy.sh xllama_X.Y.Z.0_x64.msix
+# App (name matches the asset on the release — revision is not always .0)
+./scripts/deploy.sh xllama_1.5.3.873_x64.msix
 ```
 
 Notes:

--- a/docs/model-matrix.md
+++ b/docs/model-matrix.md
@@ -117,6 +117,13 @@ exact after trimming with **513 left for a requested 512**, the fix for the sile
 dead feature because it pinned `n_predict=128`, and now runs at the shipping
 default (long turn → GPU at 1769 tok, short → CPU at 23).
 
+**Re-validated on v1.5.3.0** (MSIX **1.5.3.873**, release asset for tag `v1.5.3.0`,
+Series S 2026-08-08): all **nine** console gates PASS
+(`routing`, `settings`, `gguf`, `longchat`, `kvsnap`, `coderpaste`, `thinkcut`,
+`genroom`, `taesd`). The `gguf` gate now also asserts a **non-empty conversation
+title** on disk (empty-title fix in this cut). Capability figures from 1.5.2
+still hold on this package.
+
 **Out of budget / deferred:** Qwen2.5-Coder-7B+, Qwen3-Coder MoE 30B+, Devstral 24B,
 DeepSeek-Coder-V2-Lite, StarCoder2 / DS-Coder 1.3B. LFM2.5-8B-A1B was on this list
 at ~5 GB (its official Q4_K_M); it moved to A3 below once the heap ceiling was

--- a/docs/phase15-re-opt.md
+++ b/docs/phase15-re-opt.md
@@ -206,11 +206,13 @@ disprove denser CS designs, but **this spike does not clear soft density ≥40**
 | 2026-08-08 | **H6.1 eng start (#228):** `gpugemv` Q4_K GEMV density probe (AOT DXIL, system D3D12, pure CPU ref). Soft G2 ≥40 GB/s packed; G1 residual. Not a SessionHub backend. |
 | 2026-08-08 | **H6.1 console:** Series S `1.5.2.860`, N=K=8192, **packed_gbs=2.15**, max_abs_err≈4.6e-5 → **G1 PASS / G2 FAIL**. Naive CS compute-bound. CSV `bench/results/phase15-gpugemv.csv`. |
 | 2026-08-08 | **H6 eng parked (#228).** Binding constraint remains bytes/token; G2 FAIL shows no free ride on STREAM 119 GB/s. No full GGUF GPU backend without new density PASS or explicit gate rewrite. Focus → product hygiene. |
+| 2026-08-08 | **v1.5.3.0 shipped** (PR #230, tag `v1.5.3.0`, MSIX `1.5.3.873`): dual-CRT package architecture + AppContainer PE hygiene + History/title product fixes. Product launch remains CI MSVC. Series S `validate-console.sh all` **9/9 PASS**. W2 stays opt-in OFF; H6 remains parked. |
 
 ## Related issues
 
-- #210 W2 prompt-lookup (eng shipped opt-in; default OFF after M3)
+- #210 W2 prompt-lookup — **closed** (eng opt-in shipped; product default OFF after M3)
 - #211 W3 gpubw gate — **closed PASS** (119.07 GB/s); PR #227
 - #228 H6 eng follow-up — **parked** after H6.1 G2 FAIL
 - #130 DML max_length valley mechanism
-- #216 kvsnap intermittent (watch on console gates)
+- #216 kvsnap intermittent (watch on console gates; green on 1.5.3.873 once)
+- #223 thinking-tier completion evidence

--- a/docs/store-readiness.md
+++ b/docs/store-readiness.md
@@ -6,10 +6,11 @@
 > `benchmarks.md`; this page owns **go-to-market gates**, dual-SKU policy, and
 > the licence matrix for a retail listing.
 
-**Status (2026-07-30):** Phase 0 discovery + Phase 1 **engineering foundation**
-landed, and the **five listing screenshots are captured** (§9). **Not
-Store-ready** for retail: no Partner Center product, no Store-signed package, no
-privacy URL, no age rating. Dev Mode remains the only supported install path.
+**Status (2026-08-08):** Phase 0 discovery + Phase 1 **engineering foundation**
+landed, and the **five listing screenshots are captured** (§9). Product Dev Mode
+cut is **v1.5.3.0** (MSIX `1.5.3.873`, 9/9 console gates). **Not Store-ready**
+for retail: no Partner Center product, no Store-signed package, no privacy URL,
+no age rating. Dev Mode remains the only supported install path.
 
 **Audience for a eventual listing:** hobbyist local-LLM / homebrew Xbox users
 who should not need Dev Mode. Contributors keep the Dev Mode sideload path.


### PR DESCRIPTION
## Summary

Documentation and project tracking after shipping **v1.5.3.0**.

- ROADMAP: shipped package `1.5.3.873` + 9/9 gates; **Next** queue after the cut
- model-matrix / crossbuild / install-release / store-readiness / docs map / README status
- phase15 log + related-issue status (#210 closed)
- AGENTS: `training/manifest-overrides/`

Also closed **#210** (W2 product default OFF) and commented **#216** (1.5.3 green once, flake stays open). Personal project note updated outside the repo.

## Test plan
- [x] `python3 scripts/check-coherence.py` exit 0
- [ ] CI green on docs PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release documentation to identify v1.5.3.0 as the current shipping version.
  * Added installation guidance for the latest package revision.
  * Documented successful launch validation, GGUF loading, and all nine console checks passing.
  * Updated model validation notes, release readiness details, and roadmap priorities.
  * Clarified Store readiness status and remaining publication requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->