### PR TITLE
fix(uwp): #216 KV snapshot save race (restored + full prefill)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **#216 KV snapshot race on conversation switch.** `SaveKvSnapshotAsync` used a
+  detached thread; a follow-up turn could take the session hub lock and rewrite
+  the resident KV before the leave-conversation save finished, so the file on the
+  old chat's path held the *new* chat's tokens. Load still logged "restored", then
+  the #170a prefix diff found no match and full-prefilled (~cold tokens). The
+  gate under `all` saw this ~1/6; standalone rarely did. Generate now waits for
+  any outstanding snapshot save; prefix-miss and hybrid-rewind paths log enough
+  for the next failure to be self-explaining.
+
 ## [1.5.3.0] - 2026-08-08
 
 User-visible polish on top of v1.5.2: conversation titles in History, a History

--- a/scripts/validate-console.sh
+++ b/scripts/validate-console.sh
@@ -883,6 +883,18 @@ JSON
 		echo "  FAIL: snapshot not restored"
 		verdict=1
 	fi
+	# #216: restore can succeed while the prefix diff still full-prefills
+	# (wrong snapshot contents after a save race, or hybrid rewind refuse).
+	# Surface those lines so a FAIL is self-explaining next to the token count.
+	if grep -aq 'KV prefix reuse none' "$log"; then
+		echo "  note: prefix reuse found no common tokens after restore"
+	fi
+	if grep -aq 'KV rewind unsupported' "$log"; then
+		echo "  note: hybrid cache refused tail rewind after restore"
+	fi
+	if grep -aq 'KV prefix reuse — kept' "$log"; then
+		echo "  ok: prefix reuse kept tokens after restore"
+	fi
 	# The point of the feature: the returning turn prefills a delta, not the
 	# history it prefilled cold.
 	python3 - "$log" <<'PY' || verdict=1

--- a/src/bridge/session.cpp
+++ b/src/bridge/session.cpp
@@ -665,6 +665,17 @@ class LlamaSession final : public Session {
                     log_output(pb);
                 }
             } else {
+                // #216: when a #170b restore just landed, "restored" + full
+                // re-prefill means the saved token list and the re-rendered
+                // prompt share no common prefix — log enough to diagnose.
+                if (!m_kv_tokens.empty()) {
+                    char pb[192];
+                    snprintf(pb, sizeof(pb),
+                             "[xllama] session: KV prefix reuse none — resident %zu tok, "
+                             "prompt %zu tok (first mismatch at 0) (#170)\n",
+                             m_kv_tokens.size(), tokens.size());
+                    log_output(pb);
+                }
                 llama_memory_clear(mem, true);
             }
             m_kv_tokens.resize(kv_keep);

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -817,10 +817,25 @@ void MainPageController::SaveCurrentConversation(bool partial) {
 // not wait on tens of MB — under the hub lock, and only while the resident
 // session is still the one this conversation was built on.
 //
-// The race with a turn starting right after the switch can only WASTE the
-// file, never corrupt a reply: the snapshot stores its own token list, and
-// load_state hands it to the #170a prefix diff, so a snapshot that no longer
-// matches the rendered prompt collapses to a normal prefill.
+// #216: a fire-and-forget save races the next turn. The worker holds hub.mtx
+// for the whole generate, so if "Say hello" on a new chat starts before the
+// snapshot finishes, save_state can capture the *new* conversation's KV and
+// write it to the *old* conversation's path. On return, load_state succeeds
+// (log: restored) but the #170a prefix never matches → full re-prefill (ret ≈
+// cold). The gate under `all` surfaces this ~1/6; standalone rarely does.
+// Fix: one outstanding save future; every generate waits before touching the
+// session. Disk I/O still stays off the UI thread.
+void MainPageController::WaitKvSnapshotSave() {
+    std::future<void> f;
+    {
+        std::lock_guard<std::mutex> lk(m_kv_save_mutex);
+        if (m_kv_save_future.valid())
+            f = std::move(m_kv_save_future);
+    }
+    if (f.valid())
+        f.wait();
+}
+
 void MainPageController::SaveKvSnapshotAsync() {
     if (!m_kv_reuse || !m_kv_valid || m_current.messages.empty())
         return;
@@ -841,17 +856,22 @@ void MainPageController::SaveKvSnapshotAsync() {
     if (path.empty())
         return;
     const uint64_t gen = m_hub_generation;
-    std::thread([store, path, gen]() {
-        auto& hub = ::xllama::session_hub();
-        std::lock_guard<std::mutex> lk(hub.mtx);
-        if (!hub.session || hub.generation != gen)
-            return; // a different model is resident now — nothing of ours to save
-        std::string err;
-        if (hub.session->save_state(path, &err))
-            store.prune(::xllama::kKvStoreMaxFiles, ::xllama::kKvStoreMaxBytes);
-        else
-            ::xllama::log_output("[xllama] KV snapshot not saved: " + err + "\n");
-    }).detach();
+    // Finish any previous save before scheduling another (same path possible).
+    WaitKvSnapshotSave();
+    {
+        std::lock_guard<std::mutex> lk(m_kv_save_mutex);
+        m_kv_save_future = std::async(std::launch::async, [store, path, gen]() {
+            auto& hub = ::xllama::session_hub();
+            std::lock_guard<std::mutex> hub_lk(hub.mtx);
+            if (!hub.session || hub.generation != gen)
+                return; // a different model is resident now — nothing of ours to save
+            std::string err;
+            if (hub.session->save_state(path, &err))
+                store.prune(::xllama::kKvStoreMaxFiles, ::xllama::kKvStoreMaxBytes);
+            else
+                ::xllama::log_output("[xllama] KV snapshot not saved: " + err + "\n");
+        });
+    }
 }
 
 void MainPageController::NewChat() {
@@ -2922,6 +2942,11 @@ void MainPageController::StartInference(std::wstring const& prompt_w) {
                  sys_prefix, kv_path, dispatcher, plan_turns, user_text, system_prompt, plan_n_ctx,
                  plan_n_predict, plan_dropped]() mutable {
         try {
+            // #216: drain any #170b snapshot save before taking hub.mtx. The save
+            // also locks the hub; waiting first keeps the leave-conversation
+            // token list on the snapshot path instead of a later turn's KV.
+            self->WaitKvSnapshotSave();
+
             // One hub lock for the whole turn: the resident session cannot be
             // swapped from under us (LAN API requests report busy meanwhile,
             // exactly as they do against each other).

--- a/uwp/MainPage.h
+++ b/uwp/MainPage.h
@@ -18,6 +18,7 @@
     #include <chrono>
     #include <cstdint>
     #include <functional>
+    #include <future>
     #include <memory>
     #include <mutex>
     #include <string>
@@ -137,7 +138,11 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     void SaveCurrentConversation(bool partial = false);
     // #170b: hand the KV of the conversation we are leaving to disk, off the UI
     // thread. Call BEFORE the switch clears m_kv_valid / m_active_model.
+    // The next generate must wait (WaitKvSnapshotSave) so a follow-up turn cannot
+    // mutate the resident session before the save has copied it — that race was
+    // #216 (restored log line + full re-prefill under suite timing).
     void SaveKvSnapshotAsync();
+    void WaitKvSnapshotSave();
     // Must be called from background thread; builds/rebuilds m_session if needed.
     bool EnsureSession(const std::string& model, std::string* err_out = nullptr);
 
@@ -181,6 +186,10 @@ class MainPageController : public std::enable_shared_from_this<MainPageControlle
     bool m_kv_reuse{true};
     bool m_kv_valid{false};
     bool m_kv_last_ended_with_stop{false};
+    // Outstanding #170b save: generate waits so the snapshot path is not
+    // overwritten with a different conversation's KV (see SaveKvSnapshotAsync).
+    std::mutex m_kv_save_mutex;
+    std::future<void> m_kv_save_future;
 
     // Per-conversation CPU/GPU routing (Stage 3). The GPU (DML fp16) EP wins the
     // prefill of long prompts; the CPU EP wins decode. Routing is decided at a


### PR DESCRIPTION
## Summary

Fixes the #216 intermittent `kvsnap` failure under `validate-console.sh all`.

**Root cause:** `SaveKvSnapshotAsync` detached a save of the leave-conversation KV while the next turn (`new_chat` → `send`) could already hold `session_hub` and rewrite the resident KV. The save then wrote the *new* chat’s tokens onto the *old* chat’s snapshot path. On return, `load_state` succeeded (gate: “restored”) but #170a found no common prefix → full re-prefill (~cold tokens). Timing under `all` made this ~1/6; standalone rarely hit it.

**Fix:** keep a single `std::future` for the outstanding save; every generate waits before taking the hub lock. Session logs prefix-none; gate prints note lines for hybrid rewind / prefix miss.

## Test plan
- [x] host `ctest` (session.cpp only on Linux path)
- [ ] CI green
- [ ] Series S: `validate-console.sh kvsnap` + several `all` runs (target: no 1-in-6 shape)

Closes #216 once console stress is green.