### PR TITLE
release: v1.5.4.0 — kvsnap race, thinking evidence, #130 close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.5.4.0] - 2026-08-08
+
+Post-1.5.3 hygiene on the product path: conversation-switch KV snapshots are
+race-free under the full console suite, and the thinking tier has a measured
+happy path (catalogue `n_predict` 1024 + `thinkdone` gate). Suite is **10**
+console gates. Product ship path remains **CI MSVC**.
+
+**Upgrading from 1.5.x is a normal in-place update** (same package identity
+`GianlucaMazza.xllama`).
+
+### Changed
+
+- **#130 DML max_length valley closed as product-mitigated.** Shipping path
+  already saturates `max_length` to `n_ctx` and runs load-time DirectML warm-up
+  so in-app turns use the warm regime (`docs/uwp-constraints.md` §5c–§5e).
+  Mechanism not node-proven; deferred.
+
 ### Added
 
 - **Thinking-tier completion evidence (#223).** Catalogue

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,55 @@
+# Third-party notices — xllama
+
+This file is a draft attribution list for a possible Xbox Store / redistributed
+package. It is **not** legal advice. Verify licence texts against the versions
+actually shipped in each release (`uwp/packages.config`, `vendor/*/SHA256SUMS`,
+submodule pin).
+
+## xllama
+
+Copyright (c) Gianluca Mazza and contributors.
+Licensed under the MIT License — see `LICENSE`.
+
+## llama.cpp (ggml / GGUF inference)
+
+Copyright (c) ggml authors and contributors.
+Licensed under the MIT License.
+Source: https://github.com/ggml-org/llama.cpp
+(shipped as a git submodule; static link into the UWP binary).
+
+## Microsoft ONNX Runtime (DirectML)
+
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT License.
+Package: `Microsoft.ML.OnnxRuntime.DirectML` (see `uwp/packages.config`).
+Shipping builds may overlay a patched `onnxruntime.dll` from the
+`vendor-dlls-v1` release (AppContainer external-data fixes) — hashes in
+`vendor/onnxruntime-patched/SHA256SUMS`.
+
+## Microsoft ONNX Runtime GenerateAI (DirectML)
+
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT License.
+Package: `Microsoft.ML.OnnxRuntimeGenAI.DirectML` (see `uwp/packages.config`).
+Shipping builds may overlay a patched `onnxruntime-genai.dll` from
+`vendor-dlls-v1` (DML device fallback) — hashes in
+`vendor/onnxruntime-genai-patched/SHA256SUMS`.
+
+## Microsoft DirectML
+
+Copyright (c) Microsoft Corporation.
+Package: `Microsoft.AI.DirectML` (see `uwp/packages.config`).
+See NuGet package licence files under `uwp/packages/` when restored.
+
+## Models (not in the MSIX)
+
+Default and catalogue models are downloaded at runtime from the project
+`models-v1` release and/or Hugging Face. Each catalogue entry’s licence
+(e.g. LFM Open License, Apache-2.0 for Qwen GGUFs) applies to the weights;
+see `uwp/models/manifest.json` and any `LICENSE` file next to the asset.
+
+## Other
+
+CppWinRT NuGet projections and VCLibs are Microsoft redistributables required
+by the UWP packaging story; see AppxManifest `PackageDependency` and NuGet
+licences.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![build-linux](https://github.com/gianlucamazza/xllama/actions/workflows/build-linux.yml/badge.svg)](https://github.com/gianlucamazza/xllama/actions/workflows/build-linux.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-**Status:** shipping **v1.5.3.0** (unified + PatchedGenAI + PatchedOrt) · research-grade — [CHANGELOG](CHANGELOG.md) · [ROADMAP](ROADMAP.md) · [latest release](https://github.com/gianlucamazza/xllama/releases/tag/v1.5.3.0)
+**Status:** shipping **v1.5.4.0** (unified + PatchedGenAI + PatchedOrt) · research-grade — [CHANGELOG](CHANGELOG.md) · [ROADMAP](ROADMAP.md) · [latest release](https://github.com/gianlucamazza/xllama/releases/tag/v1.5.4.0)
 **Maintainer:** [Gianluca Mazza](https://github.com/gianlucamazza)
 
 ![xllama running on an Xbox Series S: a chat answer, the coding tier writing a C function, saved conversations and a Stable-Diffusion image, all on-console](docs/screenshots/xllama-demo-v1.5.2.gif)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,13 +5,12 @@ performance belongs in `docs/benchmarks.md`.
 
 ## Current product state
 
-- Current manifest: **1.5.3.0** under the **`GianlucaMazza.xllama`** identity
+- Current manifest: **1.5.4.0** under the **`GianlucaMazza.xllama`** identity
   (in-place update from 1.5.x; still breaking vs ≤1.4.x, see
-  `docs/install-release.md`). **v1.5.3.0** (2026-08-08): conversation titles +
-  History leak (#219), gate-log retention, dual-CRT ORT packaging architecture,
-  Phase 15 measure (W2 opt-in, W3 STREAM PASS, H6 eng parked). Previous:
-  **v1.5.2.0** (2026-07-30) Phase 14 + exact token budget + Store SKU foundation;
-  **v1.5.1.0** (2026-07-27) Phase 13; **v1.5.0.0** (2026-07-26) perf + rebrand.
+  `docs/install-release.md`). **v1.5.4.0** (2026-08-08): #216 KV snapshot save
+  race fix; #223 thinking `n_predict` 1024 + `thinkdone` (suite **10** gates);
+  #130 closed as product-mitigated. Previous: **v1.5.3.0** titles/History/dual-CRT;
+  **v1.5.2.0** Phase 14; **v1.5.1.0** Phase 13; **v1.5.0.0** perf + rebrand.
 - Shipping artifact: unified ORT GenAI + llama.cpp, with pinned patched runtime
   DLLs while upstream fixes have not reached NuGet. The UWP ggml build now
   enables `GGML_USE_CPU_REPACK` (PR #155): **GGUF prefill +62%** on Q4_K.
@@ -30,39 +29,21 @@ performance belongs in `docs/benchmarks.md`.
   (host + console marker gates PASS; pin-blocked filter-widening remains);
   Phase 11 closed the headless↔UI gap (in-app personalize + LAN API parity,
   #116/#118). Phases 13 and 14 are complete and shipped. Remaining open work:
-  Phase 15 (make the 3B–4B class usable), the #130 root-cause profile, and
-  upstream vendor pin drops.
-- **Shipped as v1.5.3.0** (tag + GitHub Release, MSIX **1.5.3.873**): conversation
-  titles, History leak (#219), demo/capture pipeline (#213/#215/#217), dual-CRT
-  packaging, train-job CI validate (#222), H6 parked (#228). Day-of-ship console
-  `validate-console.sh all` **9/9 PASS** (Series S). Linux store PE launch remains
-  open (layer 2); product packages are CI MSVC — `docs/crossbuild-console.md`.
-- **On main after v1.5.3 (not yet a new tag):** #216 KV snapshot save race
-  (PR #232, `all` ×6 PASS); #223 thinking `n_predict` 1024 + **`thinkdone`**
-  (PR #234, `thinkcut`+`thinkdone` PASS on **1.5.3.881**). Suite is **10** gates.
-- **Demo capture remains the v1.5.2 assets** (576 stills; re-record optional —
-  `check-coherence` allows a minor-version lag). Pipeline is re-runnable
-  (`demo/demo-script.json` + `scripts/capture-demo-video.sh`); Store screenshots
-  in `docs/screenshots/store/`.
+  Phase 15 research (parked eng), and upstream vendor pin drops.
+- **Shipped as v1.5.4.0:** #216 + #223 + 10-gate suite; #130 product-closed.
+  Prior tag **v1.5.3.0** (MSIX 1.5.3.873, day-of-ship 9/9) carried titles,
+  dual-CRT, H6 park. Product packages are CI MSVC — `docs/crossbuild-console.md`.
+- **Demo capture remains the v1.5.2 assets** (576 stills; re-record optional).
+  Pipeline is re-runnable (`demo/demo-script.json` + `scripts/capture-demo-video.sh`).
 
-### Next (after v1.5.3.0)
+### Next (after v1.5.4.0)
 
-**Done on main (not yet retagged):** #216 kvsnap save race (PR #232, `all` ×6);
-#223 thinking `n_predict` 1024 + `thinkdone` (PR #234). Suite is **10** gates.
-
-Open (hygiene / risks — not parked eng reopens):
-
-1. **#130 DML prefill valley** — mitigated by warm-up; mechanism profile open
-   (or explicit “mitigation-only” close).
-2. **Vendor pin drops** (#84/#85/#86) — PatchedGenAI / PatchedOrt; blocked until
-   NuGet moves (`scripts/check-vendor-nuget-status.sh`).
-3. **Store readiness** — Partner Center, App-vs-Game spike, listing copy
-   (`docs/store-readiness.md`).
-4. **Optional next cut** — 1.5.4 when the 10-gate suite is the release contract
-   and Unreleased (#216/#223) is cut.
-
-**Parked:** H6/H7 (#228); Linux store PE layer 2; prompt-lookup product default
-(OFF after W2).
+1. **Vendor pin drops** (#84/#85/#86) — blocked until NuGet moves
+   (`scripts/check-vendor-nuget-status.sh`, poll 2026-08-08: still required).
+2. **Store readiness** — Partner Center human gate; App-vs-Game spike;
+   NOTICE / listing (`docs/store-readiness.md`).
+3. **Parked eng** — H6/H7 (#228); Linux store PE layer 2; prompt-lookup default
+   OFF; Phase 15 “3B usable” without new density measure.
 
 ## Phase 7 — Peer-class model research
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,7 +126,7 @@ Spot-checked against code + evidence:
 | GPU allowlist `-v2` only                            | `dml_text_model_ok`                                       | OK                                                        |
 | NuGet 0.14.1 / 1.24.4 / DML 1.15.4                  | `packages.config`                                         | OK                                                        |
 | Decode table (94.9 / 37.9 / 18.4 / 74.8 / 44.4 / …) | `generate-benchmark-summary.py --check`                   | OK (2026-07-26: LFM post-#168 median, ORT CPU shipped-t6) |
-| Package identity `GianlucaMazza.xllama` (1.5.3.0)   | `uwp/AppxManifest.xml`; migration in `install-release.md` | OK (in-place from 1.5.x; breaking vs ≤1.4.x)              |
+| Package identity `GianlucaMazza.xllama` (1.5.4.0)   | `uwp/AppxManifest.xml`; migration in `install-release.md` | OK (in-place from 1.5.x; breaking vs ≤1.4.x)              |
 | One resident Session (GUI+API)                      | `include/xllama/session_hub.h`                            | OK (PR #161/#164)                                         |
 | H9 6/8 · 7/8 · 4/8 · 5/8                            | `phase7-h9.jsonl`                                         | OK                                                        |
 | Lane B peak_ws 1195 MB, wall 446 s                  | `phase10-console-devtrain-result.json`                    | OK                                                        |

--- a/docs/install-release.md
+++ b/docs/install-release.md
@@ -2,7 +2,7 @@
 
 How to install a tagged xllama release (see the
 [releases page](https://github.com/gianlucamazza/xllama/releases) for the current
-tag — today **[v1.5.3.0](https://github.com/gianlucamazza/xllama/releases/tag/v1.5.3.0)**)
+tag — today **[v1.5.4.0](https://github.com/gianlucamazza/xllama/releases/tag/v1.5.4.0)**)
 on an Xbox Series S|X in Dev Mode, from a Linux/macOS host. For building from
 source see the [README](../README.md#build); for Dev Mode activation and Device
 Portal basics see [device-portal.md](./device-portal.md).
@@ -25,8 +25,8 @@ Portal basics see [device-portal.md](./device-portal.md).
 From the GitHub Release page (or `gh release download vX.Y.Z`):
 
 - `xllama_X.Y.Z.<rev>_x64.msix` — the app (~19 MB, no model inside). The fourth
-  version component is the CI run stamp (e.g. `xllama_1.5.3.873_x64.msix` for
-  **v1.5.3.0**); local builds keep `.0`.
+  version component is the CI run stamp (e.g. `xllama_1.5.4.<rev>_x64.msix` for
+  **v1.5.4.0**); local builds keep `.0`.
 - `xllama-test.cer` — the signing test certificate
 - `Microsoft.VCLibs.x64.14.00.appx` — runtime dependency
 
@@ -43,7 +43,7 @@ source ~/.config/xllama/xbox-env
 # (or add it as a dependency in the same WDP install dialog as the MSIX)
 
 # App (name matches the asset on the release — revision is not always .0)
-./scripts/deploy.sh xllama_1.5.3.873_x64.msix
+./scripts/deploy.sh xllama_1.5.4.0_x64.msix   # or the CI-stamped name from the release
 ```
 
 Notes:

--- a/docs/launch-copy.md
+++ b/docs/launch-copy.md
@@ -181,7 +181,7 @@ re-deriving the fact by hand.
   test files; **215 host test cases / 2880 assertions**; **10 console validation
   gates** (`scripts/validate-console.sh` — routing, settings, gguf, longchat,
   kvsnap, coderpaste, thinkcut, thinkdone, genroom, taesd); **16 product
-  releases** since 2026-05-19, current **1.5.3.0**. Derivations:
+  releases** since 2026-05-19, current **1.5.4.0**. Derivations:
 
   ```bash
   # lines and files — src/ + include/ + uwp/ + tests/, tracked .cpp/.h only

--- a/docs/phase15-re-opt.md
+++ b/docs/phase15-re-opt.md
@@ -110,7 +110,7 @@ until APP-CRT import parity with CI is proven on device.
 | DML RMSNorm kernel | Worked around (`-v2` asset); watch driver updates |
 | Driver metacommands | Opt-out experiment FAIL; not the #91 cause |
 | ggml Q4_K CPU kernels / repack | Repack enabled (#155); decode still BW-bound |
-| #130 max_length valley mechanism | Mitigated (warm-up); profile still open |
+| #130 max_length valley mechanism | **closed** product-mitigated 2026-08-08 (§5e warm-up + max_length saturate) |
 | RDNA2 outside DirectML | **W3 M6 PASS** — own CS STREAM **119.07 GB/s** on Series S |
 
 ## Workstreams
@@ -120,7 +120,7 @@ until APP-CRT import parity with CI is proven on device.
 | WS0 | Baseline freeze + this doc | — | **done** (this file) |
 | WS-A | W2 prompt-lookup speculative | #210 | **closed for default** — host PASS; console M3 **1.04× FAIL** gate; opt-in remains |
 | WS-B | W3 gpubw STREAM + Q4 GEMV spike | #211 | **closed PASS** — STREAM **119.07 GB/s** Series S (`1.5.2.853`); Q4 GEMV moves to #228 |
-| WS-C | #130 DML valley mechanism profile | #130 | opportunistic on console |
+| WS-C | #130 DML valley mechanism profile | #130 | **closed** mitigation-only (no new RE) |
 | WS-D | H5 BitNet desk survey | — | parallel desk, no eng yet |
 | WS-E | H6/H7 GGUF GPU path | #228 | **parked** — H6.1 G1 PASS / G2 FAIL (2.15 GB/s); Decision 2026-08-08 |
 
@@ -178,7 +178,7 @@ disprove denser CS designs, but **this spike does not clear soft density ≥40**
 | M4 | Product default decision (after M3 numbers) | **OFF** (opt-in only); CHANGELOG |
 | M5 | gpubw STREAM spike (code + flag + DXIL) | **done** (eng); multi-dim Dispatch for 1 GiB; host helpers unit-tested |
 | M6 | console measure vs 100 GB/s | **PASS** — Series S **119.07 GB/s**, checksum_ok, 1024 MB, CI `1.5.2.853`; CSV `bench/results/phase15-gpubw.csv` |
-| M7 | #130 closed | §5e verdict |
+| M7 | #130 closed | **done** product-mitigated 2026-08-08 |
 | M8 | H5 survey note | go/no-go |
 | M9 | H6.1 Q4_K GEMV measure (code + flag + DXIL) | **measured** — G1 PASS / G2 FAIL |
 | M9+ | H6 full decode eng | **parked** (Decision 2026-08-08); reopen only with new density PASS or revised gate |
@@ -209,12 +209,13 @@ disprove denser CS designs, but **this spike does not clear soft density ≥40**
 | 2026-08-08 | **v1.5.3.0 shipped** (PR #230, tag `v1.5.3.0`, MSIX `1.5.3.873`): dual-CRT package architecture + AppContainer PE hygiene + History/title product fixes. Product launch remains CI MSVC. Series S `validate-console.sh all` **9/9 PASS**. W2 stays opt-in OFF; H6 remains parked. |
 | 2026-08-08 | **#216 closed** (PR #232): serialize #170b snapshot save vs next generate; Series S `all` ×6 PASS (kvsnap 551→19). |
 | 2026-08-08 | **#223 closed** (PR #234): catalogue `n_predict` 1024 + console gate `thinkdone` (short happy path); hard multi-step may still exhaust CoT. Suite **10** gates. CSV `bench/results/phase15-thinking-complete.csv`. |
+| 2026-08-08 | **#130 closed** product-mitigated (max_length saturate + dml_warmup; mechanism not node-proven). **v1.5.4.0** cut. |
 
 ## Related issues
 
 - #210 W2 prompt-lookup — **closed** (eng opt-in shipped; product default OFF after M3)
 - #211 W3 gpubw gate — **closed PASS** (119.07 GB/s); PR #227
 - #228 H6 eng follow-up — **parked** after H6.1 G2 FAIL
-- #130 DML max_length valley mechanism (mitigated by warm-up; mechanism open)
+- #130 DML max_length valley — **closed** product-mitigated 2026-08-08
 - #216 kvsnap save race — **closed** PR #232 (`all` ×6)
 - #223 thinking-tier completion — **closed** PR #234 (`thinkdone` + n_predict 1024)

--- a/docs/store-readiness.md
+++ b/docs/store-readiness.md
@@ -8,10 +8,10 @@
 
 **Status (2026-08-08):** Phase 0 discovery + Phase 1 **engineering foundation**
 landed, and the **five listing screenshots are captured** (§9). Product Dev Mode
-cut is **v1.5.3.0** (MSIX `1.5.3.873` day-of-ship; main has 10 console gates
-including `thinkdone` after #234). **Not Store-ready**
+cut is **v1.5.4.0** (10 console gates including `thinkdone`). **Not Store-ready**
 for retail: no Partner Center product, no Store-signed package, no privacy URL,
-no age rating. Dev Mode remains the only supported install path.
+no age rating. Dev Mode remains the only supported install path. Partner Center
+account / product reservation is a **human gate** before engineering listing work.
 
 **Audience for a eventual listing:** hobbyist local-LLM / homebrew Xbox users
 who should not need Dev Mode. Contributors keep the Dev Mode sideload path.
@@ -178,7 +178,7 @@ allowlist draft** — not legal advice; re-verify before submission.
 - [x] `install-latest-build.sh --store` (Linux → Device Portal)
 - [x] First-run generative-AI disclaimer (`LocalState\disclaimer.accepted`)
 - [x] Privacy draft [`privacy.md`](./privacy.md)
-- [ ] NOTICE / runtime attributions (ORT, llama.cpp, DirectML, models)
+- [x] NOTICE / runtime attributions draft (`NOTICE` at repo root — verify per release)
 - [ ] App vs Game spike results filed under `bench/results/`
 - [ ] Console smoke of store SKU (chat + model download)
 

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -325,6 +325,12 @@ warm-up run before the user's first send and the first turn pays
 prefill+decode only — confirmed on-console after the 1.5.0.0 migration (first
 DML request: prefill 873 tok/s on 961 tok, decode 23.4, both at warm parity).
 
+**#130 closed 2026-08-08 (product-mitigated).** Shipping path saturates
+`max_length` to `n_ctx` and warms at load; in-app turns do not sit in the
+interior valley. Mechanism (lazy DML compile vs other) is **not** proven
+node-level — reopen only for a profile campaign or a regression with warm-up
+off. Issue tracker: closed as mitigation-only.
+
 ### §5f — CPU threading: prefill does not scale, and t8 is worse than recorded (2026-07-21)
 
 `docs/recommended-config.md` previously recommended `intra_op_num_threads: 4`

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -15,7 +15,7 @@
   <Identity
     Name="GianlucaMazza.xllama"
     Publisher="CN=xllama-dev"
-    Version="1.5.3.0"
+    Version="1.5.4.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity


### PR DESCRIPTION
## Summary

**v1.5.4.0** release cut.

| Item | Status |
| --- | --- |
| #216 KV snapshot save race | shipped |
| #223 thinking n_predict 1024 + thinkdone | shipped (10 gates) |
| #130 DML valley | **closed product-mitigated** |
| #84/#85/#86 vendor pins | NuGet unchanged — left open with poll comment |
| Store | NOTICE draft; Partner Center still human gate |

## Test plan
- [x] check-coherence
- [ ] CI green
- [ ] Tag + GitHub release assets after merge
- [ ] Optional console smoke of 1.5.4 CI MSIX