### PR TITLE
docs: verify zero drift after v1.5.4.0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -227,24 +227,13 @@ long prompt and the CPU wins from the second turn (§5d). Evidence under
       worth a future hardening is the `max_length` saturation, expressed in two
       files (`session.cpp`, `inference.cpp`) that agree by comment rather than by a
       shared helper — not a defect today.
-- [ ] Confirm the `max_length` valley mechanism. §5e gives **strong evidence for
-      per-process lazy kernel compilation** (DirectML warms 1.64×/1.72× on the
-      second call in a process; CPU control 1.00×), which is the leading
-      hypothesis over WDDM residency — but not yet a conclusive profile. The
-      per-node profiler cannot localise it alone (the graph is one
-      `DmlFusedNode_0_0` at 96% of kernel time, §12). Tracked in #130.
-      **2026-07-25 update (PR #158):** the cost is now _paid at load_ — a
-      throwaway generate warms DML sessions inside the "loading model" phase.
-      New mechanism facts from the Session/LAN-API path (960-token request,
-      same process): the cold cost hits **decode too** (18.2 → 23.1 tok/s), and
-      a ~2-token warm-up recovers only part of it (turn-1 prefill 682 vs 899
-      tok/s warm) — the warm-up must run a real-length prompt plus decode
-      steps, i.e. compilation is at least coarsely shape-dependent. What
-      remains open here is only the _root-cause profile_, not the user-facing
-      cost. **PR #164 closed the wall-clock half**: sessions pre-load at
-      model-Ready (`PreloadSessionAsync`), so the warm-up runs before the
-      user's first send instead of inside its wait — confirmed on-console
-      (first DML request: prefill 873 tok/s, decode at warm parity).
+- [x] **Confirm the `max_length` valley mechanism — product closed 2026-08-08
+      (#130).** §5e: strong evidence for per-process lazy DML kernel compile
+      (warms 1.64×/1.72×; CPU control 1.00×); not node-proven (`DmlFusedNode`
+      ~96%). Product mitigations shipped: saturate `max_length` to `n_ctx` +
+      load-time warm-up + pre-load at model-Ready (PR #158/#164). In-app turns
+      run warm. Issue **closed** product-mitigated; reopen only for a profile
+      campaign or regression with warm-up off.
 
 ## Phase 13 — CPU prefill & KV-reuse structural campaign ✅ complete (shipped 1.5.1.0)
 

--- a/docs/crossbuild-console.md
+++ b/docs/crossbuild-console.md
@@ -10,7 +10,7 @@ Companion SSOTs: [uwp-constraints.md](uwp-constraints.md), campaign notes in
 
 | Goal | Path | Status on Series S |
 | --- | --- | --- |
-| Ship / measure product tok/s | CI MSVC `build-uwp` → `xllama-appx` → openappx pack/sign/deploy | **Launches** (shipping **v1.5.3.0**; main suite **10** gates incl. `thinkdone`) |
+| Ship / measure product tok/s | CI MSVC `build-uwp` → `xllama-appx` → openappx pack/sign/deploy | **Launches** (shipping **v1.5.4.0** / MSIX `1.5.4.887`; **10** gates incl. `thinkdone`) |
 | Compile + package from Linux | uwp-crossbuild ≥ **0.5.0** + store `/MD` + dual-CRT stage | **Links; audit PASS**; dual-CRT stage required; **store PE still fails activation** (`0x80040904`) — layer 2 |
 | hello-uwp / non-filesystem samples | uwp-crossbuild `/MT` or store `/MD` | Launches |
 
@@ -26,9 +26,9 @@ Companion SSOTs: [uwp-constraints.md](uwp-constraints.md), campaign notes in
 ## Launchable package today (shipping path)
 
 **CI MSVC (`build-uwp` → artifact `xllama-appx`) is the proven product path on
-Series S.** Measured through **v1.5.3.0** (MSIX `1.5.3.873` activates, loads GGUF,
-and passes the full console gate suite). Earlier hybrid dual-CRT probes used
-`1.5.2.x` packages (see layer table below).
+Series S.** Measured through **v1.5.4.0** (MSIX `1.5.4.887`; suite **10** gates
+including `thinkdone`). Day-of-ship **v1.5.3.0** was `1.5.3.873` (9 gates).
+Earlier hybrid dual-CRT probes used `1.5.2.x` packages (see layer table below).
 
 ## Architecture: two integrated runtimes (SSOT)
 

--- a/docs/install-release.md
+++ b/docs/install-release.md
@@ -43,7 +43,7 @@ source ~/.config/xllama/xbox-env
 # (or add it as a dependency in the same WDP install dialog as the MSIX)
 
 # App (name matches the asset on the release — revision is not always .0)
-./scripts/deploy.sh xllama_1.5.4.0_x64.msix   # or the CI-stamped name from the release
+./scripts/deploy.sh xllama_1.5.4.887_x64.msix   # name from the GitHub Release assets
 ```
 
 Notes:

--- a/docs/launch-copy.md
+++ b/docs/launch-copy.md
@@ -180,7 +180,7 @@ re-deriving the fact by hand.
 - **Scale**: **~19.9k lines of own C++ across 90 files**, of which 3.5k in 23
   test files; **215 host test cases / 2880 assertions**; **10 console validation
   gates** (`scripts/validate-console.sh` — routing, settings, gguf, longchat,
-  kvsnap, coderpaste, thinkcut, thinkdone, genroom, taesd); **16 product
+  kvsnap, coderpaste, thinkcut, thinkdone, genroom, taesd); **17 product
   releases** since 2026-05-19, current **1.5.4.0**. Derivations:
 
   ```bash

--- a/docs/model-matrix.md
+++ b/docs/model-matrix.md
@@ -127,10 +127,10 @@ Series S 2026-08-08): all **nine** console gates PASS
 title** on disk (empty-title fix in this cut). Capability figures from 1.5.2
 still hold on this package.
 
-**Post-1.5.3 hygiene (main after #232/#234, MSIX **1.5.3.881**, Series S
-2026-08-08):** **ten** console gates — the nine above plus **`thinkdone`**
-(#223). `thinkcut` + `thinkdone` both PASS; `kvsnap` stress **6× `all` PASS**
-after the #216 save race fix (PR #232). Suite entry for `all` is now 10 gates.
+**Post-1.5.3 hygiene (shipped in **v1.5.4.0**, MSIX **1.5.4.887**):** **ten**
+console gates — the nine above plus **`thinkdone`** (#223). `thinkcut` +
+`thinkdone` both PASS; `kvsnap` stress **6× `all` PASS** after the #216 save
+race fix (PR #232). Intermediate verify on 1.5.3.881 before the 1.5.4 cut.
 
 **Out of budget / deferred:** Qwen2.5-Coder-7B+, Qwen3-Coder MoE 30B+, Devstral 24B,
 DeepSeek-Coder-V2-Lite, StarCoder2 / DS-Coder 1.3B. LFM2.5-8B-A1B was on this list


### PR DESCRIPTION
## Summary

Post-release alignment pass after **v1.5.4.0**:

- crossbuild shipping → 1.5.4.0 / 1.5.4.887
- ROADMAP Phase 12 #130 → closed product-mitigated
- model-matrix re-validate → shipped in 1.5.4.0
- launch-copy **17** product releases
- install-release example matches release asset stamp

## Test plan
- [x] check-coherence
- [x] no active-doc "shipping v1.5.3" as current

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release documentation to reflect version 1.5.4.0 and MSIX build 1.5.4.887.
  * Updated installation guidance with the current MSIX filename.
  * Revised release history to reflect 17 product releases.
  * Recorded the completed `max_length` investigation and shipped performance mitigations.
  * Updated validation notes and historical package details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->