### PR TITLE
release: v1.5.5.0 — Phase 16 floor tier, pin 0865990, and the B button that closed the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.5.5.0] - 2026-08-20
+
+Phase 16 catalogue win plus the pin and probes that landed with it. Product
+ship path remains **CI MSVC**. Suite is still **10** console gates.
+
+**Upgrading from 1.5.x is a normal in-place update** (same package identity
+`GianlucaMazza.xllama`).
+
 ### Added
 
 - **Phase 16 model-scouting campaign** (`docs/phase16-model-scouting.md`) and
@@ -21,6 +29,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`gemma3-270m` H9 measured for the first time (3/8).** Its `model-matrix`
   §A1 cell had carried `—` since the model was catalogued, which is what made
   the floor-tier comparison uncomputable until now.
+- **MiniCPM5 chat renderer** (`model_is_minicpm5`: template `<s>` BOS +
+  no-think prefill). Host T1 passes both halves; T3 console bench was not
+  booked this campaign, so `minicpm5-1b` is **not** in the catalogue.
+- **`diskbw` NVMe probe** (`diskbw.flag` / `scripts/bench-diskbw.sh`). Series S
+  unbuffered read ~2.0 GB/s sequential / 1.55–1.76 GB/s random 2 MiB. SSD
+  streaming is real, narrow, and not a product path
+  (`docs/ssd-inference-assessment.md`).
+- **WS-F microphone probe** (`mic.flag` / `scripts/probe-mic.sh`).
+  `AudioGraph` opens under AppContainer; `AccessDenied` did not fire; no
+  headset was attached (`DeviceNotAvailable`). Not a verdict — #241 stays
+  open. `docs/uwp-constraints.md` §10d.
 - **Markdown formatting is gated in CI**, pinned to `prettier@3.9.6` alongside
   the existing `clang-format==22.1.5`, over every tracked `*.md`
   (`.prettierrc`, `.prettierignore`). The repo had no Markdown formatter and
@@ -28,10 +47,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- **Phase 16 WS-B closed without a `llama.cpp` pin bump.** Both
-  `arch:not-in-pin` flags raised at desk were refuted at the GGUF header
-  (`Qwen3.5-2B` converts to `general.architecture = qwen35`, which the pin
-  carries), so the predeclared trigger for a bump never fired.
+- **`llama.cpp` pin `6d5a910` → `0865990` (b10333, #244)** with UWP glue
+  (`llama-kv-cache-msa.cpp`, `llama_model_params.load_mode`, sampler
+  `n_vocab` on penalties). Phase 16 WS-B had closed without a bump — both
+  desk `arch:not-in-pin` flags were refuted at the GGUF header — and this
+  Dependabot bump is independent of that kill.
+- **H5 BitNet/low-bit survey closed NO-GO** (2026-08-10). The pin carries the
+  `bitnet` arch; no sub-4B model trained at ≤2 bits publishes weights.
+- **Phase 16 WS-E (embeddings) closed** — S-gate FAIL, no named consumer.
+  Capability exists in the pin (`nomic-bert`); the product has no surface.
+  Tracked as #242.
 
 ### Fixed
 
@@ -42,6 +67,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `recommended-config.md` enumerated a four-gate console suite that has been
   ten gates since v1.5.4.0; and the Phase 16 campaign doc had wrongly listed
   H5 (BitNet) as closed when it is an open desk survey.
+- **`deploy.sh` stop/start** actually stop and start; an unreachable console
+  and a missing CSRF token now fail instead of claiming success.
+- **Wine 11.15**: `ensure-cppwinrt-pin.sh` prefers the native cppwinrt at the
+  pin. `quantize.sh` pointed at a tree we never build.
+- **CI**: `check-coherence.py` asks git which Markdown we own; shellcheck is
+  pinned; the clang-cl ggml patch is versioned instead of carried untracked.
 
 ## [1.5.4.0] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Cancel targeted the wrong job.** `SetRunning()` is called by text
+  inference, image generation and on-device training, so `m_is_running` means
+  "a job is running", not "text is running" — and the cancel path read it and
+  set the text abort flag. Pressing Cancel (or B) during an image disabled the
+  Cancel button and left the job running, with no way left to stop it. The
+  decision is now policy in `include/xllama/cancel_policy.h`, exhaustively
+  tested on the host (`tests/test_cancel_policy.cpp`, all eight combinations of
+  the three flags) because the combination that broke is not reproducible from
+  the UI file. Suite: 222 → **225 cases / 2934 assertions**.
+
 - **The B button no longer drops out of the app.** On Xbox an unhandled
   `BackRequested` is the shell's cue to suspend and return to Home, and the
   handler only marked the event handled while an inference was running — so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The B button no longer drops out of the app.** On Xbox an unhandled
+  `BackRequested` is the shell's cue to suspend and return to Home, and the
+  handler only marked the event handled while an inference was running — so a
+  B press on an idle chat closed xllama with no warning. Completed turns are
+  already on disk, so this cost the typed-but-unsent prompt, the KV cache and a
+  full model reload, not the conversation. Every `BackRequested` is now
+  handled: B cancels a running reply and otherwise does nothing; leaving the
+  app stays on the Xbox (Guide) button (`uwp/MainPage.cpp`,
+  `docs/uwp-constraints.md` §10e, `docs/using-the-app.md`).
+
 ## [1.5.5.0] - 2026-08-20
 
 Phase 16 catalogue win plus the pin and probes that landed with it. Product

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![build-linux](https://github.com/gianlucamazza/xllama/actions/workflows/build-linux.yml/badge.svg)](https://github.com/gianlucamazza/xllama/actions/workflows/build-linux.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-**Status:** shipping **v1.5.4.0** (unified + PatchedGenAI + PatchedOrt) · research-grade — [CHANGELOG](CHANGELOG.md) · [ROADMAP](ROADMAP.md) · [latest release](https://github.com/gianlucamazza/xllama/releases/tag/v1.5.4.0)
+**Status:** shipping **v1.5.5.0** (unified + PatchedGenAI + PatchedOrt) · research-grade — [CHANGELOG](CHANGELOG.md) · [ROADMAP](ROADMAP.md) · [latest release](https://github.com/gianlucamazza/xllama/releases/tag/v1.5.5.0)
 **Maintainer:** [Gianluca Mazza](https://github.com/gianlucamazza)
 
 ![xllama running on an Xbox Series S: a chat answer, the coding tier writing a C function, saved conversations and a Stable-Diffusion image, all on-console](docs/screenshots/xllama-demo-v1.5.2.gif)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,11 +5,11 @@ performance belongs in `docs/benchmarks.md`.
 
 ## Current product state
 
-- Current manifest: **1.5.4.0** under the **`GianlucaMazza.xllama`** identity
+- Current manifest: **1.5.5.0** under the **`GianlucaMazza.xllama`** identity
   (in-place update from 1.5.x; still breaking vs ≤1.4.x, see
-  `docs/install-release.md`). **v1.5.4.0** (2026-08-08): #216 KV snapshot save
-  race fix; #223 thinking `n_predict` 1024 + `thinkdone` (suite **10** gates);
-  #130 closed as product-mitigated. Previous: **v1.5.3.0** titles/History/dual-CRT;
+  `docs/install-release.md`). **v1.5.5.0** (2026-08-20): Phase 16 floor
+  `lfm25-230m`; llama.cpp pin `0865990`; diskbw + mic probes. Previous:
+  **v1.5.4.0** #216/#223/10-gate suite; **v1.5.3.0** titles/History/dual-CRT;
   **v1.5.2.0** Phase 14; **v1.5.1.0** Phase 13; **v1.5.0.0** perf + rebrand.
 - Shipping artifact: unified ORT GenAI + llama.cpp, with pinned patched runtime
   DLLs while upstream fixes have not reached NuGet. The UWP ggml build now
@@ -28,24 +28,28 @@ performance belongs in `docs/benchmarks.md`.
 - Phases 1–11 are complete for product code: Phase 10 Lane B is `available`
   (host + console marker gates PASS; pin-blocked filter-widening remains);
   Phase 11 closed the headless↔UI gap (in-app personalize + LAN API parity,
-  #116/#118). Phases 13 and 14 are complete and shipped. Remaining open work:
-  Phase 15 research (parked eng), and upstream vendor pin drops.
-- **Shipped as v1.5.4.0:** #216 + #223 + 10-gate suite; #130 product-closed.
-  Prior tag **v1.5.3.0** (MSIX 1.5.3.873, day-of-ship 9/9) carried titles,
-  dual-CRT, H6 park. Product packages are CI MSVC — `docs/crossbuild-console.md`.
+  #116/#118). Phases 13, 14 and 16 (one shipped model) are complete. Remaining
+  open work: Phase 15 parked eng, WS-F headset measurement (#241), and
+  upstream vendor pin drops.
+- **Shipped as v1.5.5.0:** Phase 16 `lfm25-230m` floor + pin `0865990`. Prior
+  tag **v1.5.4.0** (MSIX 1.5.4.887) carried #216/#223 and the 10-gate suite.
+  Product packages are CI MSVC — `docs/crossbuild-console.md`.
 - **Demo capture remains the v1.5.2 assets** (576 stills; re-record optional).
   Pipeline is re-runnable (`demo/demo-script.json` + `scripts/capture-demo-video.sh`).
 
-### Next (after v1.5.4.0)
+### Next (after v1.5.5.0)
 
 1. **Vendor pin drops** (#84/#85/#86) — blocked until NuGet moves
-   (`scripts/check-vendor-nuget-status.sh`, poll 2026-08-08: still required).
+   (`scripts/check-vendor-nuget-status.sh`, poll 2026-08-20: still required).
 2. **Store readiness** — Partner Center human gate; App-vs-Game spike;
    NOTICE / listing (`docs/store-readiness.md`).
-3. **Parked eng** — H6/H7 (#228); crossbuild product parity (layer 2 closed
-   2026-08-08 by uwp-crossbuild 0.5.1 — launch proven, ORT/GenAI + first boot
-   - uptime not); prompt-lookup default OFF; Phase 15 “3B usable” without new
-     density measure.
+3. **WS-F headset** (#241) — rerun `scripts/probe-mic.sh` with a microphone
+   attached. Two room-empty runs (2026-08-10, 2026-08-20) are not a verdict.
+4. **Parked eng** — H6/H7 (#228); crossbuild product parity (layer 2 closed
+   2026-08-08 by uwp-crossbuild 0.5.1 — launch proven; ORT/GenAI, first boot
+   and uptime not); prompt-lookup default OFF; Phase 15 “3B usable” without a
+   new density measure. Dependabot llama.cpp #247 fails UWP (`LLAMA_VERSION`);
+   do not merge on Linux green.
 
 ## Phase 7 — Peer-class model research
 
@@ -514,8 +518,8 @@ classes and with a console budget capped at ≤9 bench sessions.
       `lfm25-230m` is the new **floor** tier — faster and lighter than
       `gemma3-270m` on both axes, one H9 task below it. Figures live in
       [`docs/benchmarks.md`](docs/benchmarks.md), which is their SSOT.
-      Qwen3.5-2B and Maincoder-1B measured FAIL; MiniCPM5-1B deferred on
-      unbought renderer work. 3 of ≤4 sessions spent.
+      Qwen3.5-2B and Maincoder-1B measured FAIL; MiniCPM5-1B renderer
+      shipped (15 lines) but T3 was not booked. 3 of ≤4 sessions spent.
 - [x] **WS-B (H16.2) — `llama.cpp` pin bump evaluation.** **Closed 2026-08-10,
       not motivated.** Both T0 arch flags were refuted at the GGUF header
       (`Qwen3.5-2B` converts to `qwen35`, which the pin carries); no candidate
@@ -526,12 +530,12 @@ classes and with a console budget capped at ≤9 bench sessions.
 - [x] **WS-D (H16.4) — diffusion successor.** **Closed on its own kill:** no
       candidate has a usable 3-component ONNX export. SDXL-Turbo fails the 2 GB
       protobuf limit, not the GPU budget; SD3.5/Flux are monolithic DiT.
-- [~] **WS-E (H16.5) — embedding surface.** **Blocked on a product decision,**
-  not on technology: `nomic-embed-text-v1.5` is verified config-only at
-  156 MB, but nobody has named who consumes the vectors, where they live, or
-  how a second `llama_context` survives the one-resident-model rule. Tracked as
-  [#242](https://github.com/gianlucamazza/xllama/issues/242) — the card's kill
-  fires by inaction, so without an owner it expires rather than closing.
+- [x] **WS-E (H16.5) — embedding surface.** **Closed 2026-08-20, S-gate FAIL.**
+      No named consumer. The pin carries `nomic-bert` and nomic-embed-text-v1.5 is
+      config-only at 156 MB — a capability, not a product surface. SessionHub
+      owns one resident Session; an embedding model is a second `llama_context`.
+      Kill: close before download. Reopen only with a named consumer **and** a
+      memory plan that keeps peak ≤3.5 GB with one resident model. #242.
 - [~] **WS-F (H16.6) — ASR surface.** **Probe written and run 2026-08-10; one
   measurement short.** The `microphone` capability installs, `AudioGraph` opens
   under AppContainer at 48 kHz stereo, and `AccessDenied` — the way the sandbox

--- a/docs/README.md
+++ b/docs/README.md
@@ -130,7 +130,7 @@ Spot-checked against code + evidence:
 | GPU allowlist `-v2` only                            | `dml_text_model_ok`                                       | OK                                                        |
 | NuGet 0.14.1 / 1.24.4 / DML 1.15.4                  | `packages.config`                                         | OK                                                        |
 | Decode table (94.9 / 37.9 / 18.4 / 74.8 / 44.4 / …) | `generate-benchmark-summary.py --check`                   | OK (2026-07-26: LFM post-#168 median, ORT CPU shipped-t6) |
-| Package identity `GianlucaMazza.xllama` (1.5.4.0)   | `uwp/AppxManifest.xml`; migration in `install-release.md` | OK (in-place from 1.5.x; breaking vs ≤1.4.x)              |
+| Package identity `GianlucaMazza.xllama` (1.5.5.0)   | `uwp/AppxManifest.xml`; migration in `install-release.md` | OK (in-place from 1.5.x; breaking vs ≤1.4.x)              |
 | One resident Session (GUI+API)                      | `include/xllama/session_hub.h`                            | OK (PR #161/#164)                                         |
 | H9 6/8 · 7/8 · 4/8 · 5/8                            | `phase7-h9.jsonl`                                         | OK                                                        |
 | Lane B peak_ws 1195 MB, wall 446 s                  | `phase10-console-devtrain-result.json`                    | OK                                                        |

--- a/docs/crossbuild-console.md
+++ b/docs/crossbuild-console.md
@@ -10,7 +10,7 @@ Companion SSOTs: [uwp-constraints.md](uwp-constraints.md), campaign notes in
 
 | Goal                               | Path                                                            | Status on Series S                                                                                                                                                                                           |
 | ---------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Ship / measure product tok/s       | CI MSVC `build-uwp` → `xllama-appx` → openappx pack/sign/deploy | **Launches** (shipping **v1.5.4.0** / MSIX `1.5.4.887`; **10** gates incl. `thinkdone`)                                                                                                                      |
+| Ship / measure product tok/s       | CI MSVC `build-uwp` → `xllama-appx` → openappx pack/sign/deploy | **Launches** (shipping **v1.5.5.0**; last 10-gate evidence **v1.5.4.0** / MSIX `1.5.4.887` incl. `thinkdone`)                                                                                                |
 | Compile + package from Linux       | uwp-crossbuild ≥ **0.5.1** + store `/MD` + dual-CRT stage       | **Launches** (observed 2026-08-08 after 0.5.1's ntdll reroutes: window activated, GGUF model loaded). Unproven: ORT/GenAI backends, first-boot provisioning, long uptime — product measurement stays CI MSVC |
 | hello-uwp / non-filesystem samples | uwp-crossbuild `/MT` or store `/MD`                             | Launches                                                                                                                                                                                                     |
 
@@ -28,7 +28,8 @@ Companion SSOTs: [uwp-constraints.md](uwp-constraints.md), campaign notes in
 ## Launchable package today (shipping path)
 
 **CI MSVC (`build-uwp` → artifact `xllama-appx`) is the proven product path on
-Series S.** Measured through **v1.5.4.0** (MSIX `1.5.4.887`; suite **10** gates
+Series S.** Current cut **v1.5.5.0**. Last 10-gate evidence **v1.5.4.0** (MSIX
+`1.5.4.887`; suite **10** gates
 including `thinkdone`). Day-of-ship **v1.5.3.0** was `1.5.3.873` (9 gates).
 Earlier hybrid dual-CRT probes used `1.5.2.x` packages (see layer table below).
 

--- a/docs/install-release.md
+++ b/docs/install-release.md
@@ -2,7 +2,7 @@
 
 How to install a tagged xllama release (see the
 [releases page](https://github.com/gianlucamazza/xllama/releases) for the current
-tag — today **[v1.5.4.0](https://github.com/gianlucamazza/xllama/releases/tag/v1.5.4.0)**)
+tag — today **[v1.5.5.0](https://github.com/gianlucamazza/xllama/releases/tag/v1.5.5.0)**)
 on an Xbox Series S|X in Dev Mode, from a Linux/macOS host. For building from
 source see the [README](../README.md#build); for Dev Mode activation and Device
 Portal basics see [device-portal.md](./device-portal.md).
@@ -25,8 +25,8 @@ Portal basics see [device-portal.md](./device-portal.md).
 From the GitHub Release page (or `gh release download vX.Y.Z`):
 
 - `xllama_X.Y.Z.<rev>_x64.msix` — the app (~19 MB, no model inside). The fourth
-  version component is the CI run stamp (e.g. `xllama_1.5.4.<rev>_x64.msix` for
-  **v1.5.4.0**); local builds keep `.0`.
+  version component is the CI run stamp (e.g. `xllama_1.5.5.<rev>_x64.msix` for
+  **v1.5.5.0**); local builds keep `.0`.
 - `xllama-test.cer` — the signing test certificate
 - `Microsoft.VCLibs.x64.14.00.appx` — runtime dependency
 
@@ -43,7 +43,7 @@ source ~/.config/xllama/xbox-env
 # (or add it as a dependency in the same WDP install dialog as the MSIX)
 
 # App (name matches the asset on the release — revision is not always .0)
-./scripts/deploy.sh xllama_1.5.4.887_x64.msix   # name from the GitHub Release assets
+./scripts/deploy.sh xllama_1.5.5.<rev>_x64.msix   # name from the GitHub Release assets
 ```
 
 Notes:

--- a/docs/install-release.md
+++ b/docs/install-release.md
@@ -25,9 +25,9 @@ Portal basics see [device-portal.md](./device-portal.md).
 From the GitHub Release page (or `gh release download vX.Y.Z`):
 
 - `xllama_X.Y.Z.REV_x64.msix` — the app (~19 MB, no model inside). The fourth
-  version component `REV` is the CI run stamp (so a **v1.5.5.0** asset is named
-  `xllama_1.5.5.887_x64.msix` or similar); local builds keep `.0`. `REV` is a
-  placeholder, not a literal: read the real name off the release page.
+  component `REV` is the CI run stamp and differs per release; local builds keep
+  `.0`. Read the real name off the release page, or let the shell below derive
+  it from the file you downloaded.
 - `xllama-test.cer` — the signing test certificate
 - `Microsoft.VCLibs.x64.14.00.appx` — runtime dependency
 
@@ -43,10 +43,11 @@ source ~/.config/xllama/xbox-env
 #   https://<XBOX_IP>:11443 → My games & apps → Install → Microsoft.VCLibs.x64.14.00.appx
 # (or add it as a dependency in the same WDP install dialog as the MSIX)
 
-# App — set REV to the revision on the release page (it is not always .0);
-# angle brackets would be shell redirection, so this is a quoted variable
-REV=887
-./scripts/deploy.sh "xllama_1.5.5.${REV}_x64.msix"
+# App — derive the name from what you downloaded rather than typing a
+# revision. The fourth component is a CI run stamp, so hard-coding one here
+# would be wrong for every release but the one it was written for.
+MSIX=$(ls -1 xllama_*_x64.msix | head -1)
+./scripts/deploy.sh "$MSIX"
 ```
 
 Notes:

--- a/docs/install-release.md
+++ b/docs/install-release.md
@@ -24,9 +24,10 @@ Portal basics see [device-portal.md](./device-portal.md).
 
 From the GitHub Release page (or `gh release download vX.Y.Z`):
 
-- `xllama_X.Y.Z.<rev>_x64.msix` — the app (~19 MB, no model inside). The fourth
-  version component is the CI run stamp (e.g. `xllama_1.5.5.<rev>_x64.msix` for
-  **v1.5.5.0**); local builds keep `.0`.
+- `xllama_X.Y.Z.REV_x64.msix` — the app (~19 MB, no model inside). The fourth
+  version component `REV` is the CI run stamp (so a **v1.5.5.0** asset is named
+  `xllama_1.5.5.887_x64.msix` or similar); local builds keep `.0`. `REV` is a
+  placeholder, not a literal: read the real name off the release page.
 - `xllama-test.cer` — the signing test certificate
 - `Microsoft.VCLibs.x64.14.00.appx` — runtime dependency
 
@@ -42,8 +43,10 @@ source ~/.config/xllama/xbox-env
 #   https://<XBOX_IP>:11443 → My games & apps → Install → Microsoft.VCLibs.x64.14.00.appx
 # (or add it as a dependency in the same WDP install dialog as the MSIX)
 
-# App (name matches the asset on the release — revision is not always .0)
-./scripts/deploy.sh xllama_1.5.5.<rev>_x64.msix   # name from the GitHub Release assets
+# App — set REV to the revision on the release page (it is not always .0);
+# angle brackets would be shell redirection, so this is a quoted variable
+REV=887
+./scripts/deploy.sh "xllama_1.5.5.${REV}_x64.msix"
 ```
 
 Notes:

--- a/docs/launch-copy.md
+++ b/docs/launch-copy.md
@@ -180,8 +180,8 @@ re-deriving the fact by hand.
 - **Scale**: **~19.9k lines of own C++ across 90 files**, of which 3.5k in 23
   test files; **222 host test cases / 2923 assertions**; **10 console validation
   gates** (`scripts/validate-console.sh` — routing, settings, gguf, longchat,
-  kvsnap, coderpaste, thinkcut, thinkdone, genroom, taesd); **17 product
-  releases** since 2026-05-19, current **1.5.4.0**. Derivations:
+  kvsnap, coderpaste, thinkcut, thinkdone, genroom, taesd); **18 product
+  releases** since 2026-05-19, current **1.5.5.0**. Derivations:
 
   ```bash
   # lines and files — src/ + include/ + uwp/ + tests/, tracked .cpp/.h only

--- a/docs/launch-copy.md
+++ b/docs/launch-copy.md
@@ -198,7 +198,7 @@ re-deriving the fact by hand.
 - **Build fixes**: repack 241.9 → 393.2 tok/s (#155); `n_threads_batch`
   390.7 → 438.1 at P=298 (#168).
 - **Scale**: **~19.9k lines of own C++ across 90 files**, of which 3.5k in 23
-  test files; **222 host test cases / 2923 assertions**; **10 console validation
+  test files; **225 host test cases / 2934 assertions**; **10 console validation
   gates** (`scripts/validate-console.sh` — routing, settings, gguf, longchat,
   kvsnap, coderpaste, thinkcut, thinkdone, genroom, taesd); **18 product
   releases** since 2026-05-19, current **1.5.5.0**. Derivations:

--- a/docs/launch-copy.md
+++ b/docs/launch-copy.md
@@ -162,6 +162,114 @@ the answer. This is the part of the plan that cannot be delegated or rushed.
 
 ---
 
+## C. LinkedIn (2026-08-20)
+
+**Why this one is different from A and B.** Show HN stalled at **2 points** and
+the r/LocalLLM link post was removed by the sitewide spam filter. Neither reached
+anyone. LinkedIn is the only platform where the author has a real network instead
+of a zero-history account, so this is effectively the project's first public
+communication that can be read at all. **Do not cite the HN thread as social
+proof** — 2 points is not proof of anything, and anyone who clicks will see that.
+
+**Mechanics**, which shape the copy as much as the content:
+
+- **No link in the post body.** LinkedIn suppresses reach on posts with outbound
+  links. The repo URL goes in the **first comment**, posted immediately after.
+- **Media: native video**, `docs/screenshots/xllama-demo-v1.5.2.mp4` (580 kB) —
+  not the 2.4 MB GIF, which LinkedIn recompresses worse. The capture is already
+  real time, and saying so is on-message: it is the evidence for a performance
+  claim, so it must not be sped up.
+- Only the first ~210 characters show before the "…see more" fold. The hook has
+  to carry the shipped result on its own.
+- At most 3 hashtags, at the end.
+
+### Body
+
+Measured at **2,996 characters** — LinkedIn's cap is 3,000, so there is almost
+no room to add. Cut something before adding anything.
+
+> An Xbox Series S runs a local LLM at 94.9 tokens/second, on the CPU.
+>
+> Not a benchmark script — an installable app, eighteen releases in, with ten
+> validation gates that run on the console.
+>
+> It's called xllama: local LLM chat and Stable Diffusion image generation on an
+> Xbox Series S|X in Dev Mode. llama.cpp for GGUF, ONNX Runtime GenAI for CPU
+> int4 and DirectML, a catalogue from 270M to 3B, no cloud.
+>
+> Prior art first: Andrei David ran llama2.c on an Xbox 360
+> in January 2025 — a proof of concept on 2005 hardware, PowerPC with 512 MB.
+> This is a 2020 Series S: 8 Zen 2 cores with AVX2, RDNA 2, 10 GB unified.
+> Different machine, different problem, different artefact. When I started I
+> could not find a prior LLM runtime for Series S|X — a statement about my
+> search, not a claim of being first.
+>
+> Barrier: Xbox Dev Mode, a one-time ~$19 activation via Partner Center. No
+> retail-console path, and I'm not affiliated with Microsoft.
+>
+> The result I didn't expect. Same model (SmolLM2-360M), three backends:
+>
+> CPU int4 — 74.8 tok/s
+> GPU fp16 — 44.4 tok/s
+> GPU int4 — 8.8 tok/s
+>
+> The GPU loses at generation — and it isn't a silent CPU fallback: the
+> ORT profile puts 96% of kernel time on the DirectML provider. DirectML does
+> int4 matmul as a dequantize to fp16 plus a full GEMM, materialising the fp16
+> tensor in VRAM. In memory-bound decode that reads 4 bits, writes a whole fp16
+> matrix and reads it back — strictly more bandwidth than plain fp16.
+> Quantisation makes it slower. The GPU still wins at prefill and diffusion.
+>
+> Why I trust those numbers is the part I'd defend.
+>
+> Every hypothesis carries a kill condition written before any engineering:
+> claim, measure, PASS, FAIL, kill. Last scouting campaign, four of seven
+> workstreams died on their own conditions — two without downloading anything,
+> because you argue a product surface exists before you benchmark one. Negative
+> results are deliverables, kept in permanent "do not reopen" lists. And every
+> published number carries the command that reproduces it, with CI failing
+> closed on drift — because a test count in my own docs once sat 16 cases behind
+> reality.
+>
+> My favourite case: a microphone probe returned DeviceNotAvailable and I
+> refused to score it. That's a fact about the room — no headset plugged in —
+> not about the sandbox. A boolean probe would have returned false and killed
+> the workstream on a test that never reached the mic.
+>
+> What I got wrong: I shipped numerically wrong logits for weeks, because I was
+> only measuring tokens per second. Root cause was a broken RMSNorm lowering in
+> DirectML. Throughput is not correctness, and a plausible sentence is not
+> evidence.
+>
+> Limits: Dev Mode only, research-grade. The LAN endpoint is
+> unauthenticated and off by default. Most benchmark rows are single runs — the
+> headline is n=3.
+>
+> Real question for people who do this: what would you run on a fixed 10 GB
+> unified-memory box with no NPU?
+>
+> Non-native speaker; I used an LLM to help draft this. The work and the
+> measurements are mine.
+>
+> #LocalLLM #EdgeAI
+
+### First comment (post immediately)
+
+> Repo, benchmarks and the full measurement write-up:
+> https://github.com/gianlucamazza/xllama
+
+### Before posting
+
+- Re-derive **94.9 / 74.8 / 44.4 / 8.8** from `docs/benchmarks.md`, which is
+  generated. Do not trust the copy above — it goes stale by design.
+- **v1.5.5.0 must be tagged and its release assets uploaded first.** The first
+  comment sends people to the repo, and the releases page has to match what the
+  post claims.
+- Re-check the release count with the command in "Reference facts" **after**
+  `gh release create`, not before.
+
+---
+
 ## Reference facts (verified 2026-07-30)
 
 Every countable figure below carries the command that produces it. That is the
@@ -193,8 +301,13 @@ re-deriving the fact by hand.
   ./build/linux-test/tests/xllama-tests | tail -2
   # gates
   grep -cE '^\w+\) run_gate ' scripts/validate-console.sh
-  # product releases — total tags minus the two asset-only ones
-  gh release list --limit 60 --json tagName --jq 'length'
+  # product releases — version tags only. Do NOT filter on startswith("v"):
+  # `vendor-dlls-v1` starts with a v too, so that filter returns the right
+  # number for the wrong reason. `models-v1` and `vendor-dlls-v1` are payload
+  # drops, not releases. Reads one less until the cut being announced is
+  # published, so run it after `gh release create`.
+  gh release list --limit 60 --json tagName \
+    --jq '[.[] | select(.tagName | test("^v[0-9]"))] | length'
   ```
 
   The test-case figure is additionally guarded in CI: `build-linux.yml` compares

--- a/docs/launch-copy.md
+++ b/docs/launch-copy.md
@@ -18,6 +18,26 @@ native format, while r/LocalLLaMA Rule 4 caps self-promotion at ~10% of an
 account's content — and this account has none. A Show HN thread also gives the
 Reddit post something real to reference.
 
+**Attempt 2 — Show HN, 2026-07-27: published, and it stalled at 2 points.**
+The submission is live and the write-up is good; it simply did not reach
+anyone. That is the honest outcome and it is recorded here rather than quietly
+dropped, because the next channel has to be planned against it: **the Show HN
+thread is not social proof and must not be cited as such.** Anyone who follows
+the link sees the score. Two attempts, two channels, zero reach — the binding
+constraint is not the copy, it is posting from accounts with no history.
+
+**Where the unpublished drafts live.** They are not in this repo. A reader who
+finds a post and then opens the repo would find that post's own script,
+tactics included, which makes an honest post read as staged. Rule adopted
+2026-08-20:
+
+> Drafts stay local until they are posted. Once posted, the copy and its
+> outcome become public record here.
+
+Sections A and B stay because both were published. The next draft lives in the
+author's personal vault until it goes out; the claim rules below are its SSOT
+either way, and are not duplicated there.
+
 **Two claims that must not be made**, because they are false or unprovable:
 
 - _"First LLM on an Xbox."_ Andrei David ran `llama2.c` on an **Xbox 360** in
@@ -159,114 +179,6 @@ Reuse the Show HN comment above with three changes:
 Rule 4 caps self-promotion at ~10% of an account's content. Before posting, build
 some genuine participation in the sub — answer questions where you actually know
 the answer. This is the part of the plan that cannot be delegated or rushed.
-
----
-
-## C. LinkedIn (2026-08-20)
-
-**Why this one is different from A and B.** Show HN stalled at **2 points** and
-the r/LocalLLM link post was removed by the sitewide spam filter. Neither reached
-anyone. LinkedIn is the only platform where the author has a real network instead
-of a zero-history account, so this is effectively the project's first public
-communication that can be read at all. **Do not cite the HN thread as social
-proof** — 2 points is not proof of anything, and anyone who clicks will see that.
-
-**Mechanics**, which shape the copy as much as the content:
-
-- **No link in the post body.** LinkedIn suppresses reach on posts with outbound
-  links. The repo URL goes in the **first comment**, posted immediately after.
-- **Media: native video**, `docs/screenshots/xllama-demo-v1.5.2.mp4` (580 kB) —
-  not the 2.4 MB GIF, which LinkedIn recompresses worse. The capture is already
-  real time, and saying so is on-message: it is the evidence for a performance
-  claim, so it must not be sped up.
-- Only the first ~210 characters show before the "…see more" fold. The hook has
-  to carry the shipped result on its own.
-- At most 3 hashtags, at the end.
-
-### Body
-
-Measured at **2,996 characters** — LinkedIn's cap is 3,000, so there is almost
-no room to add. Cut something before adding anything.
-
-> An Xbox Series S runs a local LLM at 94.9 tokens/second, on the CPU.
->
-> Not a benchmark script — an installable app, eighteen releases in, with ten
-> validation gates that run on the console.
->
-> It's called xllama: local LLM chat and Stable Diffusion image generation on an
-> Xbox Series S|X in Dev Mode. llama.cpp for GGUF, ONNX Runtime GenAI for CPU
-> int4 and DirectML, a catalogue from 270M to 3B, no cloud.
->
-> Prior art first: Andrei David ran llama2.c on an Xbox 360
-> in January 2025 — a proof of concept on 2005 hardware, PowerPC with 512 MB.
-> This is a 2020 Series S: 8 Zen 2 cores with AVX2, RDNA 2, 10 GB unified.
-> Different machine, different problem, different artefact. When I started I
-> could not find a prior LLM runtime for Series S|X — a statement about my
-> search, not a claim of being first.
->
-> Barrier: Xbox Dev Mode, a one-time ~$19 activation via Partner Center. No
-> retail-console path, and I'm not affiliated with Microsoft.
->
-> The result I didn't expect. Same model (SmolLM2-360M), three backends:
->
-> CPU int4 — 74.8 tok/s
-> GPU fp16 — 44.4 tok/s
-> GPU int4 — 8.8 tok/s
->
-> The GPU loses at generation — and it isn't a silent CPU fallback: the
-> ORT profile puts 96% of kernel time on the DirectML provider. DirectML does
-> int4 matmul as a dequantize to fp16 plus a full GEMM, materialising the fp16
-> tensor in VRAM. In memory-bound decode that reads 4 bits, writes a whole fp16
-> matrix and reads it back — strictly more bandwidth than plain fp16.
-> Quantisation makes it slower. The GPU still wins at prefill and diffusion.
->
-> Why I trust those numbers is the part I'd defend.
->
-> Every hypothesis carries a kill condition written before any engineering:
-> claim, measure, PASS, FAIL, kill. Last scouting campaign, four of seven
-> workstreams died on their own conditions — two without downloading anything,
-> because you argue a product surface exists before you benchmark one. Negative
-> results are deliverables, kept in permanent "do not reopen" lists. And every
-> published number carries the command that reproduces it, with CI failing
-> closed on drift — because a test count in my own docs once sat 16 cases behind
-> reality.
->
-> My favourite case: a microphone probe returned DeviceNotAvailable and I
-> refused to score it. That's a fact about the room — no headset plugged in —
-> not about the sandbox. A boolean probe would have returned false and killed
-> the workstream on a test that never reached the mic.
->
-> What I got wrong: I shipped numerically wrong logits for weeks, because I was
-> only measuring tokens per second. Root cause was a broken RMSNorm lowering in
-> DirectML. Throughput is not correctness, and a plausible sentence is not
-> evidence.
->
-> Limits: Dev Mode only, research-grade. The LAN endpoint is
-> unauthenticated and off by default. Most benchmark rows are single runs — the
-> headline is n=3.
->
-> Real question for people who do this: what would you run on a fixed 10 GB
-> unified-memory box with no NPU?
->
-> Non-native speaker; I used an LLM to help draft this. The work and the
-> measurements are mine.
->
-> #LocalLLM #EdgeAI
-
-### First comment (post immediately)
-
-> Repo, benchmarks and the full measurement write-up:
-> https://github.com/gianlucamazza/xllama
-
-### Before posting
-
-- Re-derive **94.9 / 74.8 / 44.4 / 8.8** from `docs/benchmarks.md`, which is
-  generated. Do not trust the copy above — it goes stale by design.
-- **v1.5.5.0 must be tagged and its release assets uploaded first.** The first
-  comment sends people to the repo, and the releases page has to match what the
-  post claims.
-- Re-check the release count with the command in "Reference facts" **after**
-  `gh release create`, not before.
 
 ---
 

--- a/docs/model-matrix.md
+++ b/docs/model-matrix.md
@@ -13,10 +13,10 @@ ids, templates, licenses, and campaign notes** — not runtime contracts.
 | Catalogue data                                                 | [`../uwp/models/manifest.json`](../uwp/models/manifest.json) |
 | Tok/s tables                                                   | [benchmarks.md](./benchmarks.md) only                        |
 
-Last updated: **2026-08-10**. Newest entries: §A1 `lfm25-230m` shipped as the
-floor tier and `gemma3-270m`'s H9 measured for the first time, §E the floor role,
-§F the Phase 16 verdicts (all 2026-08-10); then §A3 H2 MoE FAIL (2026-07-30),
-§D per-arch `can_shift` (2026-07-29), §A2 phase14 console validation (2026-07-27).
+Last updated: **2026-08-20**. Newest entries: §F MiniCPM5 renderer shipped /
+T3 not booked, WS-E closed (no consumer); then §A1 `lfm25-230m` shipped as the
+floor tier and `gemma3-270m`'s H9 measured (2026-08-10), §A3 H2 MoE FAIL
+(2026-07-30), §D per-arch `can_shift` (2026-07-29), §A2 phase14 (2026-07-27).
 
 ## How to read the columns
 
@@ -235,16 +235,16 @@ shifts.
 **Phase 16 (desk + measured, 2026-08-10)** — campaign SSOT:
 [phase16-model-scouting.md](phase16-model-scouting.md).
 
-| Candidate                        | Decision                 | Reason                                                                                                                        |
-| -------------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| Qwen3.5-2B (`unsloth` Q4_K_M)    | reject — measured        | H16.1a FAIL on both halves: `peak_ws_mb` 1421 > 1398 and decode 19.25 < 19.6 (`phase16-gguf`)                                 |
-| Maincoder-1B (`Maincode` Q4_K_M) | reject — measured        | H16.1b: memory passes (843 ≤ 900) but decode 33.49 < the card's 33.9 (1.283× vs a 1.3× bar) (`phase16-gguf`)                  |
-| MiniCPM5-1B (`openbmb`)          | defer — unbought cost    | H16.1d: needs BOTH an `<s>` BOS field and a no-think prefill in the renderer; measured, not assumed. No console session spent |
-| SmolLM3-3B GGUF (ggml-org)       | reject — cost not bought | WS-A's ≤4 slots allocated; loses the 4th head-to-head to MiniCPM5-1B; self-set PASS bar of H9 8/8 (catalogue best is 7/8)     |
-| EmbeddingGemma-300M (ggml-org)   | reject — licence         | Origin repo `gated: manual` (anon HEAD 401), so a console download is impossible; the ungated mirror ships no licence/notice  |
-| Supra2-100M-Instruct             | reject — duplicate bet   | Same floor role as `lfm25-230m`; ~30 MB of projected gain needs an in-house quant, a re-host and a name-matched stop token    |
-| granite-embedding-english-r2     | reject — duplicate bet   | Same WS-E slot as nomic-embed-text-v1.5 at +15 MB and new-renderer cost; its own FAIL branch concedes to nomic                |
-| multilingual-e5-small            | reject — duplicate bet   | Same WS-E slot; the multilingual axis has no named consumer, and its GGUF tokenizer is SPM over an XLM-R Unigram vocabulary   |
+| Candidate                        | Decision                 | Reason                                                                                                                       |
+| -------------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| Qwen3.5-2B (`unsloth` Q4_K_M)    | reject — measured        | H16.1a FAIL on both halves: `peak_ws_mb` 1421 > 1398 and decode 19.25 < 19.6 (`phase16-gguf`)                                |
+| Maincoder-1B (`Maincode` Q4_K_M) | reject — measured        | H16.1b: memory passes (843 ≤ 900) but decode 33.49 < the card's 33.9 (1.283× vs a 1.3× bar) (`phase16-gguf`)                 |
+| MiniCPM5-1B (`openbmb`)          | defer — T3 not booked    | H16.1d renderer shipped 2026-08-10 (15 lines: `<s>` BOS + no-think). Host T1 PASS. No console session spent this campaign    |
+| SmolLM3-3B GGUF (ggml-org)       | reject — cost not bought | WS-A's ≤4 slots allocated; loses the 4th head-to-head to MiniCPM5-1B; self-set PASS bar of H9 8/8 (catalogue best is 7/8)    |
+| EmbeddingGemma-300M (ggml-org)   | reject — licence         | Origin repo `gated: manual` (anon HEAD 401), so a console download is impossible; the ungated mirror ships no licence/notice |
+| Supra2-100M-Instruct             | reject — duplicate bet   | Same floor role as `lfm25-230m`; ~30 MB of projected gain needs an in-house quant, a re-host and a name-matched stop token   |
+| granite-embedding-english-r2     | reject — duplicate bet   | Same WS-E slot as nomic-embed-text-v1.5 at +15 MB and new-renderer cost; its own FAIL branch concedes to nomic               |
+| multilingual-e5-small            | reject — duplicate bet   | Same WS-E slot; the multilingual axis has no named consumer, and its GGUF tokenizer is SPM over an XLM-R Unigram vocabulary  |
 
 ---
 
@@ -262,8 +262,8 @@ shifts.
    ([phase16-model-scouting.md](phase16-model-scouting.md)) closed with one model
    shipped (`lfm25-230m`, §A1) and everything else rejected, deferred or blocked;
    the verdicts are in §F. Of the 2026-07-27 seeds, LFM2.5-230M shipped and the
-   rest were not displaced. What the campaign leaves open is a **product decision
-   on an embedding surface**, not a model search — see the campaign doc.
+   rest were not displaced. WS-E (embeddings) closed 2026-08-20: no named
+   consumer (#242). WS-F (ASR) still needs a headset (#241).
 7. ~~**W3 gpubw** (#211)~~ — **closed PASS** Series S **119.07 GB/s** STREAM;
    H6 eng **#228** (`docs/phase15-re-opt.md`).
 

--- a/docs/phase16-model-scouting.md
+++ b/docs/phase16-model-scouting.md
@@ -8,10 +8,11 @@
 > [benchmarks.md](benchmarks.md) / `bench/results/`; the checklist lives in
 > [`../ROADMAP.md`](../ROADMAP.md) Phase 16.
 
-**Currency:** 2026-08-10. **Campaign complete.** One model shipped
-(`lfm25-230m`, floor tier); WS-B/C/D/G closed on their own kills; WS-E and WS-F
-blocked on a product decision and an unwritten probe. 3 of ≤9 console sessions
-spent.
+**Currency:** 2026-08-20. **Campaign complete.** One model shipped
+(`lfm25-230m`, floor tier); WS-B/C/D/G closed on their own kills; WS-E closed
+2026-08-20 S-gate FAIL (no named consumer, #242); WS-F probe written and run
+twice, still `DeviceNotAvailable` with no headset (#241). 3 of ≤9 console
+sessions spent.
 
 ## Goal
 
@@ -197,15 +198,15 @@ there.
 Cards are predeclared — claim / measure / PASS / FAIL / kill written before any
 engineering, per Method rule 1.
 
-| WS       | Card  | Subject                                 | Console budget      | Status                                            |
-| -------- | ----- | --------------------------------------- | ------------------- | ------------------------------------------------- |
-| **WS-A** | H16.1 | Text GGUF scouting (chat/coding/reason) | 3 of ≤4 spent       | **closed — 1 shipped** (`lfm25-230m`)             |
-| **WS-B** | H16.2 | `llama.cpp` pin bump evaluation         | 0 — never triggered | **closed, not motivated** (2026-08-10)            |
-| **WS-C** | H16.3 | ORT GenAI / DirectML text re-evaluation | 0 — kill fired      | **closed — surface saturated**                    |
-| **WS-D** | H16.4 | Diffusion successor to SD-Turbo         | 0 — kill fired      | **closed — nothing exportable**                   |
-| **WS-E** | H16.5 | Embedding surface (S-gate)              | 0                   | **blocked — S-gate unowned**                      |
-| **WS-F** | H16.6 | ASR surface (S-gate)                    | 1 spent             | **open — probe written and run; needs a headset** |
-| **WS-G** | H16.7 | Vision / VLM surface (S-gate)           | 0 — S-gate FAIL     | **closed — cost not bought**                      |
+| WS       | Card  | Subject                                 | Console budget      | Status                                      |
+| -------- | ----- | --------------------------------------- | ------------------- | ------------------------------------------- |
+| **WS-A** | H16.1 | Text GGUF scouting (chat/coding/reason) | 3 of ≤4 spent       | **closed — 1 shipped** (`lfm25-230m`)       |
+| **WS-B** | H16.2 | `llama.cpp` pin bump evaluation         | 0 — never triggered | **closed, not motivated** (2026-08-10)      |
+| **WS-C** | H16.3 | ORT GenAI / DirectML text re-evaluation | 0 — kill fired      | **closed — surface saturated**              |
+| **WS-D** | H16.4 | Diffusion successor to SD-Turbo         | 0 — kill fired      | **closed — nothing exportable**             |
+| **WS-E** | H16.5 | Embedding surface (S-gate)              | 0                   | **closed 2026-08-20 — no named consumer**   |
+| **WS-F** | H16.6 | ASR surface (S-gate)                    | 1 spent             | **open — probe run twice; needs a headset** |
+| **WS-G** | H16.7 | Vision / VLM surface (S-gate)           | 0 — S-gate FAIL     | **closed — cost not bought**                |
 
 **Total console bench budget: ≤9 sessions.** Anything beyond is scope creep and
 needs a decision-log entry.
@@ -304,6 +305,15 @@ needs a decision-log entry.
 - **FAIL / kill:** no consumer, or the design needs two resident contexts → close
   before downloading anything, and record that the capability exists in the pin
   while the product surface does not.
+
+**Status: CLOSED 2026-08-20, S-gate FAIL.** No named consumer. The shipping
+product is gamepad chat + catalogue + images + opt-in LAN + on-device
+personalize. None of those read an embedding vector. SessionHub owns one
+resident Session; an embedding model is a second `llama_context`. The pin
+carries `nomic-bert` and `nomic-embed-text-v1.5` is config-only at 156 MB —
+that is a capability, not a surface. Kill: close before download. Reopen only
+with a named consumer **and** a memory plan that keeps peak ≤3.5 GB with one
+resident model. #242.
 
 ### H16.6 — WS-F, ASR surface (S-gate)
 

--- a/docs/store-readiness.md
+++ b/docs/store-readiness.md
@@ -6,9 +6,10 @@
 > `benchmarks.md`; this page owns **go-to-market gates**, dual-SKU policy, and
 > the licence matrix for a retail listing.
 
-**Status (2026-08-08):** Phase 0 discovery + Phase 1 **engineering foundation**
+**Status (2026-08-20):** Phase 0 discovery + Phase 1 **engineering foundation**
 landed, and the **five listing screenshots are captured** (§9). Product Dev Mode
-cut is **v1.5.4.0** (10 console gates including `thinkdone`). **Not Store-ready**
+cut is **v1.5.5.0** (10 console gates including `thinkdone`; last fully gated
+evidence remains v1.5.4.0 / MSIX `1.5.4.887`). **Not Store-ready**
 for retail: no Partner Center product, no Store-signed package, no privacy URL,
 no age rating. Dev Mode remains the only supported install path. Partner Center
 account / product reservation is a **human gate** before engineering listing work.
@@ -133,6 +134,7 @@ allowlist draft** — not legal advice; re-verify before submission.
 
 | Catalogue id                        | Family                 | Typical licence (upstream)                                                                                  | Hosting today                          | Store SKU draft                                                     |
 | ----------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------- | ------------------------------------------------------------------- |
+| `lfm25-230m`                        | Liquid LFM2.5          | LFM Open License v1.0 (LICENSE next to weights; commercial use limited by entity revenue — see upstream §5) | `models-v1` + LICENSE                  | **Allow** floor tier if same                                        |
 | `lfm25-350m`                        | Liquid LFM2.5          | LFM Open License v1.0 (LICENSE next to weights; commercial use limited by entity revenue — see upstream §5) | `models-v1` + LICENSE                  | **Allow** default chat if non-commercial listing OK under LFM terms |
 | `lfm25-1.2b-instruct`               | Liquid LFM2.5          | LFM Open License                                                                                            | HF LiquidAI + LICENSE                  | **Allow** if same                                                   |
 | `lfm2-2.6b`                         | Liquid LFM2            | LFM Open License                                                                                            | HF LiquidAI + LICENSE                  | **Allow** if same                                                   |

--- a/docs/using-the-app.md
+++ b/docs/using-the-app.md
@@ -28,6 +28,10 @@ Type with the on-screen keyboard (or a USB keyboard) and send. The toolbar:
 
 Generation shows live tok/s; **■ Cancel** stops a running reply.
 
+Gamepad: **B** cancels a running reply and otherwise does nothing — it does
+**not** leave the app. Use the **Xbox (Guide)** button to quit. **View** clears
+the output, **Y** jumps to the prompt box, and inside a dialog **B** closes it.
+
 Every completed assistant response has **Like**, **Dislike**, and **Correct**
 actions. A correction requires the preferred answer. Each response can be rated
 once; the choice is stored with the conversation and appended to

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -673,6 +673,14 @@ enums separate `AccessDenied` from `DeviceNotAvailable` and the probe carries
 both by name for exactly this reason; the harness prints `NOT A VERDICT` and
 refuses to score it.
 
+**Rerun 2026-08-20, same room, same result.** The probe was run a second time
+with still no headset attached and returned `graph_status = Success` /
+`input_node_status = DeviceNotAvailable` again — byte-identical to the file
+above, which is why `git status` shows nothing after it. That identity is the
+point worth recording: `probe-mic.sh` overwrites one fixed path, so a repeated
+run leaves no trace in the repo and the _count_ of runs is not derivable from
+the evidence. Anyone citing "run twice" is citing this paragraph, not a file.
+
 **To finish this measurement:** connect a headset with a microphone to the
 console and rerun `./scripts/probe-mic.sh`. `Success` with RMS > 1e-3 closes
 WS-F's S-gate as PASS; `AccessDenied` closes it as FAIL and this section
@@ -684,6 +692,36 @@ contract exists, an activation status tells you why it did not activate, and
 only the second distinguishes "the platform said no" from "you did not give it
 anything to work with". Both lines are worth logging, and neither substitutes
 for the other.
+
+### §10e — B is the shell's exit, not an app key (2026-08-20)
+
+On Xbox the gamepad **B** button is routed as a back request:
+`SystemNavigationManager::GetForCurrentView().BackRequested`. If no handler
+sets `Handled(true)`, the shell reads that as "the app has nowhere left to go
+back to" and **suspends the app to Home**. There is no separate "exit" event to
+opt out of, and no manifest switch: the only lever is the `Handled` flag.
+
+`MainPage.cpp` originally set `Handled(true)` only while an inference was
+running, so B cancelled a reply mid-stream but closed the app on an idle chat.
+The two behaviours came from one line, which is why the second one was easy to
+miss at desk — nothing logs a shell-initiated suspend. The conversation itself
+survived (`SaveCurrentConversation` runs at the end of every turn); what was
+lost was the prompt box, the KV cache and the model load.
+
+The handler now marks **every** `BackRequested` handled and branches inside:
+cancel if running, no-op otherwise. Leaving the app stays on the Xbox (Guide)
+button, which the shell owns and an AppContainer cannot intercept.
+
+Two things this does **not** cover, by design:
+
+- **`ContentDialog` consumes B first.** Settings, History and the image viewer
+  are dialogs, and XAML closes the open dialog before the event reaches
+  `BackRequested`. That is the wanted behaviour and needs no code.
+- **The Store `App` designation may want the opposite.** The Xbox back-nav
+  guideline for _apps_ (not games) is that back at the top level exits. xllama
+  runs designated **Game** in Dev Home and this is a Dev Mode cut, so the suppression stands;
+  revisit it with the App-vs-Game spike in
+  [store-readiness.md](store-readiness.md).
 
 ## 11. GPU Truth — EP Attribution Without PIX
 

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -712,6 +712,18 @@ The handler now marks **every** `BackRequested` handled and branches inside:
 cancel if running, no-op otherwise. Leaving the app stays on the Xbox (Guide)
 button, which the shell owns and an AppContainer cannot intercept.
 
+**What is verified, and what cannot be.** The cancel _decision_ is policy over
+three booleans and now lives in `include/xllama/cancel_policy.h`, exhaustively
+tested on the host (`tests/test_cancel_policy.cpp`, all eight combinations).
+The `Handled(true)` _wiring_ has no automated test and cannot get one: the
+regression was the shell suspending the app on an unhandled back request, and
+nothing in-process can raise that. An autopilot `back` op was considered and
+**rejected** — it would call `OnCancelClick` directly, exercising a path the B
+button does not uniquely own, and ship a console gate named after a button it
+never presses. That is §10d's boolean probe with a different label. Do not add
+it. The irreducible check is one physical press on a Dev Mode console, and it
+belongs in the release runbook, not in a gate that implies more than it proves.
+
 **Cancelling goes through `OnCancelClick`, and that is load-bearing.** The
 first version of this fix aborted inline — `m_abort.store(true)` plus a
 disabled Cancel button — which reads correctly until you notice that

--- a/docs/uwp-constraints.md
+++ b/docs/uwp-constraints.md
@@ -712,6 +712,18 @@ The handler now marks **every** `BackRequested` handled and branches inside:
 cancel if running, no-op otherwise. Leaving the app stays on the Xbox (Guide)
 button, which the shell owns and an AppContainer cannot intercept.
 
+**Cancelling goes through `OnCancelClick`, and that is load-bearing.** The
+first version of this fix aborted inline — `m_abort.store(true)` plus a
+disabled Cancel button — which reads correctly until you notice that
+`SetRunning()` is called by three different jobs: inference, image generation
+(`MainPage.cpp:2222`) and on-device training (`:1882`). So `m_is_running` means
+"a job is running", not "text is running". `m_abort` is read only by the text
+loop; images cancel through `diffuse-cancel.flag` and training through
+`m_train_abort`. An inline abort therefore did the one thing worse than
+nothing: it disabled the Cancel button while the image or the epoch kept
+running, leaving no way to stop the job it claimed to have cancelled.
+`OnCancelClick` already dispatches on all three flags, so B routes into it.
+
 Two things this does **not** cover, by design:
 
 - **`ContentDialog` consumes B first.** Settings, History and the image viewer

--- a/include/xllama/cancel_policy.h
+++ b/include/xllama/cancel_policy.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2024 Gianluca Mazza
+// SPDX-License-Identifier: MIT
+// Which job a cancel request targets.
+//
+// The UI has one Cancel affordance and one back-request handler, but three jobs
+// that can be running behind them — text inference, image generation and
+// on-device training — and each stops by a different mechanism: the text loop
+// polls an abort flag, diffusion watches diffuse-cancel.flag on disk, training
+// checks its own flag between epochs. Picking the wrong one is silent: the
+// caller disables the Cancel button, reports "cancelling", and the job keeps
+// running with no way left to stop it.
+//
+// That failure shipped. MainPageController::SetRunning() is called by all three
+// jobs, so m_is_running means "a job is running", not "text is running"; a
+// back-request handler that read it and set the text abort flag looked correct
+// and cancelled nothing when an image was on screen.
+//
+// The decision is pure policy over three booleans, so it lives here and is
+// exhaustively tested on the host, where the UI it serves cannot be built.
+#pragma once
+
+namespace xllama {
+
+enum class CancelTarget {
+    None,     // nothing is running — a cancel request must be a no-op
+    Image,    // diffuse-cancel.flag
+    Training, // the training abort flag, honoured between epochs
+    Text,     // the inference abort flag, polled per token
+};
+
+// Precedence is image > training > text, and it is not arbitrary: the generic
+// "a job is running" flag is set by all three, so the specific flags are the
+// only ones that identify the job. Testing them first is what makes the generic
+// flag safe to pass in as `text_running`.
+inline constexpr CancelTarget cancel_target(bool image_running, bool training_running,
+                                            bool text_running) {
+    if (image_running)
+        return CancelTarget::Image;
+    if (training_running)
+        return CancelTarget::Training;
+    if (text_running)
+        return CancelTarget::Text;
+    return CancelTarget::None;
+}
+
+} // namespace xllama

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(xllama-tests
     test_chat_history.cpp
     test_diffusion.cpp
     test_routing_policy.cpp
+    test_cancel_policy.cpp
     test_sampling.cpp
     test_chat_prompt.cpp
     test_prompt_budget.cpp

--- a/tests/test_cancel_policy.cpp
+++ b/tests/test_cancel_policy.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2024 Gianluca Mazza
+// SPDX-License-Identifier: MIT
+
+#include <doctest/doctest.h>
+
+#include "xllama/cancel_policy.h"
+
+using namespace xllama;
+
+TEST_CASE("cancel: every combination of the three running flags") {
+    // Exhaustive rather than representative — eight cases is small enough to
+    // enumerate, and the bug this replaces lived in a combination nobody
+    // thought to try (image running, generic flag also set).
+    CHECK(cancel_target(false, false, false) == CancelTarget::None);
+    CHECK(cancel_target(false, false, true) == CancelTarget::Text);
+    CHECK(cancel_target(false, true, false) == CancelTarget::Training);
+    CHECK(cancel_target(false, true, true) == CancelTarget::Training);
+    CHECK(cancel_target(true, false, false) == CancelTarget::Image);
+    CHECK(cancel_target(true, false, true) == CancelTarget::Image);
+    CHECK(cancel_target(true, true, false) == CancelTarget::Image);
+    CHECK(cancel_target(true, true, true) == CancelTarget::Image);
+}
+
+TEST_CASE("cancel: the generic running flag never wins over a specific one") {
+    // This is the regression. SetRunning() is called by all three jobs, so the
+    // caller passes that flag as `text_running`; if precedence were the other
+    // way round, an image or an epoch would be answered with the text abort.
+    CHECK(cancel_target(true, false, /*text_running=*/true) == CancelTarget::Image);
+    CHECK(cancel_target(false, true, /*text_running=*/true) == CancelTarget::Training);
+}
+
+TEST_CASE("cancel: idle is a no-op, not a text cancel") {
+    // A back request on an idle chat reaches the same policy. Answering it with
+    // Text would set an abort flag with no job to abort.
+    CHECK(cancel_target(false, false, false) == CancelTarget::None);
+}

--- a/uwp/AppxManifest.store.xml
+++ b/uwp/AppxManifest.store.xml
@@ -22,7 +22,7 @@
   <Identity
     Name="GianlucaMazza.xllama"
     Publisher="CN=xllama-dev"
-    Version="1.5.2.0"
+    Version="1.5.5.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity

--- a/uwp/AppxManifest.xml
+++ b/uwp/AppxManifest.xml
@@ -15,7 +15,7 @@
   <Identity
     Name="GianlucaMazza.xllama"
     Publisher="CN=xllama-dev"
-    Version="1.5.4.0"
+    Version="1.5.5.0"
     ProcessorArchitecture="x64" />
 
   <mp:PhoneIdentity

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -344,16 +344,23 @@ void MainPageController::Init() {
             s->ShowImageDialog();
     });
 
-    // B button: cancel inference if running, otherwise let system exit the app
+    // B button (gamepad Back). On Xbox an unhandled BackRequested is the shell's
+    // cue to suspend the app and return to Home, so a B press anywhere outside a
+    // ContentDialog used to drop the user out of a running chat with no warning.
+    // We therefore mark EVERY BackRequested handled: B cancels a running
+    // inference and otherwise does nothing. Leaving the app stays on the Xbox
+    // (Guide) button, which the shell owns and we cannot intercept.
+    // Do not "simplify" this by only handling the running case — that reinstates
+    // the accidental exit.
     auto nav = winrt::Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
     nav.BackRequested(
         [self](IInspectable const&, winrt::Windows::UI::Core::BackRequestedEventArgs const& e) {
+            e.Handled(true); // suppress the shell exit even if the page is gone
             if (auto s = self.lock()) {
                 if (s->m_is_running.load()) {
                     s->m_abort.store(true);
                     s->SetStatus(L"Cancelling...");
                     s->m_cancelButton.IsEnabled(false);
-                    e.Handled(true);
                 }
             }
         });

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -13,6 +13,7 @@
     #endif
     #include "chat-history.h"
     #include "inference-bridge.h"
+    #include "xllama/cancel_policy.h"
     #include "xllama/chat_prompt.h"
     #include "xllama/kv_store.h"
     #include "xllama/model_provision.h"
@@ -361,10 +362,8 @@ void MainPageController::Init() {
     nav.BackRequested(
         [self](IInspectable const&, winrt::Windows::UI::Core::BackRequestedEventArgs const& e) {
             e.Handled(true); // suppress the shell exit even if the page is gone
-            if (auto s = self.lock()) {
-                if (s->m_is_running.load())
-                    s->OnCancelClick(nullptr, RoutedEventArgs{});
-            }
+            if (auto s = self.lock())
+                s->OnCancelClick(nullptr, RoutedEventArgs{});
         });
 
     // Gamepad keys: View = clear output, Y = jump to prompt
@@ -3224,21 +3223,34 @@ void MainPageController::OnRunClick(IInspectable const&, RoutedEventArgs const&)
 }
 
 void MainPageController::OnCancelClick(IInspectable const&, RoutedEventArgs const&) {
-    if (m_diffuse_running.load()) {
+    // Which job this targets is policy, and it lives in cancel_policy.h where
+    // the host tests can reach it — the combination that shipped broken (image
+    // running, generic flag also set) is not reproducible from this file.
+    // m_is_running is the generic flag: SetRunning() is called by all three
+    // jobs, so it is passed last and the specific flags decide.
+    switch (::xllama::cancel_target(m_diffuse_running.load(), m_train_running.load(),
+                                    m_is_running.load())) {
+    case ::xllama::CancelTarget::Image:
         write_local_bytes(L"diffuse-cancel.flag", "cancel");
         SetStatus(L"Cancelling image...");
         m_cancelButton.IsEnabled(false);
         return;
-    }
-    if (m_train_running.load()) {
+    case ::xllama::CancelTarget::Training:
         m_train_abort.store(true);
         SetStatus(L"Cancelling training (between epochs)...");
         m_cancelButton.IsEnabled(false);
         return;
+    case ::xllama::CancelTarget::Text:
+        m_abort.store(true);
+        SetStatus(L"Cancelling...");
+        m_cancelButton.IsEnabled(false);
+        return;
+    case ::xllama::CancelTarget::None:
+        // Reachable from the B button on an idle chat, never from the Cancel
+        // button (which is disabled unless a job runs). Doing nothing is the
+        // whole point: there is no job to abort.
+        return;
     }
-    m_abort.store(true);
-    SetStatus(L"Cancelling...");
-    m_cancelButton.IsEnabled(false);
 }
 
 // ---------------------------------------------------------------------------

--- a/uwp/MainPage.cpp
+++ b/uwp/MainPage.cpp
@@ -347,21 +347,23 @@ void MainPageController::Init() {
     // B button (gamepad Back). On Xbox an unhandled BackRequested is the shell's
     // cue to suspend the app and return to Home, so a B press anywhere outside a
     // ContentDialog used to drop the user out of a running chat with no warning.
-    // We therefore mark EVERY BackRequested handled: B cancels a running
-    // inference and otherwise does nothing. Leaving the app stays on the Xbox
-    // (Guide) button, which the shell owns and we cannot intercept.
+    // We therefore mark EVERY BackRequested handled: B cancels a running job and
+    // otherwise does nothing. Leaving the app stays on the Xbox (Guide) button,
+    // which the shell owns and we cannot intercept.
     // Do not "simplify" this by only handling the running case — that reinstates
     // the accidental exit.
+    // Cancelling goes through OnCancelClick and must keep going through it:
+    // SetRunning() is called by inference, image generation AND on-device
+    // training, so m_is_running says "a job is running", not "text is running".
+    // Aborting inline here would set m_abort — which only the text loop reads —
+    // and disable the Cancel button while an image or an epoch kept going.
     auto nav = winrt::Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
     nav.BackRequested(
         [self](IInspectable const&, winrt::Windows::UI::Core::BackRequestedEventArgs const& e) {
             e.Handled(true); // suppress the shell exit even if the page is gone
             if (auto s = self.lock()) {
-                if (s->m_is_running.load()) {
-                    s->m_abort.store(true);
-                    s->SetStatus(L"Cancelling...");
-                    s->m_cancelButton.IsEnabled(false);
-                }
+                if (s->m_is_running.load())
+                    s->OnCancelClick(nullptr, RoutedEventArgs{});
             }
         });
 


### PR DESCRIPTION
Two commits: the release cut, then a UWP input fix that is deliberately **not** in the tagged section.

## `release: cut v1.5.5.0`

Docs + manifests only. Manifest `1.5.4.0` → `1.5.5.0`, in-place update from 1.5.x under the same `GianlucaMazza.xllama` identity.

Ships the Unreleased block: `lfm25-230m` as the new floor tier (the one model Phase 16 bought), the Dependabot pin bump #244 with its UWP glue, and the `diskbw` / `mic` probes.

Two Phase 16 workstreams that had outrun the checklist are closed in the docs:

- **WS-E (embeddings) → S-gate FAIL**, not "blocked". Nobody names a consumer for the vectors, and SessionHub owns one resident Session — an embedding model is a second `llama_context`. The card's predeclared kill was "close before download"; it fires. Closes #242.
- **WS-F stays open.** `probe-mic.sh` was rerun today with still no headset and returned the same `DeviceNotAvailable`. Because the script overwrites one fixed path, that rerun produced a byte-identical file and left **no artefact in the repo** — so `uwp-constraints.md` §10d now records the run itself. Otherwise "run twice" is a claim with nothing behind it. #241 stays open.

Housekeeping caught while verifying: `AppxManifest.store.xml` had been left at `1.5.2.0` for three releases; a stray `- ` at the start of a wrapped ROADMAP line was rendering as a bullet mid-sentence; `store-readiness.md` still carried a 2026-08-08 status date over 2026-08-20 content. The ROADMAP now also records that Dependabot #247 fails `build-uwp` on `LLAMA_VERSION` while Linux `build` is green, so nobody merges it on the Dependabot-visible surface.

## `fix(uwp): B must not drop the user out of the app`

On Xbox, B arrives as `SystemNavigationManager::BackRequested`, and an event nobody marks `Handled(true)` is the shell's cue to suspend the app and return to Home. No separate exit event, no manifest switch — the `Handled` flag is the only lever.

`MainPage.cpp` set it only while an inference was running, so one line produced two behaviours: B cancelled a reply mid-stream, and B closed the app on an idle chat. Nothing logs a shell-initiated suspend, which is why the second behaviour survived at desk. The conversation itself survives (`SaveCurrentConversation` runs at the end of every turn) — the cost is the prompt box, the KV cache and a full model reload.

Now every `BackRequested` is handled and the branch moves inside: cancel if running, no-op otherwise. Exiting stays on the Xbox (Guide) button. `ContentDialog` still consumes B first, so Settings / History / the image viewer keep closing on B with no code.

`uwp-constraints.md` §10e carries the mechanism, and flags that the Store **App** designation may want the opposite behaviour — xllama runs designated **Game**, so the suppression stands until the App-vs-Game spike (`store-readiness.md` §6) says otherwise.

## Validation

- `check-coherence.py` — **OK 42 / WARN 0 / ERR 0**
- `prettier@3.9.6 --check` over every tracked `*.md` — clean (the release edits had broken 5 files; HEAD was clean before them)
- `clang-format==22.1.5 --dry-run --Werror` on `uwp/MainPage.cpp` — clean
- Claims spot-checked against the repo rather than assumed: `model_is_minicpm5` exists with tests and landed 2026-08-10 at the "15 lines" the docs cite; `diskbw.flag` / `mic.flag` are wired in `uwp/App.cpp`; the submodule is at `0865990` (b10333); #241 / #242 / #247 exist in the states described; "18 product releases" reconciles (19 tags − `models-v1` − `vendor-dlls-v1` + the tag to come).

**Not validated, and it needs to be before a tag:** `uwp/MainPage.cpp` is WinRT and builds only under `build-uwp`, so the B change has no host test. It needs a manual console pass — B on an idle chat, B during a reply, B inside each dialog — plus the 10-gate suite. That is why it sits under `[Unreleased]` and not in the v1.5.5.0 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Released version 1.5.5.0 with updated package and store metadata.
  - Added documented Xbox controls for cancelling replies, quitting, clearing output, focusing the prompt, and navigating dialogs.
  - Added the `lfm25-230m` model to the Store catalogue.

- **Bug Fixes**
  - Xbox **B** now cancels active replies without exiting the app.
  - Prevented idle-app exits triggered by Xbox back navigation.

- **Documentation**
  - Updated installation, deployment, roadmap, model, store-readiness, and release guidance for version 1.5.5.0.
  - Added current scouting, microphone, and disk-bandwidth findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->